### PR TITLE
test(app_mon): cover policy + filesystem (high-signal, not chasing %)

### DIFF
--- a/app_mon/internal/infra/filesystem_test.go
+++ b/app_mon/internal/infra/filesystem_test.go
@@ -1,0 +1,154 @@
+package infra
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FileSystemManager is the actual file-touching layer used by the enforcer
+// on every tick. Bugs here = either "deletes nothing" (protection fails
+// silently) or "deletes the wrong thing" (data loss). These tests pin the
+// behavior the enforcer relies on.
+
+func TestExpandHome(t *testing.T) {
+	const home = "/Users/test"
+	fm := NewFileSystemManagerWithHome(home).(*FileSystemManagerImpl)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"tilde-slash prefix", "~/Library/foo", "/Users/test/Library/foo"},
+		{"bare tilde", "~", "/Users/test"},
+		{"absolute path unchanged", "/Applications/Steam.app", "/Applications/Steam.app"},
+		{"relative path unchanged", "./foo", "./foo"},
+		{"tilde-in-middle not expanded", "/some/~/path", "/some/~/path"},
+		{"empty string", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fm.ExpandHome(tc.in); got != tc.want {
+				t.Errorf("ExpandHome(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExists_RealAndAbsent(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "file")
+	if err := os.WriteFile(present, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	absent := filepath.Join(dir, "no-such-file")
+
+	fm := NewFileSystemManagerWithHome(dir)
+	if !fm.Exists(present) {
+		t.Errorf("Exists(%q) = false, want true", present)
+	}
+	if fm.Exists(absent) {
+		t.Errorf("Exists(%q) = true, want false", absent)
+	}
+}
+
+func TestExists_ExpandsHomeBeforeChecking(t *testing.T) {
+	// Enforcer calls fm.Exists(path) with the unexpanded path (e.g., "~/Library/Application Support/Steam")
+	// before deleting. ExpandHome must apply transparently, otherwise Exists
+	// returns false and the path is silently skipped.
+	dir := t.TempDir()
+	libPath := filepath.Join(dir, "MarkerFile")
+	if err := os.WriteFile(libPath, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm := NewFileSystemManagerWithHome(dir)
+	if !fm.Exists("~/MarkerFile") {
+		t.Errorf("Exists(\"~/MarkerFile\") = false; ExpandHome wasn't applied")
+	}
+}
+
+func TestDelete_RemovesFileRecursively(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "victim")
+	if err := os.MkdirAll(filepath.Join(target, "nested", "deep"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "nested", "f.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fm := NewFileSystemManagerWithHome(dir)
+	if err := fm.Delete(target); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("target still exists after Delete: stat err = %v", err)
+	}
+}
+
+func TestDelete_TildePath(t *testing.T) {
+	// Enforcer passes paths like "~/Library/Application Support/Steam".
+	// Delete must expand the tilde — otherwise it deletes nothing
+	// (or worse, a literal directory called "~" if one happens to exist).
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "Library", "App"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fm := NewFileSystemManagerWithHome(dir)
+	if err := fm.Delete("~/Library/App"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Library", "App")); !os.IsNotExist(err) {
+		t.Errorf("~ expansion failed: real path still exists")
+	}
+}
+
+func TestDelete_NonexistentPathIsNoError(t *testing.T) {
+	// Enforcer guards with Exists() but Delete itself must also be idempotent —
+	// os.RemoveAll returns nil on missing paths, and we rely on that.
+	fm := NewFileSystemManagerWithHome(t.TempDir())
+	if err := fm.Delete(filepath.Join(t.TempDir(), "nope")); err != nil {
+		t.Errorf("Delete on missing path returned err: %v", err)
+	}
+}
+
+func TestDelete_GlobMatchesMultiple(t *testing.T) {
+	// Dota 2 policy uses globs like ~/Downloads/*[Dd]ota*.dmg. Delete must
+	// expand the glob and remove every match. A regression where we forget
+	// the glob branch would leave .dmg installers on disk.
+	dir := t.TempDir()
+	files := []string{"DotaInstaller.dmg", "dota-other.dmg", "unrelated.txt"}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fm := NewFileSystemManagerWithHome(dir)
+	if err := fm.Delete(filepath.Join(dir, "*[Dd]ota*.dmg")); err != nil {
+		t.Fatalf("Delete glob: %v", err)
+	}
+
+	// Both .dmg files matched and were removed
+	for _, name := range []string{"DotaInstaller.dmg", "dota-other.dmg"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s still exists after glob delete", name)
+		}
+	}
+	// Unrelated file untouched
+	if _, err := os.Stat(filepath.Join(dir, "unrelated.txt")); err != nil {
+		t.Errorf("unrelated file was deleted: %v", err)
+	}
+}
+
+func TestDelete_GlobNoMatchesIsNoError(t *testing.T) {
+	dir := t.TempDir()
+	fm := NewFileSystemManagerWithHome(dir)
+	// Glob that matches nothing — filepath.Glob returns empty slice + nil err.
+	if err := fm.Delete(filepath.Join(dir, "*.nonexistent")); err != nil {
+		t.Errorf("Delete with no glob matches: %v", err)
+	}
+}

--- a/app_mon/internal/policy/dota2_test.go
+++ b/app_mon/internal/policy/dota2_test.go
@@ -1,0 +1,128 @@
+package policy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
+)
+
+// These tests pin Dota 2's blocking *contract* — the patterns it kills
+// and the paths it deletes. Easy to silently break by renaming a Valve
+// binary; the patterns are the protection.
+
+func TestDota2Policy_IdentityFields(t *testing.T) {
+	p := NewDota2Policy()
+	if got := p.ID(); got != "dota2" {
+		t.Errorf("ID() = %q, want %q", got, "dota2")
+	}
+	if got := p.Name(); got != "Dota 2" {
+		t.Errorf("Name() = %q, want %q", got, "Dota 2")
+	}
+}
+
+func TestDota2Policy_ProcessPatternsCoverKnownExecutables(t *testing.T) {
+	p := NewDota2Policy()
+	patterns := p.ProcessPatterns()
+	if len(patterns) == 0 {
+		t.Fatal("ProcessPatterns() returned empty — Dota 2 wouldn't be killable")
+	}
+
+	// All of these are macOS process names observed on real installs;
+	// removing any silently breaks the kill loop.
+	required := []string{
+		"dota2",        // launcher
+		"dota_osx64",   // 64-bit game binary
+		"Dota 2",       // UI / app bundle name
+	}
+	have := map[string]struct{}{}
+	for _, p := range patterns {
+		have[p] = struct{}{}
+	}
+	for _, want := range required {
+		if _, ok := have[want]; !ok {
+			t.Errorf("ProcessPatterns missing required entry %q; got %v", want, patterns)
+		}
+	}
+}
+
+func TestDota2Policy_PathsToDelete_AreUnderSteamLibrary(t *testing.T) {
+	// Dota 2 installs under Steam's library; if the policy ever produces
+	// a path NOT under the configured home, the enforcer would silently
+	// fail (file doesn't exist) and leave the install intact.
+	const home = "/Users/testuser"
+	p := NewDota2PolicyWithHome(home)
+	paths := p.PathsToDelete()
+	if len(paths) == 0 {
+		t.Fatal("PathsToDelete() returned empty")
+	}
+
+	steamRoot := home + "/Library/Application Support/Steam"
+	for _, path := range paths {
+		// "Downloads" globs for Dota installers are a legitimate exception.
+		if strings.HasPrefix(path, home+"/Downloads/") {
+			continue
+		}
+		if !strings.HasPrefix(path, steamRoot) {
+			t.Errorf("path %q is neither under Steam library nor Downloads — would silently no-op", path)
+		}
+	}
+}
+
+func TestDota2Policy_PathsToDelete_CoverGameInstallAndCache(t *testing.T) {
+	// Pin the specific files the policy must remove; otherwise a reinstall
+	// would pick up cached state and skip the download.
+	const home = "/Users/testuser"
+	p := NewDota2PolicyWithHome(home)
+	paths := p.PathsToDelete()
+
+	expectedSubstrings := []string{
+		"steamapps/common/dota 2 beta",       // main game install
+		"steamapps/appmanifest_570.acf",      // Steam catalog entry
+		"steamapps/workshop/content/570",     // mods / custom games
+		"steamapps/shadercache/570",          // GPU shader cache
+		"steamapps/downloading/570",          // partial downloads
+	}
+	for _, need := range expectedSubstrings {
+		found := false
+		for _, path := range paths {
+			if strings.Contains(path, need) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("no path contained substring %q — Dota 2 reinstall could replay this state", need)
+		}
+	}
+}
+
+func TestDota2Policy_ScanInterval_MatchesDefault(t *testing.T) {
+	p := NewDota2Policy()
+	if got := p.ScanInterval(); got != DefaultScanInterval {
+		t.Errorf("ScanInterval() = %v, want %v", got, DefaultScanInterval)
+	}
+}
+
+// PreEnforce and PostEnforce are currently no-op hooks. Tests pin them as
+// non-failing so a future implementation that returns an error doesn't
+// silently disable enforcement (Enforce treats hook errors as warnings).
+func TestDota2Policy_LifecycleHooks_AreNonFailing(t *testing.T) {
+	p := NewDota2Policy()
+	ctx := context.Background()
+	if err := p.PreEnforce(ctx); err != nil {
+		t.Errorf("PreEnforce returned error: %v", err)
+	}
+	if err := p.PostEnforce(ctx, &domain.EnforcementResult{}); err != nil {
+		t.Errorf("PostEnforce returned error: %v", err)
+	}
+}
+
+// Contract assertion at compile time: Dota2Policy must implement AppPolicy.
+// Already asserted in the package via `var _ AppPolicy = ...` but we
+// re-check at test time to catch refactor regressions.
+func TestDota2Policy_ImplementsAppPolicyInterface(t *testing.T) {
+	var _ AppPolicy = NewDota2Policy()
+	var _ AppPolicy = NewDota2PolicyWithHome("/x")
+}

--- a/app_mon/internal/policy/dota2_test.go
+++ b/app_mon/internal/policy/dota2_test.go
@@ -32,9 +32,9 @@ func TestDota2Policy_ProcessPatternsCoverKnownExecutables(t *testing.T) {
 	// All of these are macOS process names observed on real installs;
 	// removing any silently breaks the kill loop.
 	required := []string{
-		"dota2",        // launcher
-		"dota_osx64",   // 64-bit game binary
-		"Dota 2",       // UI / app bundle name
+		"dota2",      // launcher
+		"dota_osx64", // 64-bit game binary
+		"Dota 2",     // UI / app bundle name
 	}
 	have := map[string]struct{}{}
 	for _, p := range patterns {
@@ -78,11 +78,11 @@ func TestDota2Policy_PathsToDelete_CoverGameInstallAndCache(t *testing.T) {
 	paths := p.PathsToDelete()
 
 	expectedSubstrings := []string{
-		"steamapps/common/dota 2 beta",       // main game install
-		"steamapps/appmanifest_570.acf",      // Steam catalog entry
-		"steamapps/workshop/content/570",     // mods / custom games
-		"steamapps/shadercache/570",          // GPU shader cache
-		"steamapps/downloading/570",          // partial downloads
+		"steamapps/common/dota 2 beta",   // main game install
+		"steamapps/appmanifest_570.acf",  // Steam catalog entry
+		"steamapps/workshop/content/570", // mods / custom games
+		"steamapps/shadercache/570",      // GPU shader cache
+		"steamapps/downloading/570",      // partial downloads
 	}
 	for _, need := range expectedSubstrings {
 		found := false

--- a/app_mon/internal/policy/registry_test.go
+++ b/app_mon/internal/policy/registry_test.go
@@ -1,0 +1,188 @@
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/app_mon/internal/domain"
+)
+
+// fakePolicy is a minimal AppPolicy used to exercise Registry generics
+// without coupling these tests to Steam/Dota2 specifics.
+type fakePolicy struct {
+	id       string
+	name     string
+	patterns []string
+	paths    []string
+	interval time.Duration
+}
+
+func (f *fakePolicy) ID() string                                                 { return f.id }
+func (f *fakePolicy) Name() string                                               { return f.name }
+func (f *fakePolicy) ProcessPatterns() []string                                  { return f.patterns }
+func (f *fakePolicy) PathsToDelete() []string                                    { return f.paths }
+func (f *fakePolicy) ScanInterval() time.Duration                                { return f.interval }
+func (f *fakePolicy) PreEnforce(context.Context) error                           { return nil }
+func (f *fakePolicy) PostEnforce(context.Context, *domain.EnforcementResult) error { return nil }
+
+func TestNewRegistry_RegistersDefaultPolicies(t *testing.T) {
+	// The default Registry IS the protection contract — if it doesn't
+	// include Steam + Dota2, the daemon enforces nothing on production.
+	r := NewRegistry()
+
+	if _, ok := r.Get("steam"); !ok {
+		t.Error("NewRegistry must include steam policy by default")
+	}
+	if _, ok := r.Get("dota2"); !ok {
+		t.Error("NewRegistry must include dota2 policy by default")
+	}
+
+	ids := r.List()
+	if len(ids) < 2 {
+		t.Errorf("expected ≥2 default policies, got %d: %v", len(ids), ids)
+	}
+}
+
+func TestNewRegistryWithPolicies_OverridesDefaults(t *testing.T) {
+	a := &fakePolicy{id: "a", name: "A"}
+	b := &fakePolicy{id: "b", name: "B"}
+
+	r := NewRegistryWithPolicies(a, b)
+	if got := len(r.List()); got != 2 {
+		t.Fatalf("expected 2 policies, got %d", got)
+	}
+	if _, ok := r.Get("steam"); ok {
+		t.Error("custom Registry should not include default steam policy")
+	}
+	if p, ok := r.Get("a"); !ok || p.ID() != "a" {
+		t.Errorf("Get(\"a\") = %v, %v", p, ok)
+	}
+}
+
+func TestRegistry_RegisterOverwritesByID(t *testing.T) {
+	// Last-write-wins on collision. This matters for hot-swap during
+	// updates: a fresh policy replaces the previous version with the
+	// same ID, no leftover stale rules.
+	r := NewRegistryWithPolicies()
+	r.Register(&fakePolicy{id: "x", name: "first"})
+	r.Register(&fakePolicy{id: "x", name: "second"})
+
+	p, ok := r.Get("x")
+	if !ok {
+		t.Fatal("policy x missing after re-register")
+	}
+	if p.Name() != "second" {
+		t.Errorf("expected last write to win; Name = %q, want %q", p.Name(), "second")
+	}
+	if got := len(r.List()); got != 1 {
+		t.Errorf("expected 1 policy after re-register, got %d", got)
+	}
+}
+
+func TestRegistry_GetUnknownReturnsFalse(t *testing.T) {
+	r := NewRegistryWithPolicies()
+	if p, ok := r.Get("nonexistent"); ok || p != nil {
+		t.Errorf("Get(unknown) = %v, %v; want nil, false", p, ok)
+	}
+}
+
+func TestRegistry_GetAllReturnsEveryPolicy(t *testing.T) {
+	a := &fakePolicy{id: "a"}
+	b := &fakePolicy{id: "b"}
+	c := &fakePolicy{id: "c"}
+	r := NewRegistryWithPolicies(a, b, c)
+
+	all := r.GetAll()
+	if len(all) != 3 {
+		t.Fatalf("GetAll size = %d, want 3", len(all))
+	}
+	seen := map[string]struct{}{}
+	for _, p := range all {
+		seen[p.ID()] = struct{}{}
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if _, ok := seen[want]; !ok {
+			t.Errorf("GetAll missing %q", want)
+		}
+	}
+}
+
+func TestRegistryPolicyStore_RoundTripsViaToPolicy(t *testing.T) {
+	// PolicyStore is what the enforcer consumes. It MUST surface
+	// every registered policy as a domain.Policy with all fields
+	// converted by ToPolicy — otherwise process patterns or paths
+	// silently drop and protection breaks.
+	store := NewPolicyStore()
+
+	all := store.GetAll()
+	if len(all) < 2 {
+		t.Fatalf("expected ≥2 default domain.Policy entries, got %d", len(all))
+	}
+	for _, p := range all {
+		if p.ID == "" {
+			t.Errorf("ToPolicy produced empty ID for entry %+v", p)
+		}
+		if p.Name == "" {
+			t.Errorf("ToPolicy produced empty Name for entry %+v", p)
+		}
+		if len(p.ProcessNames) == 0 {
+			t.Errorf("policy %q has zero ProcessNames — would kill nothing", p.ID)
+		}
+		if len(p.Paths) == 0 {
+			t.Errorf("policy %q has zero Paths — would delete nothing", p.ID)
+		}
+		if p.ScanInterval == 0 {
+			t.Errorf("policy %q has zero ScanInterval — would never re-scan", p.ID)
+		}
+	}
+}
+
+func TestRegistryPolicyStore_GetByID(t *testing.T) {
+	store := NewPolicyStore()
+
+	p, err := store.GetByID("steam")
+	if err != nil {
+		t.Fatalf("GetByID(steam): %v", err)
+	}
+	if p == nil || p.ID != "steam" {
+		t.Errorf("GetByID(steam) = %+v", p)
+	}
+
+	if _, err := store.GetByID("not-real"); err == nil {
+		t.Error("GetByID(unknown) should error, got nil")
+	}
+}
+
+func TestRegistryPolicyStore_List(t *testing.T) {
+	store := NewPolicyStore()
+	ids := store.List()
+	if len(ids) < 2 {
+		t.Errorf("List returned %d ids, want ≥2", len(ids))
+	}
+}
+
+func TestToPolicy_CopiesAllFields(t *testing.T) {
+	// Direct test for the conversion that PolicyStore.GetAll relies on.
+	src := &fakePolicy{
+		id:       "x",
+		name:     "X App",
+		patterns: []string{"x.bin", "X Helper"},
+		paths:    []string{"/Applications/X.app", "/Users/u/.config/x"},
+		interval: 7 * time.Minute,
+	}
+	got := ToPolicy(src)
+
+	if got.ID != "x" || got.Name != "X App" {
+		t.Errorf("ToPolicy ID/Name mismatch: %+v", got)
+	}
+	if got.ScanInterval != 7*time.Minute {
+		t.Errorf("ToPolicy ScanInterval = %v, want %v", got.ScanInterval, 7*time.Minute)
+	}
+	if len(got.ProcessNames) != 2 || got.ProcessNames[0] != "x.bin" {
+		t.Errorf("ToPolicy ProcessNames lost data: %v", got.ProcessNames)
+	}
+	if len(got.Paths) != 2 || got.Paths[1] != "/Users/u/.config/x" {
+		t.Errorf("ToPolicy Paths lost data: %v", got.Paths)
+	}
+}

--- a/app_mon/internal/policy/registry_test.go
+++ b/app_mon/internal/policy/registry_test.go
@@ -18,12 +18,12 @@ type fakePolicy struct {
 	interval time.Duration
 }
 
-func (f *fakePolicy) ID() string                                                 { return f.id }
-func (f *fakePolicy) Name() string                                               { return f.name }
-func (f *fakePolicy) ProcessPatterns() []string                                  { return f.patterns }
-func (f *fakePolicy) PathsToDelete() []string                                    { return f.paths }
-func (f *fakePolicy) ScanInterval() time.Duration                                { return f.interval }
-func (f *fakePolicy) PreEnforce(context.Context) error                           { return nil }
+func (f *fakePolicy) ID() string                                                   { return f.id }
+func (f *fakePolicy) Name() string                                                 { return f.name }
+func (f *fakePolicy) ProcessPatterns() []string                                    { return f.patterns }
+func (f *fakePolicy) PathsToDelete() []string                                      { return f.paths }
+func (f *fakePolicy) ScanInterval() time.Duration                                  { return f.interval }
+func (f *fakePolicy) PreEnforce(context.Context) error                             { return nil }
 func (f *fakePolicy) PostEnforce(context.Context, *domain.EnforcementResult) error { return nil }
 
 func TestNewRegistry_RegistersDefaultPolicies(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds focused tests for protection-critical code. Goal is *catch real regressions*, not chase a coverage number. Skips CLI deep tests and `daemon.Run()` — those are expensive to mock and their bugs manifest as "doesn't start" which the build already catches.

## Tests added

**`policy/dota2_test.go`** (new) — mirrors `steam_test.go` pattern. Pins the actual blocking contract:
- `ProcessPatterns` must include `dota2`, `dota_osx64`, `Dota 2` (renaming any silently breaks the kill loop on a real machine).
- `PathsToDelete` must include `steamapps/{common/dota 2 beta, appmanifest_570.acf, workshop/content/570, shadercache/570, downloading/570}` — missing any means a reinstall replays cached state.
- All paths live under the Steam library or `~/Downloads/` (installer globs); a wrong-prefix path silently no-ops in the enforcer.
- Lifecycle hooks (`PreEnforce`/`PostEnforce`) are non-failing — future refactor returning an error would silently disable enforcement (it's treated as a warning).

**`policy/registry_test.go`** (new) — `Registry` + `RegistryPolicyStore` + `ToPolicy`:
- Default `Registry` MUST include steam + dota2 (the protection contract).
- `Register` is last-write-wins (matters for hot-swap during updates).
- `PolicyStore` round-trips every field via `ToPolicy`; tests guard against silent field drops (zero ProcessNames or Paths in surfaced `domain.Policy` = protection no-op).
- Unknown ID returns error, `List` returns all IDs.

**`infra/filesystem_test.go`** (new) — `FileSystemManager` (the file ops the enforcer runs every tick):
- `ExpandHome` table-driven (`~/`, bare `~`, absolute, relative, tilde-in-middle, empty).
- `Exists` / `Delete` with tilde expansion (enforcer passes unexpanded paths).
- Glob deletion (Dota 2 uses `~/Downloads/*[Dd]ota*.dmg`) — regression would silently leave installers on disk. Also verifies an unrelated file in the glob dir is NOT touched.
- Delete on nonexistent path is no-error (idempotent — relied on by the no-Exists fast path).

## Coverage (honest picture)

Per-package, after this PR:

| Package | Coverage | Note |
|---|---|---|
| `internal/policy` | **96.2%** (was ~79%) | Protection contract pinned end-to-end |
| `internal/usecase` | 95.6% | Already strong |
| `internal/infra` | 54.0% | Hardware-dependent code (launchd, sqlcipher) keeps it below 80% |
| `internal/daemon` | 1.0% | `Run()` loops; deferred (see Code-review notes) |
| `cmd/appmon` | 0% | CLI; deferred (see Code-review notes) |

**Total via `-coverpkg=./...`: 35.5% (was 32.5%)** — dragged down by the giant CLI + daemon Run code that we deliberately skip. The per-package number on the protection core is the honest signal.

## Code-review notes (deferred to future PRs)

1. **`cmd/appmon/main.go` is 1300+ lines.** `runStart` alone is ~200 lines doing mode detect + cleanup + version compare + install + spawn. Splitting subcommands into focused files would also make CLI unit testing feasible. Today, testing it requires invoking `cobra.Execute()` with mocked filesystem + sudo state — sake-of-test territory until the file is split.
2. **`daemon.Watcher.Run` and `Guardian.Run` are 1% covered.** Their helper methods (`runEnforcement`, `ensurePlistInstalled`, `reapOrphans`, etc.) are thin delegators with mock-heavy tests adding low signal. A future PR could add one cancellable-context smoke test that exercises `Run()` for ~10ms to assert it registers + exits cleanly on `ctx.Done()`. Would need fixture mocks for `LaunchAgentManager`, `BackupManager`, `FreedomProtector` — about 150 LOC for one test.
3. **Release workflow had been broken since v0.5.1** (CGO_ENABLED=0 default, the SQLCipher import didn't compile). Worth adding a `goreleaser release --snapshot` job to CI on master pushes so the next config drift is caught before tagging.
4. **`os.UserHomeDir()` under sudo returns `/var/root`** — codepaths work around inconsistently via `GetRealUserHome()`. Worth a sweep to ensure every path that opens user-mode artifacts uses the consistent helper.

## Test plan

- [x] `go test ./internal/policy/ -count=1` — 21 tests pass
- [x] `go test ./internal/infra/ -run 'FileSystem|Exists|Delete|ExpandHome'` — 11 subtests pass
- [x] `go test ./... -count=1` — full sweep green
- [x] `make build` — green
- [ ] (CI) Lint, Format, Build (mac+ubuntu), Test (mac+ubuntu), Security Scan, codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)