### PR TITLE
feat(app_mon): killall-resistance, cron respawn, encrypted-registry update flow

### DIFF
--- a/app_mon/CHANGELOG.md
+++ b/app_mon/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to appmon will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-12
+
+### Features
+- **killall / pkill resistance** via binary relocation. Each daemon spawn copies
+  or hard-links `/usr/local/bin/appmon` to a randomized system-looking basename
+  (`com.apple.cfprefsd.xpc.<hex>` etc) under an obfuscated cache dir
+  (`~/.cache/.com.apple.xpc.<host-hash>/`) and execs from there. The kernel's
+  `p_comm` for the running daemon is the relocated basename, so
+  `killall appmon` matches nothing. Path does not contain "appmon", so
+  `pkill -f appmon` also misses. Each spawn rotates the name, so an attacker
+  who learns one name can only kill that one instance — peer-restart spawns
+  the partner under a new random name.
+- **Login Items obfuscation**: LaunchAgent / LaunchDaemon plist now references
+  a "launch stub" — a relocated copy of the main binary stored at a
+  randomized path. macOS Login Items shows the obfuscated basename instead
+  of `appmon`.
+- **5-min cron-like respawn**: plist `StartInterval: 300` plus
+  `KeepAlive: { Crashed: true, SuccessfulExit: false }` means launchd
+  re-fires `appmon start` every 5 minutes. `start` is idempotent — fast no-op
+  if both daemons are alive, full respawn if dead. Belt-and-suspenders backup
+  to peer-restart in case both daemons die simultaneously.
+- **Daemon self-relocate fallback**: `appmon daemon …` re-execs itself from a
+  relocated path on startup if exec'd from outside the relocator dir
+  (e.g. by an older parent during an update). Idempotent.
+- **Orphan reaper**: Watcher periodically (on startup + every 60s) scans
+  the relocator cache dir and SIGKILLs any process whose PID is not in the
+  encrypted registry. Makes the registry the single source of truth for
+  daemon membership and self-heals after failed updates, racing spawns, or
+  any stale state.
+
+### Bug Fixes
+- **CRITICAL — updater registry split-brain**: `NewUpdater` previously
+  instantiated `NewFileRegistry` (the legacy JSON file at
+  `/var/tmp/.cf_sys_registry_*`) while the live daemons write to the
+  encrypted SQLCipher registry. Health checks therefore never saw the just-
+  spawned daemons, every update timed out and triggered a phantom rollback,
+  and each rollback spawned another pair of orphan daemons. Updater now
+  opens the encrypted registry via `openUpdaterRegistry`, falling back to
+  the legacy file registry only on hard failure.
+- **Updater spawnDaemon bypasses relocation**: previously exec'd
+  `/usr/local/bin/appmon` directly, forcing the daemon to self-relocate via
+  `syscall.Exec`. Now relocates before exec like
+  `daemon.StartDaemonWithMode` does; child runs from a randomized path
+  immediately.
+- **Health-check timeout 10s → 30s**: absorbs SQLCipher key derivation +
+  daemon self-relocate on cold-start. Too-tight timeout was the proximate
+  cause of phantom rollbacks (combined with the registry split-brain).
+
+### Architecture
+- New `infra.Relocator` (relocator.go) — copies/hard-links binaries to
+  obfuscated paths, sweeps stale entries, lists PIDs running from the
+  relocator dir.
+- New `infra.EnsureLaunchStub` (launch_stub.go) — stable randomized stub for
+  the LaunchAgent plist, persisted as a secret in the encrypted registry,
+  auto-refreshed when content drifts from the main binary.
+- Watcher gains `sweepStaleRelocations` + `reapOrphans` hooks on its 60s
+  binary-check tick.
+
 ## [0.4.0] - 2026-01-29
 
 ### Features

--- a/app_mon/README.md
+++ b/app_mon/README.md
@@ -12,9 +12,12 @@ A self-enforcing application monitor that blocks distracting apps like Steam and
 
 - **Process Killing**: Automatically kills Steam/Dota2 processes when detected
 - **File Deletion**: Removes Steam app bundle and Dota2 game files
-- **Mutual Daemon Protection**: Two daemons monitor each other - kill one, the other restarts it
-- **Auto-Start on Login**: Installs as a LaunchAgent for persistence across reboots
-- **Obfuscated Process Names**: Daemons appear as system processes (e.g., `com.apple.cfprefsd.xpc.abc123`)
+- **Mutual Daemon Protection**: Two daemons monitor each other — kill one, the other restarts it
+- **Auto-Start + 5-min Cron Respawn**: Plist `RunAtLoad` + `StartInterval=300` so launchd revives both daemons within 5 minutes even if simultaneously killed
+- **Binary Relocation (killall-resistant)**: Each daemon spawn copies/hard-links the binary to a randomized system-looking basename and execs from there, so `killall appmon` and `pkill -f appmon` match nothing
+- **Login-Items Obfuscation**: The LaunchAgent plist points at a relocated "launch stub" — macOS Login Items shows e.g. `com.apple.security.agent.f7cf9323`, not `appmon`
+- **Encrypted Registry (source of truth)**: SQLCipher database holds daemon PIDs, plist label, launch stub path, version. Update flow and watcher both read from it — no split-brain
+- **Orphan Reaper**: Watcher periodically scans the relocator cache dir and kills any process whose PID isn't in the registry (handles failed updates, racing spawns, stale state)
 - **No Stop Command**: Intentional friction to prevent impulsive disabling
 
 ## Installation
@@ -45,24 +48,37 @@ appmon list
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  Layer 1: macOS LaunchAgent                                  │
-│  - Auto-starts on login                                      │
-│  - KeepAlive: restarts if crashed                            │
+│  Layer 1: macOS launchd (cron-like respawn)                  │
+│  - RunAtLoad on login                                        │
+│  - StartInterval: 300s (re-fires every 5 min)                │
+│  - KeepAlive: { Crashed: true, SuccessfulExit: false }       │
+│  - ProgramArguments[0] = launch stub (obfuscated basename)   │
 └──────────────────────────────────────────────────────────────┘
                             │
 ┌──────────────────────────────────────────────────────────────┐
 │  Layer 2: Mutual Daemon Monitoring                           │
-│  ┌────────────────┐          ┌────────────────┐             │
-│  │    Watcher     │◄────────►│    Guardian    │             │
-│  │ - kills procs  │ monitors │ - restarts     │             │
-│  │ - deletes files│  each    │   watcher      │             │
-│  └────────────────┘  other   └────────────────┘             │
+│  ┌────────────────┐          ┌────────────────┐              │
+│  │    Watcher     │◄────────►│    Guardian    │              │
+│  │ - kills procs  │ monitors │ - restarts     │              │
+│  │ - deletes files│  each    │   watcher      │              │
+│  └────────────────┘  other   └────────────────┘              │
+│  Each spawn = fresh randomized basename via Relocator        │
 └──────────────────────────────────────────────────────────────┘
                             │
 ┌──────────────────────────────────────────────────────────────┐
-│  Layer 3: Obfuscated Process Names                           │
-│  - Random system-looking names per restart                   │
-│  - Example: com.apple.security.worker.789abc                 │
+│  Layer 3: Binary Relocation                                  │
+│  - Cache dir: ~/.cache/.com.apple.xpc.<host-hash>/           │
+│  - Basenames: com.apple.{cfprefsd,metadata,security,...}.    │
+│    {xpc,helper,agent,...}.<random-hex>                       │
+│  - killall appmon / pkill -f appmon → no match               │
+└──────────────────────────────────────────────────────────────┘
+                            │
+┌──────────────────────────────────────────────────────────────┐
+│  Layer 4: Encrypted Registry (source of truth)               │
+│  - SQLCipher DB at <DataDir>/registry.db                     │
+│  - Tracks: WatcherPID, GuardianPID, plist label, stub path   │
+│  - Updater + watcher both read from it (no split-brain)      │
+│  - Orphan reaper kills cache-dir PIDs not in registry        │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -88,27 +104,46 @@ appmon list
 
 ## Scan Interval
 
-The daemon scans every **10 minutes** (configurable via code). This is a balance between responsiveness and CPU usage.
+The watcher scans every **5 minutes**, matching the LaunchAgent's `StartInterval`. So blocked apps get killed within 5 min whether the daemons stay healthy or get respawned by launchd.
 
 ## Resilience
 
 | Scenario | What Happens |
 |----------|--------------|
-| Kill watcher | Guardian restarts it within 30s |
-| Kill guardian | Watcher restarts it within 60s |
-| Kill both | macOS LaunchAgent restarts appmon |
-| System restart | LaunchAgent auto-starts appmon |
-| Delete registry file | Daemons recreate it on next heartbeat |
-| Delete LaunchAgent plist | Watcher restores it automatically |
+| `killall appmon` / `pkill -f appmon` | No match — daemons exec from a randomized basename in a path that doesn't contain "appmon" |
+| Kill watcher (by PID) | Guardian restarts it within 30s, with a fresh randomized name |
+| Kill guardian (by PID) | Watcher restarts it within 60s, with a fresh randomized name |
+| Kill both | launchd re-fires `appmon start` within 5 min (`StartInterval`) and respawns both daemons |
+| System restart | LaunchAgent/Daemon auto-starts at next login (user mode) or boot (system mode) |
+| Delete registry DB | Daemons recreate it on next start (loses tracking — orphan reaper still works because cache dir is canonical) |
+| Delete LaunchAgent plist | Watcher restores it within 60s, pointing to the launch stub |
+| Delete main binary `/usr/local/bin/appmon` | Watcher restores from hidden backup or GitHub release |
+| Stale daemons from failed update | Orphan reaper kills any cache-dir PID missing from the encrypted registry, within 60s |
 
 ## File Locations
+
+System mode (LaunchDaemon, root):
 
 | File | Purpose |
 |------|---------|
 | `/usr/local/bin/appmon` | Main binary |
-| `~/Library/LaunchAgents/com.focusd.appmon.plist` | LaunchAgent config |
-| `/var/tmp/.cf_sys_registry_*` | Hidden daemon registry |
+| `/Library/LaunchDaemons/com.apple.xpc.launchd.helper.<hex>.plist` | LaunchDaemon config (randomized label) |
+| `/var/lib/appmon/registry.db` | SQLCipher-encrypted registry (PIDs, secrets) |
+| `/var/lib/appmon/.key` | Encryption key for registry |
+| `~/.cache/.com.apple.xpc.<host-hash>/` | Relocated daemon binaries + launch stub |
+| `~/.config/.com.apple.preferences.<hex>/` | Backup manifest (hidden) |
+| `~/.config/.com.apple.helper.<hex>/` etc | Binary backups (multiple hidden locations) |
 | `/var/tmp/appmon.log` | Daemon logs |
+
+User mode (LaunchAgent, current user):
+
+| File | Purpose |
+|------|---------|
+| `~/.local/bin/appmon` | Main binary |
+| `~/Library/LaunchAgents/com.apple.xpc.launchd.helper.<hex>.plist` | LaunchAgent config |
+| `~/.appmon/registry.db` | Encrypted registry |
+
+Both modes use the same randomized basename schemes; all paths are derived from a hash of the hostname and persisted in the encrypted registry.
 
 ## Why No Uninstall?
 

--- a/app_mon/cmd/appmon/main.go
+++ b/app_mon/cmd/appmon/main.go
@@ -28,6 +28,34 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4"
 )
 
+// daemonSelfRelocate re-execs the current daemon process from a relocated
+// binary path if its executable still lives outside the relocator cache.
+// This guards against spawners that bypass the relocator (e.g., an older
+// CLI driving an update, or a manual `appmon daemon` invocation from
+// /usr/local/bin/appmon). Idempotent: if argv[0] is already under the
+// relocator dir, returns nil without changing anything.
+//
+// On successful re-exec the function does not return — syscall.Exec
+// replaces the process image. On any failure the caller continues with
+// the original (un-relocated) executable; the daemon still functions,
+// just with `p_comm = appmon` which `killall appmon` would match.
+func daemonSelfRelocate() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	relocator := infra.NewRelocator(infra.GetRealUserHome())
+	if strings.HasPrefix(exe, relocator.Dir()+string(os.PathSeparator)) {
+		return nil // already relocated
+	}
+	relocated, err := relocator.Relocate(exe)
+	if err != nil {
+		return err
+	}
+	argv := append([]string{relocated}, os.Args[1:]...)
+	return syscall.Exec(relocated, argv, os.Environ())
+}
+
 var (
 	// Version info (set via ldflags during release build)
 	// go build -ldflags "-X main.Version=x.y.z -X main.Commit=abc123 -X main.BuildTime=2024-01-01"
@@ -341,6 +369,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Binary backups created (v%s) with GitHub fallback\n", Version)
 	}
 
+	// Build the launch stub the plist will reference. Using a randomized
+	// system-looking basename keeps "appmon" out of Login Items (the UI
+	// shows the basename of ProgramArguments[0]).
+	plistExec := binaryPath
+	if stub, err := infra.EnsureLaunchStub(binaryPath, infra.GetRealUserHome(), registry); err == nil {
+		plistExec = stub
+	} else {
+		fmt.Printf("Warning: Could not create launch stub: %v\n", err)
+		fmt.Println("         (auto-start will still work, but Login Items will show 'appmon')")
+	}
+
 	// Install LaunchAgent/LaunchDaemon based on execution mode (idempotent)
 	launchdManager := infra.NewLaunchdManager(execMode)
 
@@ -354,7 +393,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	if !launchdManager.IsInstalled() {
 		// Fresh install
-		if err := launchdManager.Install(binaryPath); err != nil {
+		if err := launchdManager.Install(plistExec); err != nil {
 			fmt.Printf("Warning: Could not install %s: %v\n", execMode.Mode, err)
 			fmt.Println("         (appmon will still run, but won't auto-start)")
 		} else {
@@ -364,9 +403,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 				fmt.Println("Installed LaunchAgent for auto-start on login")
 			}
 		}
-	} else if launchdManager.NeedsUpdate(binaryPath) {
+	} else if launchdManager.NeedsUpdate(plistExec) {
 		// Exists but outdated - update in place
-		if err := launchdManager.Update(binaryPath); err != nil {
+		if err := launchdManager.Update(plistExec); err != nil {
 			fmt.Printf("Warning: Could not update %s: %v\n", execMode.Mode, err)
 		} else {
 			fmt.Println("Updated plist with new binary path")
@@ -666,6 +705,15 @@ func runScan(cmd *cobra.Command, args []string) error {
 func runDaemon(cmd *cobra.Command, args []string) error {
 	if daemonRole == "" || daemonName == "" {
 		return fmt.Errorf("--role and --name are required")
+	}
+
+	// Ensure we're running from a relocated path (kernel-visible p_comm is
+	// something like com.apple.cfprefsd.xpc.<hex>, not "appmon") so
+	// `killall appmon` cannot match this process. Best-effort: failures
+	// are non-fatal and only mean reduced obfuscation.
+	if err := daemonSelfRelocate(); err != nil {
+		// Log via stderr only — logger isn't initialized yet.
+		fmt.Fprintf(os.Stderr, "appmon daemon: self-relocate failed: %v\n", err)
 	}
 
 	// Set up logger (writes to /var/tmp/appmon.log)

--- a/app_mon/internal/daemon/bootstrap.go
+++ b/app_mon/internal/daemon/bootstrap.go
@@ -30,21 +30,29 @@ func StartDaemonWithPath(role domain.DaemonRole, binaryPath string) error {
 // StartDaemonWithPathAndMode spawns a daemon from a specific binary path with explicit mode.
 // If binaryPath is empty, uses the installed binary path based on exec mode.
 // If mode is empty, daemon will auto-detect based on euid.
+//
+// Before exec, the source binary is relocated (hard link / copy) to an
+// obfuscated cache directory under a randomized basename. The child process
+// therefore runs with a non-"appmon" p_comm, so `killall appmon` does not
+// match the running daemon. Each spawn produces a fresh basename, so an
+// attacker who learns one name and runs `killall <name>` only kills that
+// instance — the peer-restart spawns the partner under a new name.
 func StartDaemonWithPathAndMode(role domain.DaemonRole, binaryPath string, mode string) error {
 	obfuscator := infra.NewObfuscator()
 	daemonName := obfuscator.GenerateName()
 
-	// Determine executable path
+	// Resolve install location for the requested mode (used both for the
+	// default executable and for the relocator home).
+	var execMode *infra.ExecModeConfig
+	if mode == "user" {
+		execMode = infra.GetUserModeConfig()
+	} else {
+		execMode = infra.DetectExecMode()
+	}
+
+	// Determine source executable
 	executable := binaryPath
 	if executable == "" {
-		// Use installed binary path, not os.Executable()
-		// This ensures daemons run from install location, not temp/dev location
-		var execMode *infra.ExecModeConfig
-		if mode == "user" {
-			execMode = infra.GetUserModeConfig()
-		} else {
-			execMode = infra.DetectExecMode()
-		}
 		executable = execMode.BinaryPath
 
 		// Fall back to os.Executable() if installed binary doesn't exist
@@ -57,6 +65,13 @@ func StartDaemonWithPathAndMode(role domain.DaemonRole, binaryPath string, mode 
 		}
 	}
 
+	// Relocate to a randomized basename. On failure, fall back to the
+	// original path — the daemon still runs but its p_comm stays "appmon".
+	relocator := infra.NewRelocator(infra.GetRealUserHome())
+	if relocated, err := relocator.Relocate(executable); err == nil {
+		executable = relocated
+	}
+
 	// Build command arguments
 	args := []string{"daemon", "--role", string(role), "--name", daemonName}
 	if mode != "" {
@@ -64,7 +79,7 @@ func StartDaemonWithPathAndMode(role domain.DaemonRole, binaryPath string, mode 
 	}
 
 	// Self-exec with daemon mode flag
-	// Hidden "daemon" command: appmon daemon --role watcher --name com.apple.xxx --mode user
+	// Hidden "daemon" command: <relocated-path> daemon --role watcher --name com.apple.xxx --mode user
 	cmd := exec.Command(executable, args...)
 
 	// Detach from parent process

--- a/app_mon/internal/daemon/daemon_test.go
+++ b/app_mon/internal/daemon/daemon_test.go
@@ -7,14 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
-	"github.com/eliteGoblin/focusd/app_mon/internal/policy"
 )
 
 // TestDefaultWatcherConfig verifies default watcher configuration
 func TestDefaultWatcherConfig(t *testing.T) {
 	config := DefaultWatcherConfig()
 
-	assert.Equal(t, policy.DefaultScanInterval, config.EnforcementInterval)
+	// EnforcementInterval matches the LaunchAgent's StartInterval (5 min)
+	// so steam/dota2 get scanned at the same cadence as the cron respawn.
+	assert.Equal(t, 5*time.Minute, config.EnforcementInterval)
 	assert.Equal(t, 30*time.Second, config.HeartbeatInterval)
 	assert.Equal(t, 60*time.Second, config.PartnerCheckInterval)
 	assert.Equal(t, 60*time.Second, config.PlistCheckInterval)

--- a/app_mon/internal/daemon/watcher.go
+++ b/app_mon/internal/daemon/watcher.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
-	"github.com/eliteGoblin/focusd/app_mon/internal/policy"
+	"github.com/eliteGoblin/focusd/app_mon/internal/infra"
 )
 
 // BackupManager interface for binary self-protection
@@ -29,9 +29,13 @@ type WatcherConfig struct {
 }
 
 // DefaultWatcherConfig returns default watcher configuration.
+//
+// EnforcementInterval is 5 min: matches the LaunchAgent's StartInterval so
+// blocked apps (Steam, Dota 2) get scanned and killed/deleted within that
+// window whether the daemons stay healthy or get respawned by launchd.
 func DefaultWatcherConfig() WatcherConfig {
 	return WatcherConfig{
-		EnforcementInterval:  policy.DefaultScanInterval, // 10 minutes
+		EnforcementInterval:  5 * time.Minute,
 		HeartbeatInterval:    30 * time.Second,
 		PartnerCheckInterval: 60 * time.Second,
 		PlistCheckInterval:   60 * time.Second, // Check plist every minute
@@ -105,6 +109,15 @@ func (w *Watcher) Run(ctx context.Context) error {
 	// Check binary integrity on startup
 	w.ensureBinaryIntegrity()
 
+	// Sweep stale relocated daemon binaries on startup
+	w.sweepStaleRelocations()
+
+	// Reap any daemon processes running from our relocator dir that aren't
+	// in the registry. This is how we recover from update rollbacks,
+	// crashed parents, or racing spawns — the encrypted registry is the
+	// single source of truth for which daemons are "ours".
+	w.reapOrphans()
+
 	// Protect Freedom on startup
 	w.protectFreedom()
 
@@ -147,6 +160,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 		case <-binaryCheckTicker.C:
 			w.ensureBinaryIntegrity()
+			w.sweepStaleRelocations()
+			w.reapOrphans()
 
 		case <-freedomCheckTicker.C:
 			w.protectFreedom()
@@ -199,21 +214,37 @@ func (w *Watcher) checkAndRestartGuardian(ctx context.Context) {
 // ensurePlistInstalled checks if LaunchAgent plist exists and restores if deleted.
 // Also checks if content is correct and updates if needed (idempotent).
 // This is self-protection: if someone deletes or modifies the plist, we restore it.
+//
+// The plist's ProgramArguments[0] points to a relocated "launch stub" with a
+// randomized basename so Login Items shows an obfuscated name rather than
+// "appmon". If the stub can't be (re)built, fall back to the main binary
+// path — auto-start still works, just without that layer of obfuscation.
 func (w *Watcher) ensurePlistInstalled() {
 	if w.launchAgent == nil {
 		return
 	}
 
-	// Get the expected binary path
-	var execPath string
+	// Resolve the canonical main-binary path.
+	var mainBinary string
 	if w.backupManager != nil {
-		execPath = w.backupManager.GetMainBinaryPath()
+		mainBinary = w.backupManager.GetMainBinaryPath()
 	} else {
 		var err error
-		execPath, err = os.Executable()
+		mainBinary, err = os.Executable()
 		if err != nil {
 			w.logger.Error("failed to get executable path", zap.Error(err))
 			return
+		}
+	}
+
+	// Prefer the launch stub so Login Items doesn't display "appmon".
+	execPath := mainBinary
+	if store, ok := w.registry.(domain.SecretStore); ok {
+		if stub, err := infra.EnsureLaunchStub(mainBinary, infra.GetRealUserHome(), store); err == nil {
+			execPath = stub
+		} else {
+			w.logger.Warn("failed to ensure launch stub, falling back to main binary",
+				zap.Error(err))
 		}
 	}
 
@@ -251,6 +282,67 @@ func (w *Watcher) ensureBinaryIntegrity() {
 
 	if restored {
 		w.logger.Info("binary was missing/corrupted, restored from backup")
+	}
+}
+
+// sweepStaleRelocations removes orphaned binary copies from the relocator
+// cache directory. Each daemon spawn creates a fresh copy/link, so repeated
+// crash-restart cycles accumulate stale files. The watcher's own exec path
+// and the launch stub are explicitly preserved; everything else older than
+// minAge is removed. Unlinking a binary while a process holds it open is
+// safe on macOS — the kernel keeps the inode alive until the process exits,
+// and peer-restart always spawns through a fresh relocation anyway.
+func (w *Watcher) sweepStaleRelocations() {
+	relocator := infra.NewRelocator(infra.GetRealUserHome())
+	keep := []string{}
+
+	if exe, err := os.Executable(); err == nil {
+		keep = append(keep, exe)
+	}
+	if store, ok := w.registry.(domain.SecretStore); ok {
+		if stub, err := store.GetSecret(infra.SecretKeyLaunchStub); err == nil && stub != "" {
+			keep = append(keep, stub)
+		}
+	}
+
+	if err := relocator.CleanStale(keep, 2*time.Minute); err != nil {
+		w.logger.Debug("relocation sweep failed", zap.Error(err))
+	}
+}
+
+// reapOrphans kills any process exec'd from our relocator directory whose
+// PID is not recorded in the encrypted registry as a live daemon. This is
+// the cleanup-on-source-of-truth mechanism: the registry decides who's
+// "ours", and anything else running from our cache dir is an orphan —
+// from a failed update rollback, a racing spawn, or an old session whose
+// parent died. Reaping orphans keeps killall-resistant peer-restart
+// converging on exactly one watcher and one guardian.
+//
+// Safe even at high frequency: we never kill our own PID or our partner.
+func (w *Watcher) reapOrphans() {
+	relocator := infra.NewRelocator(infra.GetRealUserHome())
+	pids, err := relocator.FindProcessesUsingDir()
+	if err != nil {
+		w.logger.Debug("orphan reap: ps failed", zap.Error(err))
+		return
+	}
+
+	keep := map[int]struct{}{os.Getpid(): {}}
+	if entry, err := w.registry.GetAll(); err == nil && entry != nil {
+		if entry.WatcherPID > 0 {
+			keep[entry.WatcherPID] = struct{}{}
+		}
+		if entry.GuardianPID > 0 {
+			keep[entry.GuardianPID] = struct{}{}
+		}
+	}
+
+	for _, pid := range pids {
+		if _, ok := keep[pid]; ok {
+			continue
+		}
+		w.logger.Info("reaping orphan daemon", zap.Int("pid", pid))
+		_ = w.processManager.Kill(pid)
 	}
 }
 

--- a/app_mon/internal/infra/launch_stub.go
+++ b/app_mon/internal/infra/launch_stub.go
@@ -1,0 +1,61 @@
+package infra
+
+import (
+	"os"
+
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
+)
+
+// SecretKeyLaunchStub stores the path of the LaunchAgent's relocated stub.
+const SecretKeyLaunchStub = "launch_stub_path"
+
+// EnsureLaunchStub returns a stable relocated path the LaunchAgent's plist
+// references via ProgramArguments[0]. The stub is a hard link / copy of
+// mainBinaryPath at a randomized system-looking basename so macOS's Login
+// Items UI displays the obfuscated name instead of "appmon".
+//
+// If a stub path is already stored in the secret store and its content
+// matches the current main binary (by SHA256), it is reused. Otherwise a
+// fresh stub is generated, the stale one is unlinked, and the new path is
+// persisted.
+//
+// On any failure the caller should fall back to mainBinaryPath; the
+// LaunchAgent will still function, but Login Items will show "appmon".
+func EnsureLaunchStub(mainBinaryPath, home string, store domain.SecretStore) (string, error) {
+	r := NewRelocator(home)
+
+	if stored, _ := store.GetSecret(SecretKeyLaunchStub); stored != "" {
+		if stubMatches(stored, mainBinaryPath) {
+			return stored, nil
+		}
+		_ = os.Remove(stored)
+	}
+
+	stub, err := r.Relocate(mainBinaryPath)
+	if err != nil {
+		return "", err
+	}
+	if err := store.SetSecret(SecretKeyLaunchStub, stub); err != nil {
+		_ = os.Remove(stub)
+		return "", err
+	}
+	return stub, nil
+}
+
+// stubMatches returns true when both files exist and share the same SHA256.
+// Used to detect when the main binary has been updated and the stub points
+// to stale content (e.g., a hard link to a now-replaced inode).
+func stubMatches(stubPath, mainBinaryPath string) bool {
+	if _, err := os.Stat(stubPath); err != nil {
+		return false
+	}
+	stubSHA, err := computeSHA256(stubPath)
+	if err != nil {
+		return false
+	}
+	mainSHA, err := computeSHA256(mainBinaryPath)
+	if err != nil {
+		return false
+	}
+	return stubSHA == mainSHA
+}

--- a/app_mon/internal/infra/launch_stub_test.go
+++ b/app_mon/internal/infra/launch_stub_test.go
@@ -1,0 +1,108 @@
+package infra
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeStubBinary creates an executable file with the given content and
+// returns its path.
+func writeStubBinary(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0755))
+	return p
+}
+
+func TestEnsureLaunchStub_FreshCreatesStubAndPersists(t *testing.T) {
+	home := t.TempDir()
+	src := writeStubBinary(t, t.TempDir(), "appmon", "payload-v1")
+
+	reg, _ := newTestRegistry(t)
+
+	stub, err := EnsureLaunchStub(src, home, reg)
+	require.NoError(t, err)
+
+	// Stub exists at a randomized basename under the relocator dir.
+	r := NewRelocator(home)
+	require.True(t, strings.HasPrefix(stub, r.Dir()+string(os.PathSeparator)),
+		"stub %q should live under %q", stub, r.Dir())
+	require.NotEqual(t, "appmon", filepath.Base(stub))
+
+	// Path is persisted in the SecretStore.
+	stored, err := reg.GetSecret(SecretKeyLaunchStub)
+	require.NoError(t, err)
+	require.Equal(t, stub, stored)
+
+	// Content matches source.
+	got, err := os.ReadFile(stub)
+	require.NoError(t, err)
+	require.Equal(t, "payload-v1", string(got))
+}
+
+func TestEnsureLaunchStub_ReusesStubWhenContentMatches(t *testing.T) {
+	home := t.TempDir()
+	src := writeStubBinary(t, t.TempDir(), "appmon", "payload")
+	reg, _ := newTestRegistry(t)
+
+	first, err := EnsureLaunchStub(src, home, reg)
+	require.NoError(t, err)
+
+	second, err := EnsureLaunchStub(src, home, reg)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second, "stub path should be reused when content unchanged")
+}
+
+func TestEnsureLaunchStub_RefreshesWhenSourceChanges(t *testing.T) {
+	home := t.TempDir()
+	srcDir := t.TempDir()
+	src := writeStubBinary(t, srcDir, "appmon", "payload-v1")
+	reg, _ := newTestRegistry(t)
+
+	first, err := EnsureLaunchStub(src, home, reg)
+	require.NoError(t, err)
+
+	// Simulate an `appmon update` install step: atomic rename gives the
+	// source a NEW inode. The hard-link stub points at the OLD inode and
+	// is therefore stale, so EnsureLaunchStub must regenerate it.
+	replacement := writeStubBinary(t, srcDir, "appmon.next", "payload-v2")
+	require.NoError(t, os.Rename(replacement, src))
+
+	second, err := EnsureLaunchStub(src, home, reg)
+	require.NoError(t, err)
+
+	require.NotEqual(t, first, second, "stub should be regenerated when source content changes")
+
+	got, err := os.ReadFile(second)
+	require.NoError(t, err)
+	require.Equal(t, "payload-v2", string(got))
+
+	// Old stub path should be cleaned up.
+	_, err = os.Stat(first)
+	require.True(t, os.IsNotExist(err), "old stub should be unlinked, stat err = %v", err)
+}
+
+func TestStubMatches(t *testing.T) {
+	dir := t.TempDir()
+	a := writeStubBinary(t, dir, "a", "same")
+	b := writeStubBinary(t, dir, "b", "same")
+	c := writeStubBinary(t, dir, "c", "different")
+
+	require.True(t, stubMatches(a, b), "identical content should match")
+	require.False(t, stubMatches(a, c), "different content should not match")
+	require.False(t, stubMatches(a, filepath.Join(dir, "missing")),
+		"missing target should not match")
+	require.False(t, stubMatches(filepath.Join(dir, "missing"), a),
+		"missing stub should not match")
+}
+
+func TestRelocator_Dir_ReturnsConfiguredPath(t *testing.T) {
+	home := t.TempDir()
+	r := NewRelocator(home)
+	require.Equal(t, relocatorDir(home), r.Dir())
+}

--- a/app_mon/internal/infra/launchd.go
+++ b/app_mon/internal/infra/launchd.go
@@ -11,7 +11,19 @@ import (
 	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
 )
 
-// LaunchAgent plist template (runs as user)
+// LaunchAgent plist template (runs as user).
+//
+// Cron-like respawn:
+//   - RunAtLoad: fire on user login
+//   - StartInterval: fire every 300s, regardless of process health
+//   - KeepAlive.Crashed: restart on non-zero exit / signal
+//   - KeepAlive.SuccessfulExit=false: do NOT loop after a clean exit (the
+//     `start` command exits cleanly when daemons are healthy)
+//
+// `appmon start` is idempotent — it returns early when both daemons are
+// alive, and respawns them otherwise. So the 5-min interval acts as a
+// belt-and-suspenders backup to the watcher↔guardian peer-restart loop:
+// even if both daemons die at once, the next tick brings everything back.
 const launchAgentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -28,10 +40,15 @@ const launchAgentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>RunAtLoad</key>
     <true/>
 
+    <key>StartInterval</key>
+    <integer>300</integer>
+
     <key>KeepAlive</key>
     <dict>
         <key>Crashed</key>
         <true/>
+        <key>SuccessfulExit</key>
+        <false/>
     </dict>
 
     <key>StandardOutPath</key>
@@ -48,7 +65,8 @@ const launchAgentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>`
 
-// LaunchDaemon plist template (runs as root)
+// LaunchDaemon plist template (runs as root). Same cron-like semantics as
+// the user-mode LaunchAgent above.
 const launchDaemonTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -65,8 +83,16 @@ const launchDaemonTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>RunAtLoad</key>
     <true/>
 
+    <key>StartInterval</key>
+    <integer>300</integer>
+
     <key>KeepAlive</key>
-    <true/>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
 
     <key>StandardOutPath</key>
     <string>{{.LogPath}}</string>

--- a/app_mon/internal/infra/launchd_test.go
+++ b/app_mon/internal/infra/launchd_test.go
@@ -1,0 +1,88 @@
+package infra
+
+import (
+	"strings"
+	"testing"
+)
+
+// newPlistManager returns a manager wired for the requested mode. The dir
+// and path fields don't matter for content generation tests.
+func newPlistManager(mode ExecMode) *LaunchdManagerImpl {
+	return &LaunchdManagerImpl{
+		mode:      mode,
+		plistDir:  "/tmp",
+		plistPath: "/tmp/test.plist",
+	}
+}
+
+func TestGeneratePlistContent_UserMode_HasCronLikeKeys(t *testing.T) {
+	m := newPlistManager(ExecModeUser)
+	out, err := m.generatePlistContent("/Users/test/.local/bin/appmon")
+	if err != nil {
+		t.Fatalf("generatePlistContent: %v", err)
+	}
+	body := string(out)
+
+	mustContain(t, body, "<key>RunAtLoad</key>")
+	mustContain(t, body, "<key>StartInterval</key>")
+	mustContain(t, body, "<integer>300</integer>")
+
+	mustContain(t, body, "<key>KeepAlive</key>")
+	mustContain(t, body, "<key>Crashed</key>")
+	mustContain(t, body, "<key>SuccessfulExit</key>")
+	mustContain(t, body, "<false/>")
+
+	mustContain(t, body, "<key>ThrottleInterval</key>")
+	mustContain(t, body, "<integer>10</integer>")
+
+	mustContain(t, body, "<string>/Users/test/.local/bin/appmon</string>")
+	mustContain(t, body, "<string>start</string>")
+}
+
+func TestGeneratePlistContent_SystemMode_HasCronLikeKeys(t *testing.T) {
+	m := newPlistManager(ExecModeSystem)
+	out, err := m.generatePlistContent("/usr/local/bin/appmon")
+	if err != nil {
+		t.Fatalf("generatePlistContent: %v", err)
+	}
+	body := string(out)
+
+	mustContain(t, body, "<key>RunAtLoad</key>")
+	mustContain(t, body, "<key>StartInterval</key>")
+	mustContain(t, body, "<integer>300</integer>")
+	mustContain(t, body, "<key>KeepAlive</key>")
+	mustContain(t, body, "<key>Crashed</key>")
+	mustContain(t, body, "<key>SuccessfulExit</key>")
+	mustContain(t, body, "<false/>")
+	mustContain(t, body, "<string>/usr/local/bin/appmon</string>")
+}
+
+// Regression: must not fall back to the old "KeepAlive: true" form, which
+// would cause launchd to loop the cleanly-exiting `start` parent every
+// ThrottleInterval (10s) — wasteful and noisy.
+func TestGeneratePlistContent_SystemMode_DoesNotUseBareKeepAlive(t *testing.T) {
+	m := newPlistManager(ExecModeSystem)
+	out, _ := m.generatePlistContent("/usr/local/bin/appmon")
+	body := string(out)
+
+	// Old form was "<key>KeepAlive</key>\n    <true/>" — the dict form is
+	// what we want now. Ensure no <key>KeepAlive</key> immediately followed
+	// by <true/>.
+	idx := strings.Index(body, "<key>KeepAlive</key>")
+	if idx < 0 {
+		t.Fatalf("KeepAlive key missing")
+	}
+	tail := body[idx:]
+	dictPos := strings.Index(tail, "<dict>")
+	truePos := strings.Index(tail, "<true/>")
+	if truePos >= 0 && (dictPos < 0 || truePos < dictPos) {
+		t.Fatalf("KeepAlive resolves to <true/> before <dict> — regression of cron config")
+	}
+}
+
+func mustContain(t *testing.T, body, needle string) {
+	t.Helper()
+	if !strings.Contains(body, needle) {
+		t.Fatalf("plist body missing %q\nbody:\n%s", needle, body)
+	}
+}

--- a/app_mon/internal/infra/relocator.go
+++ b/app_mon/internal/infra/relocator.go
@@ -115,8 +115,9 @@ func (r *Relocator) FindProcessesUsingDir() ([]int, error) {
 	}
 	prefix := r.dir + string(os.PathSeparator)
 
-	var pids []int
-	for _, line := range strings.Split(string(out), "\n") {
+	lines := strings.Split(string(out), "\n")
+	pids := make([]int, 0, len(lines))
+	for _, line := range lines {
 		line = strings.TrimLeft(line, " \t")
 		if line == "" {
 			continue

--- a/app_mon/internal/infra/relocator.go
+++ b/app_mon/internal/infra/relocator.go
@@ -1,0 +1,215 @@
+package infra
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Relocator copies (or hard-links) the appmon binary to a randomized,
+// system-looking basename under an obfuscated cache directory. Daemons exec
+// from the relocated path so `killall appmon` does not match the running
+// process (killall matches on the kernel's p_comm, which is set from the
+// exec'd file basename — not from argv[0]).
+//
+// Neither the directory nor the basename contains the literal "appmon", so
+// `pkill -f appmon` also fails to match.
+//
+//	Dir:      ~/.cache/.com.apple.xpc.<host-hash>/
+//	Basename: e.g. com.apple.cfprefsd.xpc.a8f3b2c1
+type Relocator struct {
+	dir string
+}
+
+// NewRelocator builds a Relocator rooted under the given home directory.
+// Callers should pass the real user's home (via GetRealUserHome when running
+// under sudo).
+func NewRelocator(home string) *Relocator {
+	return &Relocator{dir: relocatorDir(home)}
+}
+
+// Dir returns the cache directory where relocated binaries live.
+func (r *Relocator) Dir() string { return r.dir }
+
+// Relocate copies srcPath to <dir>/<random-name>. Hard link is attempted
+// first (same inode, near-zero cost); on failure (cross-fs or unsupported)
+// it falls back to an atomic copy. Returns the new path.
+func (r *Relocator) Relocate(srcPath string) (string, error) {
+	if err := os.MkdirAll(r.dir, 0700); err != nil {
+		return "", fmt.Errorf("create relocator dir: %w", err)
+	}
+	dst := filepath.Join(r.dir, randomRelocatedName())
+
+	if err := os.Link(srcPath, dst); err == nil {
+		_ = os.Chmod(dst, 0755)
+		return dst, nil
+	}
+
+	if err := relocateCopy(srcPath, dst); err != nil {
+		return "", fmt.Errorf("relocate %s -> %s: %w", srcPath, dst, err)
+	}
+	return dst, nil
+}
+
+// CleanStale removes files in the relocator dir that are not in `keep` and
+// whose mtime is older than minAge. The minAge guard avoids racing a child
+// process that has been linked but not yet exec'd. Unlinking a running
+// binary on macOS is safe — the kernel preserves the inode until the
+// process exits — so aggressive sweeps do not crash live daemons.
+func (r *Relocator) CleanStale(keep []string, minAge time.Duration) error {
+	entries, err := os.ReadDir(r.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	keepSet := make(map[string]struct{}, len(keep))
+	for _, k := range keep {
+		if k != "" {
+			keepSet[k] = struct{}{}
+		}
+	}
+	cutoff := time.Now().Add(-minAge)
+	for _, e := range entries {
+		path := filepath.Join(r.dir, e.Name())
+		if _, kept := keepSet[path]; kept {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(path)
+	}
+	return nil
+}
+
+// FindProcessesUsingDir returns PIDs of running processes whose executable
+// path lives under the relocator directory. The watcher uses this to find
+// orphan daemons — anything in our cache dir whose PID isn't recorded in
+// the encrypted registry is by definition not a daemon we own. This makes
+// the registry the single source of truth for live daemon membership;
+// rolling back, racing spawns, or stale state self-heal on the next sweep.
+//
+// Implementation: shells out to `ps -axww -o pid=,command=`. argv[0] is the
+// full path passed to execve, which on macOS is the path used to start the
+// process — so any of our re-exec'd daemons will report their relocated
+// path here. Errors are returned to the caller; nil pids on success when
+// nothing matches.
+func (r *Relocator) FindProcessesUsingDir() ([]int, error) {
+	out, err := exec.Command("ps", "-axww", "-o", "pid=,command=").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ps: %w", err)
+	}
+	prefix := r.dir + string(os.PathSeparator)
+
+	var pids []int
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimLeft(line, " \t")
+		if line == "" {
+			continue
+		}
+		// "<pid> <command...>" — split on first whitespace.
+		spaceIdx := strings.IndexAny(line, " \t")
+		if spaceIdx < 0 {
+			continue
+		}
+		pidStr := line[:spaceIdx]
+		cmd := strings.TrimLeft(line[spaceIdx:], " \t")
+		if !strings.HasPrefix(cmd, prefix) {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+// relocatedNamePrefixes is the pool of system-looking basenames. Kept
+// narrow so generated names blend with real macOS XPC services.
+var relocatedNamePrefixes = []string{
+	"com.apple.cfprefsd.xpc",
+	"com.apple.metadata.helper",
+	"com.apple.security.agent",
+	"com.apple.xpc.launchd.helper",
+	"com.apple.coreservices.service",
+	"com.apple.diskarbitrationd.worker",
+	"com.apple.finder.helper",
+}
+
+// randomRelocatedName produces a basename like com.apple.cfprefsd.xpc.a8f3b2c1.
+func randomRelocatedName() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return relocatedNamePrefixes[0] + ".000000"
+	}
+	prefix := relocatedNamePrefixes[int(buf[0])%len(relocatedNamePrefixes)]
+	return fmt.Sprintf("%s.%s", prefix, hex.EncodeToString(buf))
+}
+
+// relocatorDir returns the obfuscated cache directory for the given home.
+// The directory name does not contain "appmon" so `pkill -f appmon` will
+// not match daemons exec'd from inside it.
+func relocatorDir(home string) string {
+	hostname, _ := os.Hostname()
+	hash := md5.Sum([]byte("appmon-relocator-" + hostname))
+	return filepath.Join(home, ".cache", ".com.apple.xpc."+hex.EncodeToString(hash[:])[:8])
+}
+
+// relocateCopy performs an atomic copy: write to a sibling temp file, sync,
+// chmod, then rename. The source is opened read-only so the running binary
+// can be relocated even while exec'd.
+func relocateCopy(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".relocate-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}

--- a/app_mon/internal/infra/relocator_test.go
+++ b/app_mon/internal/infra/relocator_test.go
@@ -1,0 +1,176 @@
+package infra
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFakeBinary writes some bytes to a temp path with 0755 perms.
+func writeFakeBinary(t *testing.T, dir, name string, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return p
+}
+
+func TestRelocator_Relocate_BasenameIsObfuscated(t *testing.T) {
+	home := t.TempDir()
+	src := writeFakeBinary(t, t.TempDir(), "appmon", "stub")
+
+	r := NewRelocator(home)
+	dst, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate: %v", err)
+	}
+
+	base := filepath.Base(dst)
+	if base == "appmon" {
+		t.Fatalf("relocated basename should not be 'appmon', got %q", base)
+	}
+	if strings.Contains(base, "appmon") {
+		t.Fatalf("relocated basename should not contain 'appmon', got %q", base)
+	}
+	if !strings.HasPrefix(base, "com.apple.") {
+		t.Fatalf("expected system-looking prefix, got %q", base)
+	}
+
+	// Path should not contain "appmon" anywhere — defeats `pkill -f appmon`.
+	if strings.Contains(dst, "appmon") {
+		t.Fatalf("relocated path should not contain 'appmon', got %q", dst)
+	}
+}
+
+func TestRelocator_Relocate_ContentMatches(t *testing.T) {
+	home := t.TempDir()
+	src := writeFakeBinary(t, t.TempDir(), "appmon", "payload-xyz")
+
+	r := NewRelocator(home)
+	dst, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read relocated: %v", err)
+	}
+	if string(got) != "payload-xyz" {
+		t.Fatalf("content mismatch: got %q", string(got))
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat relocated: %v", err)
+	}
+	if info.Mode().Perm()&0100 == 0 {
+		t.Fatalf("relocated file should be executable, mode=%v", info.Mode())
+	}
+}
+
+func TestRelocator_Relocate_FreshBasenamePerCall(t *testing.T) {
+	home := t.TempDir()
+	src := writeFakeBinary(t, t.TempDir(), "appmon", "data")
+	r := NewRelocator(home)
+
+	seen := map[string]struct{}{}
+	for i := 0; i < 6; i++ {
+		dst, err := r.Relocate(src)
+		if err != nil {
+			t.Fatalf("Relocate %d: %v", i, err)
+		}
+		if _, dup := seen[dst]; dup {
+			t.Fatalf("got duplicate relocated path on iteration %d: %s", i, dst)
+		}
+		seen[dst] = struct{}{}
+	}
+}
+
+func TestRelocator_CleanStale_RespectsKeepAndMinAge(t *testing.T) {
+	home := t.TempDir()
+	r := NewRelocator(home)
+
+	// Create three relocated files, manually backdate two of them.
+	srcDir := t.TempDir()
+	src := writeFakeBinary(t, srcDir, "appmon", "data")
+
+	a, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate a: %v", err)
+	}
+	b, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate b: %v", err)
+	}
+	c, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate c: %v", err)
+	}
+
+	old := time.Now().Add(-10 * time.Minute)
+	for _, p := range []string{a, b, c} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatalf("Chtimes %s: %v", p, err)
+		}
+	}
+
+	if err := r.CleanStale([]string{a}, 5*time.Minute); err != nil {
+		t.Fatalf("CleanStale: %v", err)
+	}
+
+	if _, err := os.Stat(a); err != nil {
+		t.Fatalf("kept file should still exist: %v", err)
+	}
+	if _, err := os.Stat(b); !os.IsNotExist(err) {
+		t.Fatalf("expected b to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(c); !os.IsNotExist(err) {
+		t.Fatalf("expected c to be removed, stat err = %v", err)
+	}
+}
+
+func TestRelocator_CleanStale_SkipsFreshEntries(t *testing.T) {
+	home := t.TempDir()
+	r := NewRelocator(home)
+	src := writeFakeBinary(t, t.TempDir(), "appmon", "data")
+
+	fresh, err := r.Relocate(src)
+	if err != nil {
+		t.Fatalf("Relocate: %v", err)
+	}
+
+	// minAge=1h, file just created → must not be deleted.
+	if err := r.CleanStale(nil, time.Hour); err != nil {
+		t.Fatalf("CleanStale: %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh file was unexpectedly removed: %v", err)
+	}
+}
+
+func TestRelocator_CleanStale_MissingDirIsNotError(t *testing.T) {
+	r := NewRelocator(t.TempDir())
+	if err := r.CleanStale(nil, time.Minute); err != nil {
+		t.Fatalf("CleanStale on missing dir: %v", err)
+	}
+}
+
+func TestRelocator_FindProcessesUsingDir_SeesOurOwnExecution(t *testing.T) {
+	// `go test` itself runs from a binary outside our relocator dir, so a
+	// dir we just created should report no PIDs.
+	r := NewRelocator(t.TempDir())
+	if err := os.MkdirAll(r.dir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pids, err := r.FindProcessesUsingDir()
+	if err != nil {
+		t.Fatalf("FindProcessesUsingDir: %v", err)
+	}
+	if len(pids) != 0 {
+		t.Fatalf("expected no PIDs in empty relocator dir, got %v", pids)
+	}
+}

--- a/app_mon/internal/infra/relocator_test.go
+++ b/app_mon/internal/infra/relocator_test.go
@@ -159,6 +159,46 @@ func TestRelocator_CleanStale_MissingDirIsNotError(t *testing.T) {
 	}
 }
 
+func TestRelocateCopy_AtomicallyWritesExecutable(t *testing.T) {
+	// Hard link is preferred by Relocate; this exercises the copy fallback
+	// directly so cross-filesystem and link-failure paths stay covered.
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	src := writeFakeBinary(t, srcDir, "appmon", "binary-content")
+	dst := filepath.Join(dstDir, "com.apple.copy.target")
+
+	if err := relocateCopy(src, dst); err != nil {
+		t.Fatalf("relocateCopy: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != "binary-content" {
+		t.Fatalf("content mismatch: got %q", string(got))
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Mode().Perm()&0100 == 0 {
+		t.Fatalf("dst should be executable, got %v", info.Mode())
+	}
+}
+
+func TestRelocateCopy_FailsOnMissingSource(t *testing.T) {
+	dstDir := t.TempDir()
+	dst := filepath.Join(dstDir, "target")
+	if err := relocateCopy(filepath.Join(t.TempDir(), "nope"), dst); err == nil {
+		t.Fatal("expected error on missing source, got nil")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("dst should not exist after failed copy, stat err = %v", err)
+	}
+}
+
 func TestRelocator_FindProcessesUsingDir_SeesOurOwnExecution(t *testing.T) {
 	// `go test` itself runs from a binary outside our relocator dir, so a
 	// dir we just created should report no PIDs.

--- a/app_mon/internal/infra/updater.go
+++ b/app_mon/internal/infra/updater.go
@@ -15,8 +15,12 @@ import (
 )
 
 const (
-	// DefaultHealthCheckTimeout is how long to wait for daemons after update
-	DefaultHealthCheckTimeout = 10 * time.Second
+	// DefaultHealthCheckTimeout is how long to wait for daemons after update.
+	// Generous to absorb SQLCipher key derivation and the daemon
+	// self-relocate re-exec on slow first runs; if it's too tight the
+	// updater triggers a rollback that itself spawns daemons, leaving
+	// orphans behind.
+	DefaultHealthCheckTimeout = 30 * time.Second
 	// DaemonCheckInterval is how often to check daemon status
 	DaemonCheckInterval = 500 * time.Millisecond
 )
@@ -41,20 +45,57 @@ type Updater struct {
 	logger         *zap.Logger
 }
 
-// NewUpdater creates a new Updater instance
+// NewUpdater creates a new Updater instance using the encrypted SQLCipher
+// registry — the same registry the live daemons read and write. Using a
+// different registry here (the old NewFileRegistry path) silently desyncs
+// the updater from the daemons: health checks would never see the just-
+// spawned daemons, every update would time out and roll back, and each
+// rollback would spawn another pair of orphan daemons.
+//
+// On failure to open the encrypted registry (e.g., missing data dir, key
+// permission errors), falls back to the legacy file registry so the
+// command at least returns a real error instead of crashing — but the
+// caller almost certainly has bigger problems to address first.
 func NewUpdater(currentVersion string, logger *zap.Logger) *Updater {
 	execMode := DetectExecMode()
 	pm := NewProcessManager()
 
+	var registry domain.DaemonRegistry = openUpdaterRegistry(execMode, pm, logger)
+
 	return &Updater{
 		downloader:     NewGitHubDownloader(),
 		backupManager:  NewBackupManager(),
-		registry:       NewFileRegistry(pm),
+		registry:       registry,
 		pm:             pm,
 		execMode:       execMode,
 		currentVersion: currentVersion,
 		logger:         logger,
 	}
+}
+
+// openUpdaterRegistry opens the encrypted registry for the given mode, or
+// falls back to the legacy file registry on any failure. The encrypted
+// registry is the source of truth — keep this aligned with the path used
+// in cmd/appmon (runStart's openEncryptedRegistry helper).
+func openUpdaterRegistry(execMode *ExecModeConfig, pm domain.ProcessManager, logger *zap.Logger) domain.DaemonRegistry {
+	keyProvider := NewFileKeyProvider(execMode.DataDir)
+	key, err := EnsureKey(keyProvider)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("updater: encrypted registry unavailable, using file registry",
+				zap.Error(err))
+		}
+		return NewFileRegistry(pm)
+	}
+	enc, err := NewEncryptedRegistry(execMode.DataDir, key, pm)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("updater: encrypted registry unavailable, using file registry",
+				zap.Error(err))
+		}
+		return NewFileRegistry(pm)
+	}
+	return enc
 }
 
 // NewUpdaterWithDeps creates an Updater with injected dependencies (for testing)
@@ -440,17 +481,34 @@ func (u *Updater) signalProcess(pid int, sig syscall.Signal) error {
 	return proc.Signal(sig)
 }
 
-// spawnDaemon starts a daemon process
+// spawnDaemon starts a daemon process. The source binary is relocated to a
+// randomized basename under the relocator cache before exec, so the spawned
+// process's p_comm does not contain "appmon" — `killall appmon` cannot
+// match it. This mirrors what daemon.StartDaemonWithMode does in the
+// non-updater spawn path; both paths must stay aligned, otherwise the
+// updater would leave behind processes the watcher will reap as orphans.
 func (u *Updater) spawnDaemon(binaryPath, role string) error {
 	obfuscator := NewObfuscator()
 	daemonName := obfuscator.GenerateName()
 
-	// Use os/exec to spawn detached process
-	cmd := &execCmd{
-		path: binaryPath,
-		args: []string{binaryPath, "daemon", "--role", role, "--name", daemonName},
+	execPath := binaryPath
+	relocator := NewRelocator(GetRealUserHome())
+	if relocated, err := relocator.Relocate(binaryPath); err == nil {
+		execPath = relocated
+	} else if u.logger != nil {
+		u.logger.Warn("spawnDaemon: relocation failed, using install path",
+			zap.Error(err))
 	}
 
+	args := []string{execPath, "daemon", "--role", role, "--name", daemonName}
+	if u.execMode != nil && u.execMode.Mode != "" {
+		args = append(args, "--mode", string(u.execMode.Mode))
+	}
+
+	cmd := &execCmd{
+		path: execPath,
+		args: args,
+	}
 	return cmd.start()
 }
 

--- a/app_mon/internal/infra/updater_test.go
+++ b/app_mon/internal/infra/updater_test.go
@@ -201,10 +201,14 @@ func TestCreateRollbackBackup(t *testing.T) {
 	assert.Equal(t, content, backupContent)
 }
 
-// TestUpdater_Constants verifies timeout constants are reasonable
+// TestUpdater_Constants verifies timeout constants are reasonable.
+// HealthCheckTimeout was widened from 10s → 30s after we observed
+// SQLCipher key derivation + the daemon self-relocate re-exec exceeding
+// 10s on first-run cold cache, which triggered a phantom rollback that
+// itself spawned daemons and left orphans behind.
 func TestUpdater_Constants(t *testing.T) {
-	assert.Equal(t, 10*time.Second, DefaultHealthCheckTimeout,
-		"health check timeout should be 10 seconds")
+	assert.Equal(t, 30*time.Second, DefaultHealthCheckTimeout,
+		"health check timeout should be 30 seconds")
 	assert.Equal(t, 500*time.Millisecond, DaemonCheckInterval,
 		"daemon check interval should be 500ms")
 }


### PR DESCRIPTION
## Summary

Three connected hardening changes to **app_mon**, all motivated by real failure modes observed on a live install:

- **`killall appmon` / `pkill -f appmon` no longer work.** Each daemon spawn copies (or hard-links) the binary into an obfuscated cache dir under a randomized system-looking basename and execs from there. The kernel's `p_comm` for the live daemon is e.g. `com.apple.cfprefsd.xpc.<hex>`, not `appmon`. Path contains no "appmon" substring so `pkill -f` also misses. Each spawn rotates the name → repeat-`killall <name>` attacks fail too.
- **Login Items no longer shows "appmon".** The LaunchAgent / LaunchDaemon plist's `ProgramArguments[0]` is now a stable randomized "launch stub" (hard-link/copy of the main binary). macOS Login Items displays the stub's basename instead of the install path.
- **5-min cron-like respawn.** `StartInterval: 300` + `KeepAlive: {Crashed: true, SuccessfulExit: false}` means launchd re-fires `appmon start` every 5 minutes — a safety net in case both daemons die simultaneously and there's nothing left to peer-restart. `start` is idempotent and a fast no-op when daemons are healthy.

### Critical bug fix (root-causes phantom rollbacks)

The updater was reading the **wrong registry**: `NewUpdater` instantiated `NewFileRegistry` (legacy JSON at `/var/tmp/.cf_sys_registry_*`) while live daemons write to the **encrypted SQLCipher registry** (`registry.db`). Health checks therefore never saw the just-spawned daemons → every `appmon update` timed out at 10s → rollback fired → rollback's `StartDaemons` spawned a *second* pair of daemons whose PIDs overwrote the registry entries. Each round of update left orphans behind. End-to-end testing on the live install showed 6 daemons running where there should have been 2.

Updater now opens the encrypted registry via `openUpdaterRegistry` (falls back to file registry on hard failure). Combined with the timeout bump (10s → 30s) and the new `updater.spawnDaemon` going through `Relocator` like `daemon.StartDaemonWithMode` does, update now completes in ~3s clean with no rollback.

### Orphan cleanup (source-of-truth model)

- `Relocator.FindProcessesUsingDir()` lists PIDs running from the cache dir.
- `Watcher.reapOrphans()` SIGKILLs any PID running from the cache dir whose entry is **not** in the encrypted registry. Runs on startup and on the existing 60s binary-check tick.
- Net effect: the encrypted registry is the single source of truth for daemon membership. Failed updates, racing spawns, stale state from old sessions — all self-heal within 60s.

### A/B-style update semantics

Before this PR, "B" (live) and "A" (candidate) could coexist after a failed health check, with neither cleaned up. Now:

1. Updater reads registry → B = current \`WatcherPID/GuardianPID\`.
2. \`StopDaemons\` SIGTERMs B (2s grace) → SIGKILL.
3. \`StartDaemons\` spawns A via relocated paths → A registers itself.
4. \`VerifyDaemonsHealthy\` polls the encrypted registry for A's PIDs.
5. On success: A is registered, B is dead. Done.
6. On failure: rollback → kills A, restores prior binary, spawns B' → orphan reaper kills any stale A processes within 60s.

## Test plan

- [x] \`go test ./... -count=1\` — green
- [x] \`make build\` — green
- [x] Live install: \`sudo /usr/local/bin/appmon update --local-binary ./build/appmon\` completes in ~3s, no rollback
- [x] \`killall appmon\` (user + root) → no matching processes
- [x] \`pkill -f appmon\` → exit 1
- [x] Daemons survive both kill commands; \`appmon status\` still RUNNING
- [x] Plist contains \`StartInterval=300\` and dict-form \`KeepAlive\`
- [x] Plist \`ProgramArguments[0]\` points at the launch stub under the relocator cache dir
- [x] Orphan reaper observed cleaning pre-existing stale daemons within the 60s tick
- [ ] (manual, post-merge) Reboot test: \`RunAtLoad\` + \`StartInterval\` brings daemons back up
- [ ] (manual, post-merge) Re-verify Login Items shows the obfuscated stub name, not \`appmon\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)