### PR TITLE
feat(freedom): Add Freedom app protection

### DIFF
--- a/app_mon/cmd/appmon/main.go
+++ b/app_mon/cmd/appmon/main.go
@@ -494,7 +494,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	// Freedom protection status
 	fmt.Println("\nFreedom protection:")
-	freedomProtector := infra.NewFreedomProtector(pm, nil) // nil logger for status
+	freedomProtector := infra.NewFreedomProtector(pm, zap.NewNop())
 	health := freedomProtector.GetHealth()
 	if !health.Installed {
 		fmt.Println("  - Not installed (skipped)")

--- a/app_mon/cmd/appmon/main.go
+++ b/app_mon/cmd/appmon/main.go
@@ -492,6 +492,37 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  - %s\n", p.Name())
 	}
 
+	// Freedom protection status
+	fmt.Println("\nFreedom protection:")
+	freedomProtector := infra.NewFreedomProtector(pm, nil) // nil logger for status
+	health := freedomProtector.GetHealth()
+	if !health.Installed {
+		fmt.Println("  - Not installed (skipped)")
+	} else {
+		// Build status line based on what we can protect
+		// Note: FreedomProxy only runs during active blocking sessions, so we don't report it as an issue
+		if health.AppRunning && health.LoginItemPresent {
+			proxyStatus := ""
+			if health.ProxyRunning {
+				proxyStatus = ", proxy active"
+			}
+			if health.HelperRunning {
+				fmt.Printf("  ✓ Freedom.app running%s, login item present\n", proxyStatus)
+			} else {
+				fmt.Printf("  ⚠ Freedom.app running%s, but helper missing (reinstall Freedom to fix)\n", proxyStatus)
+			}
+		} else {
+			var issues []string
+			if !health.AppRunning {
+				issues = append(issues, "app not running")
+			}
+			if !health.LoginItemPresent {
+				issues = append(issues, "login item missing")
+			}
+			fmt.Printf("  ⚠ Degraded: %s (will auto-fix)\n", strings.Join(issues, ", "))
+		}
+	}
+
 	fmt.Println("=====================")
 	return nil
 }
@@ -639,6 +670,9 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	// Initialize backup manager for self-protection
 	backupManager := infra.NewBackupManager()
 
+	// Initialize Freedom protector (best effort - nil-safe if not installed)
+	freedomProtector := infra.NewFreedomProtector(pm, logger)
+
 	// Run appropriate daemon
 	switch role {
 	case domain.RoleWatcher:
@@ -649,6 +683,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 			pm,
 			launchdManager,
 			backupManager,
+			freedomProtector,
 			d,
 			logger,
 		)

--- a/app_mon/internal/daemon/daemon_test.go
+++ b/app_mon/internal/daemon/daemon_test.go
@@ -82,13 +82,13 @@ type mockFreedomProtector struct {
 	err           error
 }
 
-func (m *mockFreedomProtector) IsInstalled() bool       { return true }
-func (m *mockFreedomProtector) IsAppRunning() bool      { return true }
-func (m *mockFreedomProtector) IsProxyRunning() bool    { return true }
-func (m *mockFreedomProtector) IsHelperRunning() bool   { return true }
+func (m *mockFreedomProtector) IsInstalled() bool        { return true }
+func (m *mockFreedomProtector) IsAppRunning() bool       { return true }
+func (m *mockFreedomProtector) IsProxyRunning() bool     { return true }
+func (m *mockFreedomProtector) IsHelperRunning() bool    { return true }
 func (m *mockFreedomProtector) IsLoginItemPresent() bool { return true }
-func (m *mockFreedomProtector) RestartApp() error       { return nil }
-func (m *mockFreedomProtector) RestoreLoginItem() error { return nil }
+func (m *mockFreedomProtector) RestartApp() error        { return nil }
+func (m *mockFreedomProtector) RestoreLoginItem() error  { return nil }
 
 func (m *mockFreedomProtector) GetHealth() domain.FreedomHealth {
 	return domain.FreedomHealth{

--- a/app_mon/internal/daemon/daemon_test.go
+++ b/app_mon/internal/daemon/daemon_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
 	"github.com/eliteGoblin/focusd/app_mon/internal/policy"
 )
 
@@ -18,6 +19,7 @@ func TestDefaultWatcherConfig(t *testing.T) {
 	assert.Equal(t, 60*time.Second, config.PartnerCheckInterval)
 	assert.Equal(t, 60*time.Second, config.PlistCheckInterval)
 	assert.Equal(t, 60*time.Second, config.BinaryCheckInterval)
+	assert.Equal(t, 5*time.Second, config.FreedomCheckInterval)
 }
 
 // TestDefaultGuardianConfig verifies default guardian configuration
@@ -37,6 +39,7 @@ func TestWatcherConfig_AllFieldsSet(t *testing.T) {
 	assert.NotZero(t, config.PartnerCheckInterval, "PartnerCheckInterval should be set")
 	assert.NotZero(t, config.PlistCheckInterval, "PlistCheckInterval should be set")
 	assert.NotZero(t, config.BinaryCheckInterval, "BinaryCheckInterval should be set")
+	assert.NotZero(t, config.FreedomCheckInterval, "FreedomCheckInterval should be set")
 }
 
 // TestGuardianConfig_AllFieldsSet verifies all guardian config fields have values
@@ -63,3 +66,45 @@ func (m *mockBackupManager) VerifyAndRestore() (bool, error) {
 func (m *mockBackupManager) GetMainBinaryPath() string {
 	return "/test/path/appmon"
 }
+
+// TestFreedomProtector_Integration verifies watcher integrates with FreedomProtector
+func TestFreedomProtector_Integration(t *testing.T) {
+	// Verify the FreedomCheckInterval is fast enough for quick restart
+	config := DefaultWatcherConfig()
+	assert.Equal(t, 5*time.Second, config.FreedomCheckInterval,
+		"Freedom check should be every 5 seconds for fast restart")
+}
+
+// mockFreedomProtector for testing watcher integration
+type mockFreedomProtector struct {
+	protectCalled int
+	actionTaken   bool
+	err           error
+}
+
+func (m *mockFreedomProtector) IsInstalled() bool       { return true }
+func (m *mockFreedomProtector) IsAppRunning() bool      { return true }
+func (m *mockFreedomProtector) IsProxyRunning() bool    { return true }
+func (m *mockFreedomProtector) IsHelperRunning() bool   { return true }
+func (m *mockFreedomProtector) IsLoginItemPresent() bool { return true }
+func (m *mockFreedomProtector) RestartApp() error       { return nil }
+func (m *mockFreedomProtector) RestoreLoginItem() error { return nil }
+
+func (m *mockFreedomProtector) GetHealth() domain.FreedomHealth {
+	return domain.FreedomHealth{
+		Installed:        true,
+		AppRunning:       true,
+		ProxyRunning:     true,
+		HelperRunning:    true,
+		LoginItemPresent: true,
+		ProxyPort:        7769,
+	}
+}
+
+func (m *mockFreedomProtector) Protect() (bool, error) {
+	m.protectCalled++
+	return m.actionTaken, m.err
+}
+
+// Ensure mock implements the interface
+var _ domain.FreedomProtector = (*mockFreedomProtector)(nil)

--- a/app_mon/internal/daemon/daemon_test.go
+++ b/app_mon/internal/daemon/daemon_test.go
@@ -67,8 +67,8 @@ func (m *mockBackupManager) GetMainBinaryPath() string {
 	return "/test/path/appmon"
 }
 
-// TestFreedomProtector_Integration verifies watcher integrates with FreedomProtector
-func TestFreedomProtector_Integration(t *testing.T) {
+// TestFreedomCheckInterval_DefaultValue verifies the Freedom check interval is configured correctly
+func TestFreedomCheckInterval_DefaultValue(t *testing.T) {
 	// Verify the FreedomCheckInterval is fast enough for quick restart
 	config := DefaultWatcherConfig()
 	assert.Equal(t, 5*time.Second, config.FreedomCheckInterval,

--- a/app_mon/internal/domain/repository.go
+++ b/app_mon/internal/domain/repository.go
@@ -134,3 +134,51 @@ type StrategyManager interface {
 	// Returns the strategy name that succeeded, or empty if none
 	UninstallApp(appName string) (string, error)
 }
+
+// FreedomHealth represents the current health status of Freedom app protection.
+type FreedomHealth struct {
+	// Installed indicates if Freedom.app exists at expected path
+	Installed bool
+	// AppRunning indicates if Freedom main process is running
+	AppRunning bool
+	// ProxyRunning indicates if FreedomProxy process is running
+	ProxyRunning bool
+	// HelperRunning indicates if com.80pct.FreedomHelper is running
+	HelperRunning bool
+	// LoginItemPresent indicates if Freedom is in Login Items
+	LoginItemPresent bool
+	// ProxyPort is the port FreedomProxy listens on (7769)
+	ProxyPort int
+}
+
+// FreedomProtector monitors and protects Freedom app.
+// It ensures Freedom stays running and Login Items are preserved.
+type FreedomProtector interface {
+	// IsInstalled checks if Freedom.app exists at /Applications/Freedom.app
+	IsInstalled() bool
+
+	// IsAppRunning checks if Freedom main process is running
+	IsAppRunning() bool
+
+	// IsProxyRunning checks if FreedomProxy process is running
+	IsProxyRunning() bool
+
+	// IsHelperRunning checks if com.80pct.FreedomHelper is running
+	IsHelperRunning() bool
+
+	// IsLoginItemPresent checks if Freedom is in Login Items
+	IsLoginItemPresent() bool
+
+	// RestartApp launches Freedom.app using `open -a`
+	RestartApp() error
+
+	// RestoreLoginItem adds Freedom back to Login Items using AppleScript
+	RestoreLoginItem() error
+
+	// GetHealth returns comprehensive health status
+	GetHealth() FreedomHealth
+
+	// Protect runs a protection cycle: restart app if needed, restore login item if needed
+	// Returns true if any action was taken
+	Protect() (actionTaken bool, err error)
+}

--- a/app_mon/internal/infra/freedom.go
+++ b/app_mon/internal/infra/freedom.go
@@ -250,12 +250,6 @@ func (f *FreedomProtectorImpl) logInfo(msg string, fields ...zap.Field) {
 	}
 }
 
-func (f *FreedomProtectorImpl) logWarn(msg string, fields ...zap.Field) {
-	if f.logger != nil {
-		f.logger.Warn(msg, fields...)
-	}
-}
-
 func (f *FreedomProtectorImpl) logError(msg string, fields ...zap.Field) {
 	if f.logger != nil {
 		f.logger.Error(msg, fields...)

--- a/app_mon/internal/infra/freedom.go
+++ b/app_mon/internal/infra/freedom.go
@@ -13,11 +13,11 @@ import (
 
 // Freedom app constants
 const (
-	FreedomAppPath            = "/Applications/Freedom.app"
-	FreedomProcessName        = "Freedom"
-	FreedomProxyProcessName   = "FreedomProxy"
-	FreedomHelperProcessName  = "com.80pct.FreedomHelper"
-	FreedomProxyPort          = 7769
+	FreedomAppPath           = "/Applications/Freedom.app"
+	FreedomProcessName       = "Freedom"
+	FreedomProxyProcessName  = "FreedomProxy"
+	FreedomHelperProcessName = "com.80pct.FreedomHelper"
+	FreedomProxyPort         = 7769
 )
 
 // FreedomProtectorImpl implements domain.FreedomProtector.

--- a/app_mon/internal/infra/freedom.go
+++ b/app_mon/internal/infra/freedom.go
@@ -1,0 +1,198 @@
+// Package infra implements infrastructure concerns (process, filesystem, registry).
+package infra
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
+)
+
+// Freedom app constants
+const (
+	FreedomAppPath            = "/Applications/Freedom.app"
+	FreedomProcessName        = "Freedom"
+	FreedomProxyProcessName   = "FreedomProxy"
+	FreedomHelperProcessName  = "com.80pct.FreedomHelper"
+	FreedomProxyPort          = 7769
+)
+
+// FreedomProtectorImpl implements domain.FreedomProtector.
+// It monitors and protects Freedom app, restarting it if killed
+// and restoring Login Items if removed.
+type FreedomProtectorImpl struct {
+	pm     domain.ProcessManager
+	logger *zap.Logger
+}
+
+// NewFreedomProtector creates a new Freedom protector.
+func NewFreedomProtector(pm domain.ProcessManager, logger *zap.Logger) *FreedomProtectorImpl {
+	return &FreedomProtectorImpl{
+		pm:     pm,
+		logger: logger,
+	}
+}
+
+// IsInstalled checks if Freedom.app exists at /Applications/Freedom.app
+func (f *FreedomProtectorImpl) IsInstalled() bool {
+	_, err := os.Stat(FreedomAppPath)
+	return err == nil
+}
+
+// IsAppRunning checks if Freedom main process is running
+func (f *FreedomProtectorImpl) IsAppRunning() bool {
+	pids, err := f.pm.FindByName(FreedomProcessName)
+	if err != nil {
+		return false
+	}
+	// Filter out FreedomProxy and FreedomHelper from results
+	for _, pid := range pids {
+		// FindByName does substring match, so we need to verify exact match
+		// by checking that it's not the proxy or helper
+		if f.isExactProcessMatch(pid, FreedomProcessName) {
+			return true
+		}
+	}
+	return false
+}
+
+// isExactProcessMatch verifies a PID matches a specific process name
+// This is needed because FindByName does substring matching
+func (f *FreedomProtectorImpl) isExactProcessMatch(pid int, expectedName string) bool {
+	// Use ps to get exact process name
+	cmd := exec.Command("ps", "-p", string(rune(pid)), "-o", "comm=")
+	output, err := cmd.Output()
+	if err != nil {
+		// Process might have exited, check via gopsutil
+		pids, _ := f.pm.FindByName(expectedName)
+		for _, p := range pids {
+			if p == pid {
+				return true
+			}
+		}
+		return false
+	}
+	name := strings.TrimSpace(string(output))
+	return strings.HasSuffix(name, expectedName) && !strings.Contains(name, "Proxy") && !strings.Contains(name, "Helper")
+}
+
+// IsProxyRunning checks if FreedomProxy process is running
+func (f *FreedomProtectorImpl) IsProxyRunning() bool {
+	pids, err := f.pm.FindByName(FreedomProxyProcessName)
+	if err != nil {
+		return false
+	}
+	return len(pids) > 0
+}
+
+// IsHelperRunning checks if com.80pct.FreedomHelper is running.
+// The helper runs as root, so gopsutil can't read its Name() directly.
+// We use ps command to check by executable path instead.
+func (f *FreedomProtectorImpl) IsHelperRunning() bool {
+	// First try FindByName (works if process name is readable)
+	pids, err := f.pm.FindByName(FreedomHelperProcessName)
+	if err == nil && len(pids) > 0 {
+		return true
+	}
+
+	// Fallback: use ps to check by executable path (works for root processes)
+	cmd := exec.Command("pgrep", "-f", FreedomHelperProcessName)
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(output))) > 0
+}
+
+// IsLoginItemPresent checks if Freedom is in Login Items
+func (f *FreedomProtectorImpl) IsLoginItemPresent() bool {
+	// Use AppleScript to check Login Items
+	script := `tell application "System Events" to get the name of every login item`
+	cmd := exec.Command("osascript", "-e", script)
+	output, err := cmd.Output()
+	if err != nil {
+		f.logger.Debug("failed to check login items", zap.Error(err))
+		return false
+	}
+	// Output is comma-separated list of login item names
+	items := string(output)
+	return strings.Contains(items, "Freedom")
+}
+
+// RestartApp launches Freedom.app using `open -a`
+func (f *FreedomProtectorImpl) RestartApp() error {
+	f.logger.Info("restarting Freedom app")
+	cmd := exec.Command("open", "-a", FreedomAppPath)
+	if err := cmd.Run(); err != nil {
+		f.logger.Error("failed to restart Freedom", zap.Error(err))
+		return err
+	}
+	f.logger.Info("Freedom app restarted successfully")
+	return nil
+}
+
+// RestoreLoginItem adds Freedom back to Login Items using AppleScript
+func (f *FreedomProtectorImpl) RestoreLoginItem() error {
+	f.logger.Info("restoring Freedom to Login Items")
+	script := `tell application "System Events" to make login item at end with properties {path:"/Applications/Freedom.app", hidden:false}`
+	cmd := exec.Command("osascript", "-e", script)
+	if err := cmd.Run(); err != nil {
+		f.logger.Error("failed to restore login item", zap.Error(err))
+		return err
+	}
+	f.logger.Info("Freedom login item restored successfully")
+	return nil
+}
+
+// GetHealth returns comprehensive health status
+func (f *FreedomProtectorImpl) GetHealth() domain.FreedomHealth {
+	return domain.FreedomHealth{
+		Installed:        f.IsInstalled(),
+		AppRunning:       f.IsAppRunning(),
+		ProxyRunning:     f.IsProxyRunning(),
+		HelperRunning:    f.IsHelperRunning(),
+		LoginItemPresent: f.IsLoginItemPresent(),
+		ProxyPort:        FreedomProxyPort,
+	}
+}
+
+// Protect runs a protection cycle: restart app if needed, restore login item if needed
+// Returns true if any action was taken
+func (f *FreedomProtectorImpl) Protect() (actionTaken bool, err error) {
+	// Skip if Freedom not installed
+	if !f.IsInstalled() {
+		f.logger.Debug("Freedom not installed, skipping protection")
+		return false, nil
+	}
+
+	// Check and restart app if killed
+	if !f.IsAppRunning() {
+		f.logger.Info("Freedom app not running, restarting...")
+		if err := f.RestartApp(); err != nil {
+			return false, err
+		}
+		actionTaken = true
+	}
+
+	// Check and restore login item if removed
+	if !f.IsLoginItemPresent() {
+		f.logger.Info("Freedom login item missing, restoring...")
+		if err := f.RestoreLoginItem(); err != nil {
+			return actionTaken, err
+		}
+		actionTaken = true
+	}
+
+	// Log helper status (we can't fix it, but we can report)
+	if !f.IsHelperRunning() {
+		f.logger.Warn("FreedomHelper not running (reinstall Freedom to fix)")
+	}
+
+	return actionTaken, nil
+}
+
+// Ensure FreedomProtectorImpl implements domain.FreedomProtector.
+var _ domain.FreedomProtector = (*FreedomProtectorImpl)(nil)

--- a/app_mon/internal/infra/freedom.go
+++ b/app_mon/internal/infra/freedom.go
@@ -228,9 +228,10 @@ func (f *FreedomProtectorImpl) Protect() (actionTaken bool, err error) {
 		actionTaken = true
 	}
 
-	// Log helper status (we can't fix it, but we can report)
+	// Helper status is reported in GetHealth() but we can't fix it.
+	// Use Debug level to avoid log spam (Protect() runs every 5 seconds).
 	if !f.IsHelperRunning() {
-		f.logWarn("FreedomHelper not running (reinstall Freedom to fix)")
+		f.logDebug("FreedomHelper not running (reinstall Freedom to fix)")
 	}
 
 	return actionTaken, nil

--- a/app_mon/internal/infra/freedom_test.go
+++ b/app_mon/internal/infra/freedom_test.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,253 +11,108 @@ import (
 	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
 )
 
-// mockFreedomDeps provides injectable dependencies for testing FreedomProtector
-type mockFreedomDeps struct {
-	appExists        bool
-	appRunning       bool
-	proxyRunning     bool
-	helperRunning    bool
-	loginItemPresent bool
-	restartAppCalled bool
-	restartAppErr    error
-	restoreLoginErr  error
+// mockProcessManagerForFreedom implements domain.ProcessManager for testing
+type mockProcessManagerForFreedom struct {
+	findResults map[string][]int
+	findErrors  map[string]error
+	killCalled  []int
+	killError   error
+	runningPIDs map[int]bool
 }
 
-func (m *mockFreedomDeps) IsInstalled() bool        { return m.appExists }
-func (m *mockFreedomDeps) IsAppRunning() bool       { return m.appRunning }
-func (m *mockFreedomDeps) IsProxyRunning() bool     { return m.proxyRunning }
-func (m *mockFreedomDeps) IsHelperRunning() bool    { return m.helperRunning }
-func (m *mockFreedomDeps) IsLoginItemPresent() bool { return m.loginItemPresent }
-
-func (m *mockFreedomDeps) RestartApp() error {
-	m.restartAppCalled = true
-	if m.restartAppErr != nil {
-		return m.restartAppErr
-	}
-	m.appRunning = true
-	m.proxyRunning = true
-	return nil
-}
-
-func (m *mockFreedomDeps) RestoreLoginItem() error {
-	if m.restoreLoginErr != nil {
-		return m.restoreLoginErr
-	}
-	m.loginItemPresent = true
-	return nil
-}
-
-func (m *mockFreedomDeps) GetHealth() domain.FreedomHealth {
-	return domain.FreedomHealth{
-		Installed:        m.appExists,
-		AppRunning:       m.appRunning,
-		ProxyRunning:     m.proxyRunning,
-		HelperRunning:    m.helperRunning,
-		LoginItemPresent: m.loginItemPresent,
-		ProxyPort:        7769,
+func newMockPMForFreedom() *mockProcessManagerForFreedom {
+	return &mockProcessManagerForFreedom{
+		findResults: make(map[string][]int),
+		findErrors:  make(map[string]error),
+		runningPIDs: make(map[int]bool),
 	}
 }
 
-func (m *mockFreedomDeps) Protect() (bool, error) {
-	actionTaken := false
-
-	if !m.appExists {
-		return false, nil // Freedom not installed, skip
+func (m *mockProcessManagerForFreedom) FindByName(pattern string) ([]int, error) {
+	if err, ok := m.findErrors[pattern]; ok {
+		return nil, err
 	}
-
-	if !m.appRunning {
-		if err := m.RestartApp(); err != nil {
-			return false, err
-		}
-		actionTaken = true
+	if pids, ok := m.findResults[pattern]; ok {
+		return pids, nil
 	}
-
-	if !m.loginItemPresent {
-		if err := m.RestoreLoginItem(); err != nil {
-			return actionTaken, err
-		}
-		actionTaken = true
-	}
-
-	return actionTaken, nil
+	return nil, nil
 }
 
-// Ensure mock implements the interface
-var _ domain.FreedomProtector = (*mockFreedomDeps)(nil)
-
-// TestFreedomProtector_NotInstalled verifies graceful skip when Freedom not installed
-func TestFreedomProtector_NotInstalled(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists: false,
-	}
-
-	assert.False(t, mock.IsInstalled())
-
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.False(t, actionTaken, "should not take action when not installed")
-	assert.False(t, mock.restartAppCalled, "should not restart when not installed")
+func (m *mockProcessManagerForFreedom) Kill(pid int) error {
+	m.killCalled = append(m.killCalled, pid)
+	return m.killError
 }
 
-// TestFreedomProtector_HealthyState verifies no action when everything is running
-func TestFreedomProtector_HealthyState(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists:        true,
-		appRunning:       true,
-		proxyRunning:     true,
-		helperRunning:    true,
-		loginItemPresent: true,
-	}
-
-	health := mock.GetHealth()
-	assert.True(t, health.Installed)
-	assert.True(t, health.AppRunning)
-	assert.True(t, health.ProxyRunning)
-	assert.True(t, health.HelperRunning)
-	assert.True(t, health.LoginItemPresent)
-	assert.Equal(t, 7769, health.ProxyPort)
-
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.False(t, actionTaken, "should not take action when healthy")
-	assert.False(t, mock.restartAppCalled, "should not restart when already running")
+func (m *mockProcessManagerForFreedom) IsRunning(pid int) bool {
+	return m.runningPIDs[pid]
 }
 
-// TestFreedomProtector_AppKilled verifies restart when app is killed
-func TestFreedomProtector_AppKilled(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists:        true,
-		appRunning:       false, // App killed
-		proxyRunning:     false, // Proxy also dead
-		helperRunning:    true,  // Helper still running
-		loginItemPresent: true,
-	}
-
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.True(t, actionTaken, "should take action to restart")
-	assert.True(t, mock.restartAppCalled, "should call restart")
-	assert.True(t, mock.appRunning, "app should be running after restart")
-	assert.True(t, mock.proxyRunning, "proxy should start with app")
+func (m *mockProcessManagerForFreedom) GetCurrentPID() int {
+	return 99999
 }
 
-// TestFreedomProtector_LoginItemRemoved verifies restoration when login item removed
-func TestFreedomProtector_LoginItemRemoved(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists:        true,
-		appRunning:       true,
-		proxyRunning:     true,
-		helperRunning:    true,
-		loginItemPresent: false, // Login item removed
-	}
+var _ domain.ProcessManager = (*mockProcessManagerForFreedom)(nil)
 
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.True(t, actionTaken, "should take action to restore login item")
-	assert.True(t, mock.loginItemPresent, "login item should be restored")
+// mockCommandRunner implements CommandRunner for testing
+type mockCommandRunner struct {
+	runCalls    [][]string
+	runError    error
+	outputCalls [][]string
+	outputMap   map[string][]byte
+	outputError map[string]error
 }
 
-// TestFreedomProtector_BothAppKilledAndLoginItemRemoved verifies both actions
-func TestFreedomProtector_BothAppKilledAndLoginItemRemoved(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists:        true,
-		appRunning:       false,
-		proxyRunning:     false,
-		helperRunning:    true,
-		loginItemPresent: false,
-	}
-
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.True(t, actionTaken, "should take action")
-	assert.True(t, mock.restartAppCalled, "should restart app")
-	assert.True(t, mock.appRunning, "app should be running")
-	assert.True(t, mock.loginItemPresent, "login item should be restored")
-}
-
-// TestFreedomProtector_HelperMissing verifies graceful degradation when helper missing
-func TestFreedomProtector_HelperMissing(t *testing.T) {
-	mock := &mockFreedomDeps{
-		appExists:        true,
-		appRunning:       true,
-		proxyRunning:     true,
-		helperRunning:    false, // Helper missing (can't fix, just report)
-		loginItemPresent: true,
-	}
-
-	health := mock.GetHealth()
-	assert.False(t, health.HelperRunning, "should report helper not running")
-
-	// Still shouldn't error - just degraded status
-	actionTaken, err := mock.Protect()
-	require.NoError(t, err)
-	assert.False(t, actionTaken, "no action needed for helper (can't restart it)")
-}
-
-// TestFreedomProtector_GetHealth verifies health struct population
-func TestFreedomProtector_GetHealth(t *testing.T) {
-	tests := []struct {
-		name     string
-		mock     mockFreedomDeps
-		expected domain.FreedomHealth
-	}{
-		{
-			name: "fully healthy",
-			mock: mockFreedomDeps{
-				appExists:        true,
-				appRunning:       true,
-				proxyRunning:     true,
-				helperRunning:    true,
-				loginItemPresent: true,
-			},
-			expected: domain.FreedomHealth{
-				Installed:        true,
-				AppRunning:       true,
-				ProxyRunning:     true,
-				HelperRunning:    true,
-				LoginItemPresent: true,
-				ProxyPort:        7769,
-			},
-		},
-		{
-			name: "not installed",
-			mock: mockFreedomDeps{
-				appExists: false,
-			},
-			expected: domain.FreedomHealth{
-				Installed: false,
-				ProxyPort: 7769,
-			},
-		},
-		{
-			name: "degraded - helper missing",
-			mock: mockFreedomDeps{
-				appExists:        true,
-				appRunning:       true,
-				proxyRunning:     true,
-				helperRunning:    false,
-				loginItemPresent: true,
-			},
-			expected: domain.FreedomHealth{
-				Installed:        true,
-				AppRunning:       true,
-				ProxyRunning:     true,
-				HelperRunning:    false,
-				LoginItemPresent: true,
-				ProxyPort:        7769,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			health := tt.mock.GetHealth()
-			assert.Equal(t, tt.expected, health)
-		})
+func newMockCommandRunner() *mockCommandRunner {
+	return &mockCommandRunner{
+		outputMap:   make(map[string][]byte),
+		outputError: make(map[string]error),
 	}
 }
 
-// TestFreedomProtector_Constants verifies expected values
+func (m *mockCommandRunner) Run(name string, args ...string) error {
+	m.runCalls = append(m.runCalls, append([]string{name}, args...))
+	return m.runError
+}
+
+func (m *mockCommandRunner) Output(name string, args ...string) ([]byte, error) {
+	call := append([]string{name}, args...)
+	m.outputCalls = append(m.outputCalls, call)
+
+	// Build key from command
+	key := name
+	if len(args) > 0 {
+		key = name + " " + args[0]
+	}
+
+	if err, ok := m.outputError[key]; ok {
+		return nil, err
+	}
+	if output, ok := m.outputMap[key]; ok {
+		return output, nil
+	}
+	return nil, errors.New("command not found")
+}
+
+var _ CommandRunner = (*mockCommandRunner)(nil)
+
+// mockFileChecker implements FileChecker for testing
+type mockFileChecker struct {
+	existsMap map[string]bool
+}
+
+func newMockFileChecker() *mockFileChecker {
+	return &mockFileChecker{
+		existsMap: make(map[string]bool),
+	}
+}
+
+func (m *mockFileChecker) Exists(path string) bool {
+	return m.existsMap[path]
+}
+
+var _ FileChecker = (*mockFileChecker)(nil)
+
+// TestFreedomProtector_Constants verifies expected constant values
 func TestFreedomProtector_Constants(t *testing.T) {
 	assert.Equal(t, "/Applications/Freedom.app", FreedomAppPath)
 	assert.Equal(t, "Freedom", FreedomProcessName)
@@ -265,26 +121,664 @@ func TestFreedomProtector_Constants(t *testing.T) {
 	assert.Equal(t, 7769, FreedomProxyPort)
 }
 
-// TestNewFreedomProtector verifies constructor creates valid instance
+// TestNewFreedomProtector verifies constructor with default dependencies
 func TestNewFreedomProtector(t *testing.T) {
-	pm := NewProcessManager()
+	pm := newMockPMForFreedom()
 	logger := zap.NewNop()
 
 	protector := NewFreedomProtector(pm, logger)
-	require.NotNil(t, protector)
 
-	// Verify it implements the interface
-	var _ domain.FreedomProtector = protector
+	require.NotNil(t, protector)
+	assert.Equal(t, pm, protector.pm)
+	assert.Equal(t, logger, protector.logger)
+	assert.NotNil(t, protector.cmdRunner)
+	assert.NotNil(t, protector.fileChecker)
 }
 
-// TestFreedomProtector_IsInstalled_Real tests with real filesystem check
-func TestFreedomProtector_IsInstalled_Real(t *testing.T) {
-	pm := NewProcessManager()
+// TestNewFreedomProtectorWithDeps verifies constructor with custom dependencies
+func TestNewFreedomProtectorWithDeps(t *testing.T) {
+	pm := newMockPMForFreedom()
 	logger := zap.NewNop()
-	protector := NewFreedomProtector(pm, logger)
+	cmdRunner := newMockCommandRunner()
+	fileChecker := newMockFileChecker()
 
-	// This will return true or false based on whether Freedom is actually installed
-	// We just verify it doesn't panic
-	installed := protector.IsInstalled()
-	t.Logf("Freedom installed: %v", installed)
+	protector := NewFreedomProtectorWithDeps(pm, logger, cmdRunner, fileChecker)
+
+	require.NotNil(t, protector)
+	assert.Equal(t, pm, protector.pm)
+	assert.Equal(t, logger, protector.logger)
+	assert.Equal(t, cmdRunner, protector.cmdRunner)
+	assert.Equal(t, fileChecker, protector.fileChecker)
+}
+
+// TestFreedomProtectorImpl_IsInstalled tests installation detection
+func TestFreedomProtectorImpl_IsInstalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		exists   bool
+		expected bool
+	}{
+		{"installed", true, true},
+		{"not installed", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			fileChecker := newMockFileChecker()
+			fileChecker.existsMap[FreedomAppPath] = tt.exists
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), newMockCommandRunner(), fileChecker)
+
+			result := protector.IsInstalled()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_IsAppRunning tests app running detection
+func TestFreedomProtectorImpl_IsAppRunning(t *testing.T) {
+	tests := []struct {
+		name        string
+		findResults map[string][]int
+		findErrors  map[string]error
+		psOutput    map[string][]byte
+		psError     map[string]error
+		expected    bool
+	}{
+		{
+			name:        "no processes found",
+			findResults: map[string][]int{},
+			expected:    false,
+		},
+		{
+			name: "Freedom process found and verified",
+			findResults: map[string][]int{
+				"Freedom": {12345},
+			},
+			psOutput: map[string][]byte{
+				"ps -p": []byte("Freedom\n"),
+			},
+			expected: true,
+		},
+		{
+			name: "FreedomProxy found (should not match)",
+			findResults: map[string][]int{
+				"Freedom": {12345},
+			},
+			psOutput: map[string][]byte{
+				"ps -p": []byte("FreedomProxy\n"),
+			},
+			expected: false,
+		},
+		{
+			name: "FreedomHelper found (should not match)",
+			findResults: map[string][]int{
+				"Freedom": {12345},
+			},
+			psOutput: map[string][]byte{
+				"ps -p": []byte("FreedomHelper\n"),
+			},
+			expected: false,
+		},
+		{
+			name: "ps command fails, fallback to FindByName",
+			findResults: map[string][]int{
+				"Freedom": {12345},
+			},
+			psError: map[string]error{
+				"ps -p": errors.New("process not found"),
+			},
+			expected: true,
+		},
+		{
+			name: "find error",
+			findErrors: map[string]error{
+				"Freedom": errors.New("process lookup failed"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			pm.findResults = tt.findResults
+			pm.findErrors = tt.findErrors
+
+			cmdRunner := newMockCommandRunner()
+			if tt.psOutput != nil {
+				cmdRunner.outputMap = tt.psOutput
+			}
+			if tt.psError != nil {
+				cmdRunner.outputError = tt.psError
+			}
+
+			fileChecker := newMockFileChecker()
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), cmdRunner, fileChecker)
+
+			result := protector.IsAppRunning()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_IsProxyRunning tests proxy running detection
+func TestFreedomProtectorImpl_IsProxyRunning(t *testing.T) {
+	tests := []struct {
+		name        string
+		findResults map[string][]int
+		findErrors  map[string]error
+		expected    bool
+	}{
+		{
+			name:        "no proxy found",
+			findResults: map[string][]int{},
+			expected:    false,
+		},
+		{
+			name: "FreedomProxy found",
+			findResults: map[string][]int{
+				"FreedomProxy": {54321},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple proxies found",
+			findResults: map[string][]int{
+				"FreedomProxy": {54321, 54322},
+			},
+			expected: true,
+		},
+		{
+			name: "find error",
+			findErrors: map[string]error{
+				"FreedomProxy": errors.New("lookup failed"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			pm.findResults = tt.findResults
+			pm.findErrors = tt.findErrors
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), newMockCommandRunner(), newMockFileChecker())
+
+			result := protector.IsProxyRunning()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_IsHelperRunning tests helper running detection
+func TestFreedomProtectorImpl_IsHelperRunning(t *testing.T) {
+	tests := []struct {
+		name        string
+		findResults map[string][]int
+		findErrors  map[string]error
+		pgrepOutput []byte
+		pgrepError  error
+		expected    bool
+	}{
+		{
+			name:        "helper found via FindByName",
+			findResults: map[string][]int{"com.80pct.FreedomHelper": {815}},
+			expected:    true,
+		},
+		{
+			name:        "helper found via pgrep fallback",
+			findResults: map[string][]int{},
+			pgrepOutput: []byte("815\n"),
+			expected:    true,
+		},
+		{
+			name:        "helper not found anywhere",
+			findResults: map[string][]int{},
+			pgrepError:  errors.New("no process found"),
+			expected:    false,
+		},
+		{
+			name:        "FindByName errors, fallback to pgrep succeeds",
+			findErrors:  map[string]error{"com.80pct.FreedomHelper": errors.New("lookup failed")},
+			pgrepOutput: []byte("815\n"),
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			pm.findResults = tt.findResults
+			pm.findErrors = tt.findErrors
+
+			cmdRunner := newMockCommandRunner()
+			if tt.pgrepOutput != nil {
+				cmdRunner.outputMap["pgrep -f"] = tt.pgrepOutput
+			}
+			if tt.pgrepError != nil {
+				cmdRunner.outputError["pgrep -f"] = tt.pgrepError
+			}
+
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), cmdRunner, newMockFileChecker())
+
+			result := protector.IsHelperRunning()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_IsLoginItemPresent tests login item detection
+func TestFreedomProtectorImpl_IsLoginItemPresent(t *testing.T) {
+	tests := []struct {
+		name           string
+		osascriptOut   []byte
+		osascriptError error
+		expected       bool
+	}{
+		{
+			name:         "Freedom in login items",
+			osascriptOut: []byte("iTerm2, Freedom, Slack\n"),
+			expected:     true,
+		},
+		{
+			name:         "Freedom not in login items",
+			osascriptOut: []byte("iTerm2, Slack\n"),
+			expected:     false,
+		},
+		{
+			name:         "empty login items",
+			osascriptOut: []byte(""),
+			expected:     false,
+		},
+		{
+			name:           "osascript error",
+			osascriptError: errors.New("system events not available"),
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdRunner := newMockCommandRunner()
+			if tt.osascriptOut != nil {
+				cmdRunner.outputMap["osascript -e"] = tt.osascriptOut
+			}
+			if tt.osascriptError != nil {
+				cmdRunner.outputError["osascript -e"] = tt.osascriptError
+			}
+
+			protector := NewFreedomProtectorWithDeps(newMockPMForFreedom(), zap.NewNop(), cmdRunner, newMockFileChecker())
+
+			result := protector.IsLoginItemPresent()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_RestartApp tests app restart
+func TestFreedomProtectorImpl_RestartApp(t *testing.T) {
+	tests := []struct {
+		name      string
+		runError  error
+		expectErr bool
+	}{
+		{
+			name:      "successful restart",
+			runError:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "restart fails",
+			runError:  errors.New("app not found"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdRunner := newMockCommandRunner()
+			cmdRunner.runError = tt.runError
+
+			protector := NewFreedomProtectorWithDeps(newMockPMForFreedom(), zap.NewNop(), cmdRunner, newMockFileChecker())
+
+			err := protector.RestartApp()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify correct command was called
+			require.Len(t, cmdRunner.runCalls, 1)
+			assert.Equal(t, []string{"open", "-a", FreedomAppPath}, cmdRunner.runCalls[0])
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_RestoreLoginItem tests login item restoration
+func TestFreedomProtectorImpl_RestoreLoginItem(t *testing.T) {
+	tests := []struct {
+		name      string
+		runError  error
+		expectErr bool
+	}{
+		{
+			name:      "successful restore",
+			runError:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "restore fails",
+			runError:  errors.New("permission denied"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdRunner := newMockCommandRunner()
+			cmdRunner.runError = tt.runError
+
+			protector := NewFreedomProtectorWithDeps(newMockPMForFreedom(), zap.NewNop(), cmdRunner, newMockFileChecker())
+
+			err := protector.RestoreLoginItem()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify osascript was called
+			require.Len(t, cmdRunner.runCalls, 1)
+			assert.Equal(t, "osascript", cmdRunner.runCalls[0][0])
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_GetHealth tests health status aggregation
+func TestFreedomProtectorImpl_GetHealth(t *testing.T) {
+	pm := newMockPMForFreedom()
+	pm.findResults = map[string][]int{
+		"Freedom":      {100},
+		"FreedomProxy": {200},
+	}
+
+	cmdRunner := newMockCommandRunner()
+	cmdRunner.outputMap["ps -p"] = []byte("Freedom\n")
+	cmdRunner.outputMap["pgrep -f"] = []byte("815\n")
+	cmdRunner.outputMap["osascript -e"] = []byte("Freedom, Slack\n")
+
+	fileChecker := newMockFileChecker()
+	fileChecker.existsMap[FreedomAppPath] = true
+
+	protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), cmdRunner, fileChecker)
+
+	health := protector.GetHealth()
+
+	assert.True(t, health.Installed)
+	assert.True(t, health.AppRunning)
+	assert.True(t, health.ProxyRunning)
+	assert.True(t, health.HelperRunning)
+	assert.True(t, health.LoginItemPresent)
+	assert.Equal(t, FreedomProxyPort, health.ProxyPort)
+}
+
+// TestFreedomProtectorImpl_Protect tests protection cycle
+func TestFreedomProtectorImpl_Protect(t *testing.T) {
+	tests := []struct {
+		name             string
+		installed        bool
+		appRunning       bool
+		loginItemPresent bool
+		helperRunning    bool
+		restartError     error
+		restoreError     error
+		expectedAction   bool
+		expectedErr      bool
+	}{
+		{
+			name:           "not installed - skip",
+			installed:      false,
+			expectedAction: false,
+			expectedErr:    false,
+		},
+		{
+			name:             "all healthy - no action",
+			installed:        true,
+			appRunning:       true,
+			loginItemPresent: true,
+			helperRunning:    true,
+			expectedAction:   false,
+			expectedErr:      false,
+		},
+		{
+			name:             "app not running - restart",
+			installed:        true,
+			appRunning:       false,
+			loginItemPresent: true,
+			helperRunning:    true,
+			expectedAction:   true,
+			expectedErr:      false,
+		},
+		{
+			name:             "login item missing - restore",
+			installed:        true,
+			appRunning:       true,
+			loginItemPresent: false,
+			helperRunning:    true,
+			expectedAction:   true,
+			expectedErr:      false,
+		},
+		{
+			name:             "both app and login item need fixing",
+			installed:        true,
+			appRunning:       false,
+			loginItemPresent: false,
+			helperRunning:    true,
+			expectedAction:   true,
+			expectedErr:      false,
+		},
+		{
+			name:             "restart fails",
+			installed:        true,
+			appRunning:       false,
+			loginItemPresent: true,
+			restartError:     errors.New("restart failed"),
+			expectedAction:   false,
+			expectedErr:      true,
+		},
+		{
+			name:             "restore login item fails",
+			installed:        true,
+			appRunning:       true,
+			loginItemPresent: false,
+			restoreError:     errors.New("restore failed"),
+			expectedAction:   false,
+			expectedErr:      true,
+		},
+		{
+			name:             "helper not running - log warning only",
+			installed:        true,
+			appRunning:       true,
+			loginItemPresent: true,
+			helperRunning:    false,
+			expectedAction:   false,
+			expectedErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			cmdRunner := newMockCommandRunner()
+			fileChecker := newMockFileChecker()
+
+			// Setup installed state
+			fileChecker.existsMap[FreedomAppPath] = tt.installed
+
+			// Setup app running state
+			if tt.appRunning {
+				pm.findResults["Freedom"] = []int{100}
+				cmdRunner.outputMap["ps -p"] = []byte("Freedom\n")
+			}
+
+			// Setup login item state
+			if tt.loginItemPresent {
+				cmdRunner.outputMap["osascript -e"] = []byte("Freedom\n")
+			} else {
+				cmdRunner.outputMap["osascript -e"] = []byte("\n")
+			}
+
+			// Setup helper running state
+			if tt.helperRunning {
+				pm.findResults["com.80pct.FreedomHelper"] = []int{815}
+			} else {
+				cmdRunner.outputError["pgrep -f"] = errors.New("not found")
+			}
+
+			// Setup errors
+			if tt.restartError != nil {
+				cmdRunner.runError = tt.restartError
+			}
+			if tt.restoreError != nil && tt.restartError == nil {
+				cmdRunner.runError = tt.restoreError
+			}
+
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), cmdRunner, fileChecker)
+
+			actionTaken, err := protector.Protect()
+
+			assert.Equal(t, tt.expectedAction, actionTaken)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestFreedomProtectorImpl_NilLogger tests nil logger handling
+func TestFreedomProtectorImpl_NilLogger(t *testing.T) {
+	pm := newMockPMForFreedom()
+	cmdRunner := newMockCommandRunner()
+	fileChecker := newMockFileChecker()
+
+	// Setup scenario that triggers all log methods
+	fileChecker.existsMap[FreedomAppPath] = true
+	cmdRunner.outputMap["osascript -e"] = []byte("\n")          // no login item
+	cmdRunner.outputError["pgrep -f"] = errors.New("not found") // no helper
+
+	protector := NewFreedomProtectorWithDeps(pm, nil, cmdRunner, fileChecker) // nil logger
+
+	// All these should not panic with nil logger
+	_ = protector.IsInstalled()
+	_ = protector.IsAppRunning()
+	_ = protector.IsProxyRunning()
+	_ = protector.IsHelperRunning()
+	_ = protector.IsLoginItemPresent()
+	_ = protector.GetHealth()
+
+	// Protect triggers logging in multiple paths
+	_, _ = protector.Protect()
+}
+
+// TestFreedomHealth_Struct verifies FreedomHealth struct fields
+func TestFreedomHealth_Struct(t *testing.T) {
+	health := domain.FreedomHealth{
+		Installed:        true,
+		AppRunning:       true,
+		ProxyRunning:     true,
+		HelperRunning:    true,
+		LoginItemPresent: true,
+		ProxyPort:        7769,
+	}
+
+	assert.True(t, health.Installed)
+	assert.True(t, health.AppRunning)
+	assert.True(t, health.ProxyRunning)
+	assert.True(t, health.HelperRunning)
+	assert.True(t, health.LoginItemPresent)
+	assert.Equal(t, 7769, health.ProxyPort)
+}
+
+// TestFreedomHealth_ZeroValue verifies FreedomHealth zero values
+func TestFreedomHealth_ZeroValue(t *testing.T) {
+	health := domain.FreedomHealth{}
+
+	assert.False(t, health.Installed)
+	assert.False(t, health.AppRunning)
+	assert.False(t, health.ProxyRunning)
+	assert.False(t, health.HelperRunning)
+	assert.False(t, health.LoginItemPresent)
+	assert.Equal(t, 0, health.ProxyPort)
+}
+
+// TestFreedomProtectorImpl_Interface verifies interface compliance
+func TestFreedomProtectorImpl_Interface(t *testing.T) {
+	pm := newMockPMForFreedom()
+	protector := NewFreedomProtector(pm, zap.NewNop())
+
+	var fp domain.FreedomProtector = protector
+	_ = fp
+}
+
+// TestRealCommandRunner verifies real command runner (integration)
+func TestRealCommandRunner(t *testing.T) {
+	runner := &RealCommandRunner{}
+
+	// Test Output with a simple command
+	output, err := runner.Output("echo", "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello\n", string(output))
+
+	// Test Run with a simple command
+	err = runner.Run("true")
+	assert.NoError(t, err)
+}
+
+// TestRealFileChecker verifies real file checker (integration)
+func TestRealFileChecker(t *testing.T) {
+	checker := &RealFileChecker{}
+
+	// Test existing path
+	assert.True(t, checker.Exists("/"))
+
+	// Test non-existing path
+	assert.False(t, checker.Exists("/nonexistent/path/xyz123"))
+}
+
+// TestIsExactProcessMatch_EdgeCases tests edge cases in process matching
+func TestIsExactProcessMatch_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		psOutput string
+		expected bool
+	}{
+		{"exact match", "Freedom", true},
+		{"path suffix match", "/Applications/Freedom.app/Contents/MacOS/Freedom", true},
+		{"FreedomProxy should not match", "FreedomProxy", false},
+		{"FreedomHelper should not match", "FreedomHelper", false},
+		{"unrelated process", "Finder", false},
+		{"empty output", "", false},
+		{"whitespace only", "  \n\t  ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm := newMockPMForFreedom()
+			pm.findResults["Freedom"] = []int{12345}
+
+			cmdRunner := newMockCommandRunner()
+			cmdRunner.outputMap["ps -p"] = []byte(tt.psOutput + "\n")
+
+			protector := NewFreedomProtectorWithDeps(pm, zap.NewNop(), cmdRunner, newMockFileChecker())
+
+			result := protector.IsAppRunning()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/app_mon/internal/infra/freedom_test.go
+++ b/app_mon/internal/infra/freedom_test.go
@@ -22,10 +22,10 @@ type mockFreedomDeps struct {
 	restoreLoginErr  error
 }
 
-func (m *mockFreedomDeps) IsInstalled() bool       { return m.appExists }
-func (m *mockFreedomDeps) IsAppRunning() bool      { return m.appRunning }
-func (m *mockFreedomDeps) IsProxyRunning() bool    { return m.proxyRunning }
-func (m *mockFreedomDeps) IsHelperRunning() bool   { return m.helperRunning }
+func (m *mockFreedomDeps) IsInstalled() bool        { return m.appExists }
+func (m *mockFreedomDeps) IsAppRunning() bool       { return m.appRunning }
+func (m *mockFreedomDeps) IsProxyRunning() bool     { return m.proxyRunning }
+func (m *mockFreedomDeps) IsHelperRunning() bool    { return m.helperRunning }
 func (m *mockFreedomDeps) IsLoginItemPresent() bool { return m.loginItemPresent }
 
 func (m *mockFreedomDeps) RestartApp() error {

--- a/app_mon/internal/infra/freedom_test.go
+++ b/app_mon/internal/infra/freedom_test.go
@@ -1,0 +1,290 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
+)
+
+// mockFreedomDeps provides injectable dependencies for testing FreedomProtector
+type mockFreedomDeps struct {
+	appExists        bool
+	appRunning       bool
+	proxyRunning     bool
+	helperRunning    bool
+	loginItemPresent bool
+	restartAppCalled bool
+	restartAppErr    error
+	restoreLoginErr  error
+}
+
+func (m *mockFreedomDeps) IsInstalled() bool       { return m.appExists }
+func (m *mockFreedomDeps) IsAppRunning() bool      { return m.appRunning }
+func (m *mockFreedomDeps) IsProxyRunning() bool    { return m.proxyRunning }
+func (m *mockFreedomDeps) IsHelperRunning() bool   { return m.helperRunning }
+func (m *mockFreedomDeps) IsLoginItemPresent() bool { return m.loginItemPresent }
+
+func (m *mockFreedomDeps) RestartApp() error {
+	m.restartAppCalled = true
+	if m.restartAppErr != nil {
+		return m.restartAppErr
+	}
+	m.appRunning = true
+	m.proxyRunning = true
+	return nil
+}
+
+func (m *mockFreedomDeps) RestoreLoginItem() error {
+	if m.restoreLoginErr != nil {
+		return m.restoreLoginErr
+	}
+	m.loginItemPresent = true
+	return nil
+}
+
+func (m *mockFreedomDeps) GetHealth() domain.FreedomHealth {
+	return domain.FreedomHealth{
+		Installed:        m.appExists,
+		AppRunning:       m.appRunning,
+		ProxyRunning:     m.proxyRunning,
+		HelperRunning:    m.helperRunning,
+		LoginItemPresent: m.loginItemPresent,
+		ProxyPort:        7769,
+	}
+}
+
+func (m *mockFreedomDeps) Protect() (bool, error) {
+	actionTaken := false
+
+	if !m.appExists {
+		return false, nil // Freedom not installed, skip
+	}
+
+	if !m.appRunning {
+		if err := m.RestartApp(); err != nil {
+			return false, err
+		}
+		actionTaken = true
+	}
+
+	if !m.loginItemPresent {
+		if err := m.RestoreLoginItem(); err != nil {
+			return actionTaken, err
+		}
+		actionTaken = true
+	}
+
+	return actionTaken, nil
+}
+
+// Ensure mock implements the interface
+var _ domain.FreedomProtector = (*mockFreedomDeps)(nil)
+
+// TestFreedomProtector_NotInstalled verifies graceful skip when Freedom not installed
+func TestFreedomProtector_NotInstalled(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists: false,
+	}
+
+	assert.False(t, mock.IsInstalled())
+
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.False(t, actionTaken, "should not take action when not installed")
+	assert.False(t, mock.restartAppCalled, "should not restart when not installed")
+}
+
+// TestFreedomProtector_HealthyState verifies no action when everything is running
+func TestFreedomProtector_HealthyState(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists:        true,
+		appRunning:       true,
+		proxyRunning:     true,
+		helperRunning:    true,
+		loginItemPresent: true,
+	}
+
+	health := mock.GetHealth()
+	assert.True(t, health.Installed)
+	assert.True(t, health.AppRunning)
+	assert.True(t, health.ProxyRunning)
+	assert.True(t, health.HelperRunning)
+	assert.True(t, health.LoginItemPresent)
+	assert.Equal(t, 7769, health.ProxyPort)
+
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.False(t, actionTaken, "should not take action when healthy")
+	assert.False(t, mock.restartAppCalled, "should not restart when already running")
+}
+
+// TestFreedomProtector_AppKilled verifies restart when app is killed
+func TestFreedomProtector_AppKilled(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists:        true,
+		appRunning:       false, // App killed
+		proxyRunning:     false, // Proxy also dead
+		helperRunning:    true,  // Helper still running
+		loginItemPresent: true,
+	}
+
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.True(t, actionTaken, "should take action to restart")
+	assert.True(t, mock.restartAppCalled, "should call restart")
+	assert.True(t, mock.appRunning, "app should be running after restart")
+	assert.True(t, mock.proxyRunning, "proxy should start with app")
+}
+
+// TestFreedomProtector_LoginItemRemoved verifies restoration when login item removed
+func TestFreedomProtector_LoginItemRemoved(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists:        true,
+		appRunning:       true,
+		proxyRunning:     true,
+		helperRunning:    true,
+		loginItemPresent: false, // Login item removed
+	}
+
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.True(t, actionTaken, "should take action to restore login item")
+	assert.True(t, mock.loginItemPresent, "login item should be restored")
+}
+
+// TestFreedomProtector_BothAppKilledAndLoginItemRemoved verifies both actions
+func TestFreedomProtector_BothAppKilledAndLoginItemRemoved(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists:        true,
+		appRunning:       false,
+		proxyRunning:     false,
+		helperRunning:    true,
+		loginItemPresent: false,
+	}
+
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.True(t, actionTaken, "should take action")
+	assert.True(t, mock.restartAppCalled, "should restart app")
+	assert.True(t, mock.appRunning, "app should be running")
+	assert.True(t, mock.loginItemPresent, "login item should be restored")
+}
+
+// TestFreedomProtector_HelperMissing verifies graceful degradation when helper missing
+func TestFreedomProtector_HelperMissing(t *testing.T) {
+	mock := &mockFreedomDeps{
+		appExists:        true,
+		appRunning:       true,
+		proxyRunning:     true,
+		helperRunning:    false, // Helper missing (can't fix, just report)
+		loginItemPresent: true,
+	}
+
+	health := mock.GetHealth()
+	assert.False(t, health.HelperRunning, "should report helper not running")
+
+	// Still shouldn't error - just degraded status
+	actionTaken, err := mock.Protect()
+	require.NoError(t, err)
+	assert.False(t, actionTaken, "no action needed for helper (can't restart it)")
+}
+
+// TestFreedomProtector_GetHealth verifies health struct population
+func TestFreedomProtector_GetHealth(t *testing.T) {
+	tests := []struct {
+		name     string
+		mock     mockFreedomDeps
+		expected domain.FreedomHealth
+	}{
+		{
+			name: "fully healthy",
+			mock: mockFreedomDeps{
+				appExists:        true,
+				appRunning:       true,
+				proxyRunning:     true,
+				helperRunning:    true,
+				loginItemPresent: true,
+			},
+			expected: domain.FreedomHealth{
+				Installed:        true,
+				AppRunning:       true,
+				ProxyRunning:     true,
+				HelperRunning:    true,
+				LoginItemPresent: true,
+				ProxyPort:        7769,
+			},
+		},
+		{
+			name: "not installed",
+			mock: mockFreedomDeps{
+				appExists: false,
+			},
+			expected: domain.FreedomHealth{
+				Installed: false,
+				ProxyPort: 7769,
+			},
+		},
+		{
+			name: "degraded - helper missing",
+			mock: mockFreedomDeps{
+				appExists:        true,
+				appRunning:       true,
+				proxyRunning:     true,
+				helperRunning:    false,
+				loginItemPresent: true,
+			},
+			expected: domain.FreedomHealth{
+				Installed:        true,
+				AppRunning:       true,
+				ProxyRunning:     true,
+				HelperRunning:    false,
+				LoginItemPresent: true,
+				ProxyPort:        7769,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			health := tt.mock.GetHealth()
+			assert.Equal(t, tt.expected, health)
+		})
+	}
+}
+
+// TestFreedomProtector_Constants verifies expected values
+func TestFreedomProtector_Constants(t *testing.T) {
+	assert.Equal(t, "/Applications/Freedom.app", FreedomAppPath)
+	assert.Equal(t, "Freedom", FreedomProcessName)
+	assert.Equal(t, "FreedomProxy", FreedomProxyProcessName)
+	assert.Equal(t, "com.80pct.FreedomHelper", FreedomHelperProcessName)
+	assert.Equal(t, 7769, FreedomProxyPort)
+}
+
+// TestNewFreedomProtector verifies constructor creates valid instance
+func TestNewFreedomProtector(t *testing.T) {
+	pm := NewProcessManager()
+	logger := zap.NewNop()
+
+	protector := NewFreedomProtector(pm, logger)
+	require.NotNil(t, protector)
+
+	// Verify it implements the interface
+	var _ domain.FreedomProtector = protector
+}
+
+// TestFreedomProtector_IsInstalled_Real tests with real filesystem check
+func TestFreedomProtector_IsInstalled_Real(t *testing.T) {
+	pm := NewProcessManager()
+	logger := zap.NewNop()
+	protector := NewFreedomProtector(pm, logger)
+
+	// This will return true or false based on whether Freedom is actually installed
+	// We just verify it doesn't panic
+	installed := protector.IsInstalled()
+	t.Logf("Freedom installed: %v", installed)
+}


### PR DESCRIPTION
## Summary

Implements automatic protection for Freedom app (freedom.to) to prevent it from being killed and staying dead until manually restarted.

- Monitor Freedom.app process, auto-restart within 5 seconds if killed
- Monitor FreedomProxy process (restarts automatically with Freedom)
- Restore Login Items if removed  
- Report Freedom health in `appmon status`
- Graceful handling if Freedom not installed (skipped)
- Graceful degradation if helper missing (warned in status)

## Implementation Details

- New `FreedomProtector` interface in domain layer
- `FreedomProtectorImpl` in infra layer with TDD tests
- Integrated with Watcher daemon (5-second check interval)
- Updated status command to show Freedom protection health

## Test plan

### Unit Tests
- [x] All unit tests pass (`go test ./...`)
- [x] FreedomProtector mock tests for all scenarios
- [x] Daemon config tests updated for new interval

### E2E Test Evidence

**Before kill:**
```
Freedom processes:
815 Contents/MacOS/com.80pct.FreedomHelper
20649 /Applications/Freedom.app/Contents/MacOS/Freedom
```

**After kill and 8 second wait:**
```
Freedom processes:
815 Contents/MacOS/com.80pct.FreedomHelper
20707 /Applications/Freedom.app/Contents/MacOS/Freedom  ← NEW PID, restarted!
```

**Appmon logs showing restart:**
```json
{"level":"info","msg":"Freedom app not running, restarting..."}
{"level":"info","msg":"restarting Freedom app"}
{"level":"info","msg":"Freedom app restarted successfully"}
{"level":"info","msg":"Freedom protection action taken"}
```

**Status command output:**
```
Freedom protection:
  ✓ Freedom.app running, proxy active, login item present
```

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)