### PR TITLE
feat(browser_guard): user-mode browser tab guard companion (bash, no sudo)

### DIFF
--- a/app_mon/README.md
+++ b/app_mon/README.md
@@ -31,6 +31,23 @@ make build
 make install
 ```
 
+### Companion tool: `browser_guard` (user-mode, no sudo)
+
+`browser_guard/` ships a standalone bash script that watches open browser
+tabs (Chrome / Brave / Safari) and SIGKILLs any browser holding a tab
+whose host is on an embedded blocklist. It complements the main daemon's
+DNS layer by catching tabs that loaded blocked URLs via DoH or AAAA
+records — i.e. the bypasses `/etc/hosts` doesn't cover.
+
+```bash
+./browser_guard/browser_guard.sh on
+```
+
+Installs four self-healing layers under obfuscated paths in user space.
+No sudo required — works on managed corp laptops where the main daemon
+can't run. See [`browser_guard/README.md`](browser_guard/README.md) for
+the full design, blocklist management, and verification commands.
+
 ## Usage
 
 ```bash

--- a/app_mon/browser_guard/README.md
+++ b/app_mon/browser_guard/README.md
@@ -1,0 +1,155 @@
+# browser_guard
+
+User-mode browser tab guard for macOS. Watches every open tab in Chrome / Brave / Safari and SIGKILLs any browser holding a tab whose host matches an embedded blocklist. Sibling tool to the Go `appmon` daemon, but standalone — no sudo, no Go runtime, just bash + macOS AppleScript + launchd + cron.
+
+## Why this exists
+
+`appmon`'s existing DNS layer (`/etc/hosts` blackhole) leaks in three places:
+
+- **DoH** — Chrome / Brave / Firefox each ship with DNS-over-HTTPS as a 1-click setting that bypasses `/etc/hosts` entirely.
+- **IPv6 leak** — `/etc/hosts` blocks only `A` records (IPv4). Dual-stack domains (youtube.com etc.) still resolve via real DNS for their `AAAA` record.
+- **Hardcoded IPs / private resolvers** — some apps bypass the system resolver entirely.
+
+For browsers, the URL bar is also the user's path-of-least-resistance bypass: toggle DoH, open the blocked URL anyway. `browser_guard` reads the URL bar via AppleScript — downstream of any DNS bypass. If a tab is open with a blocked host, the browser gets killed regardless of how it resolved DNS.
+
+`browser_guard` is **user-mode only**, so it works on managed/corp laptops without admin or root. Browser-extension approaches were ruled out for the same reason (can't install extensions on a managed device).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `browser_guard.sh` | Single self-installing script. `on` deploys all four self-protection layers; default action (called by launchd + cron) does heal + scan. |
+| `list_open_tabs.sh` | Read-only debug script. Lists every open tab in Chrome / Brave / Safari. No kills, no install. Use to verify AppleScript is granted Automation permission. |
+
+## Install
+
+```sh
+./browser_guard.sh on
+```
+
+That's the entire surface area. There is **no `off` / `uninstall` command** by design — friction is the point.
+
+On first run after install, macOS prompts once per running browser for Automation permission ("com.apple.cfprefsd.helper.<hex> wants to control Google Chrome"). Approve each. Subsequent scans are silent.
+
+The install command:
+
+1. Hashes `"browser-guard-<hostname>"` to derive obfuscated paths (deterministic per machine, opaque per anyone else).
+2. Force-copies the script to **two** hidden install locations:
+   - `~/.cache/.com.apple.metadata.<hash>/com.apple.metadata.helper.<hash>` (primary)
+   - `~/Library/Application Support/.com.apple.coreservices.<hash>/com.apple.coreservices.daemon.<hash>` (backup)
+3. Force-writes a LaunchAgent plist at `~/Library/LaunchAgents/com.apple.cfprefsd.helper.<hash>.plist` (label looks like a macOS XPC helper).
+4. Adds a crontab entry `*/5 * * * *` with an idempotent marker comment.
+5. `launchctl unload`+`load` so the agent picks up any changes (e.g. updated `SCAN_INTERVAL`).
+
+After install, both installed copies + the plist + the cron entry are independent. Delete any single one → the next tick of any other layer restores it. The user must locate AND delete all four within one cron cycle (5 minutes) to fully remove the system.
+
+`on` is **idempotent**: re-running it after editing the source script propagates the changes to both installed copies and reloads the LaunchAgent. This is the workflow for updating the blocklist.
+
+## The 4 layers (self-healing)
+
+| Layer | What it does | Fires |
+|---|---|---|
+| **Primary script** | Real executable invoked by launchd + cron | On every tick |
+| **Backup script** | Independent copy at a different hidden path | Heals primary if it's missing |
+| **LaunchAgent plist** | Fires the script every 10s | macOS launchd |
+| **Cron entry** | Fires the script every 5 min (heals LaunchAgent if unloaded) | `/usr/sbin/cron` |
+
+Every invocation runs `heal_all` BEFORE scanning. Heal is idempotent — stat's all four pieces, restores any missing one from any surviving copy. If only ONE script copy survives, it can re-derive the other three on its next 10-second tick.
+
+```
+        ┌─────────────────┐
+        │ primary script  │◄─────────┐
+        └────────┬────────┘          │
+                 │ invoked by        │ heal
+                 ▼                   │
+        ┌─────────────────┐    ┌─────┴───────┐
+        │  LaunchAgent    │    │ backup copy │
+        │    every 10s    │    └─────┬───────┘
+        └─────────────────┘          │ heal-from-survivor
+                                     │
+        ┌─────────────────┐          │
+        │   cron entry    │──────────┘
+        │   every 5 min   │
+        └─────────────────┘
+```
+
+## What it kills
+
+Per scan tick the script reads URLs via AppleScript from every running browser:
+
+- **Google Chrome** — includes Incognito windows by default (Chrome exposes them to AppleScript).
+- **Brave Browser** — same dialect as Chrome (Chromium fork).
+- **Safari** — normal windows only. Private Browsing windows are NOT exposed to AppleScript (deliberate macOS restriction). The DNS layer in the main `appmon` daemon covers this gap because Safari Private mode still uses the system resolver.
+
+For each URL it extracts the host, compares to the embedded `BLOCKLIST` array (case-insensitive, exact-OR-subdomain match), and if any tab matches → `osascript`-quits the browser, then `pkill -i -f <browser>` to catch renderer / GPU / network subprocesses.
+
+## Updating the blocklist
+
+```sh
+# 1. Edit the BLOCKLIST=(...) array near the top of browser_guard.sh
+vim browser_guard.sh
+
+# 2. Re-run install — force-copies the new version to both installed paths
+./browser_guard.sh on
+
+# 3. Within ~10 seconds, the next LaunchAgent tick uses the new blocklist
+tail -f ~/.cache/.com.apple.metadata.*/.log
+```
+
+The blocklist is a flat list of apex domains. Each apex matches itself AND any subdomain — `youtube.com` covers `youtube.com`, `www.youtube.com`, `m.youtube.com`, `music.youtube.com`, etc. Don't need to enumerate subdomains.
+
+The list is **compiled into the script** by design (the perm-ban semantic). To remove a domain you must edit the source AND propagate via `on`, same friction as adding one. There is no separate config file.
+
+## Verify it's running
+
+```sh
+# LaunchAgent loaded?
+launchctl list | grep 'com.apple.cfprefsd.helper'
+
+# Cron entry present?
+crontab -l | grep '# bg-'
+
+# What's the log doing?
+tail -f ~/.cache/.com.apple.metadata.*/.log
+```
+
+The log shows:
+- `BLOCKED browser=<browser> host=<host>` whenever a tab on the blocklist is detected.
+- `killing browser=<browser>` immediately after.
+- `restored <thing>` whenever heal had to fix a missing piece.
+
+A healthy install has the log mostly empty in steady state — heal is idempotent, so when nothing is missing and no blocked tabs are open, no log lines are written.
+
+## How it complements `appmon` proper
+
+`appmon` (the Go daemon, this directory's parent) provides:
+
+- **Process layer** — kill blocked apps (Steam, Dota 2).
+- **Filesystem layer** — delete blocked app bundles + caches.
+- **DNS layer** — `/etc/hosts` blackhole for known hosts.
+- **Plist + Binary self-protection** — system-mode launchd with relocator-based killall resistance.
+
+`browser_guard` adds:
+
+- **Browser tab layer** — reads URLs from open tabs and kills the browser if any is on the blocklist. Catches the gap when an app (browser) ignores `/etc/hosts` via DoH or AAAA records, or when a tab is opened directly via the URL bar.
+
+The two systems share **no state** and **no code**. They can be installed independently. The Go `appmon` is system-mode (sudo). `browser_guard` is user-mode (no sudo). Running both gives the deepest defense.
+
+## Known limitations
+
+- **Safari Private Browsing**: AppleScript does not enumerate Safari Private windows. Mitigation: rely on the DNS layer in `appmon` proper (Safari Private uses the system resolver). Documented in the requirements doc.
+- **Firefox**: no AppleScript surface for tabs without a custom WebExtension. Out of scope (managed laptops can't install extensions).
+- **Automation permission denial**: if the user denies the macOS Automation prompt for a browser, the scan for that browser silently returns nothing. The script can't force the prompt to reappear; user must re-enable in System Settings → Privacy & Security → Automation.
+- **Cron + Full Disk Access on Catalina+**: `/usr/sbin/cron` may need FDA to actually run. If it doesn't, the LaunchAgent alone handles blocking + heal. The cron layer is "best-effort second mechanism".
+- **No version sync with the Go binary**: `browser_guard.sh` versioning is independent. The Go `CHANGELOG.md` does not track this script.
+
+## Removing the system
+
+Not documented. Required by design.
+
+See the source for which paths and labels are involved; everything is hostname-hash-derived, so you can re-derive them by reading the script. Removing all four layers inside one 5-minute cron window is doable but takes deliberate effort — that's the cool-off the system is engineered to impose.
+
+## Related
+
+- `../README.md` — main `appmon` daemon (Go).
+- `../../requirements/monitor_browser_tab_url/monitor_web_browser_tab_url.md` — original design doc + threat model + Phase 2 ideas (MITM proxy, NEFilterControlProvider, Firefox WebExtension — none implemented; all deferred or rejected for the managed-laptop use case).

--- a/app_mon/browser_guard/browser_guard.sh
+++ b/app_mon/browser_guard/browser_guard.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# browser_guard.sh — single-file, user-mode browser tab guard for macOS.
+#
+# Layered self-protection (all user-mode, no sudo needed):
+#
+#   Layer 1: primary script copy at hidden path A
+#   Layer 2: backup script copy at hidden path B
+#   Layer 3: LaunchAgent plist with obfuscated com.apple.* label
+#            (fires every 10s; runs the scan + heal)
+#   Layer 4: cron entry (fires every 5 min; runs heal + scan as fallback
+#            in case the LaunchAgent gets unloaded)
+#
+# Every invocation (LaunchAgent OR cron) heals first, then scans. Heal is
+# idempotent — stat's all four pieces, restores any one missing from any
+# surviving copy. To fully remove, user must locate AND delete all four
+# pieces inside the cron's 5-minute window. Missing any single piece →
+# the next tick of the other layer restores it.
+#
+# USAGE
+#   ./browser_guard.sh on          one-time install (sets up all four layers)
+#   (no further commands — by design)
+#
+# PERMISSION
+#   First scan after install: macOS prompts for Automation permission for
+#   each running browser. Approve once per browser; the prompt is per-parent-
+#   process so it sticks. To inspect: System Settings → Privacy & Security →
+#   Automation.
+#
+#   Cron may need /usr/sbin/cron to have Full Disk Access on Catalina+ to run
+#   at all. macOS still ships cron but flags it deprecated; this script
+#   installs it best-effort. If cron silently doesn't run, the LaunchAgent
+#   alone still handles blocking + heal.
+
+set -u
+
+# ─── Embedded blocklist (case-insensitive, exact OR subdomain match) ────
+
+BLOCKLIST=(
+    # Google search (main distraction surface)
+    google.com
+
+    # Video / streaming
+    youtube.com
+    bilibili.com
+
+    # Gaming
+    steampowered.com
+    steamcommunity.com
+    steamcontent.com
+    steamstatic.com
+    dota2.com
+    dota.com
+    chronodivide.com
+    dos.zone
+    play-cs.com
+    webrcade.com
+
+    # News / doomscroll
+    9news.com.au
+    abc.net.au
+    news.com.au
+    smh.com.au
+    espn.com.au
+    theaustralian.com.au
+    163.com
+    iranintl.com
+    southcn.com
+    tmtpost.com
+
+    # Misc
+    zhihu.com
+    heheda.top
+    alibaba.com
+)
+
+# ─── Obfuscated install paths derived from hostname-hash ────────────────
+#
+# SHA-1 of "browser-guard-<hostname>" gives a deterministic 40-char hex
+# string. Slice into 8-char chunks so different paths don't share suffix.
+# All names follow the com.apple.* XPC helper pattern.
+
+_hash() {
+    printf '%s' "browser-guard-$(hostname)" | shasum | awk '{print $1}'
+}
+HASH="$(_hash)"
+
+INSTALL_DIR_A="${HOME}/.cache/.com.apple.metadata.${HASH:0:8}"
+INSTALL_SCRIPT_A="${INSTALL_DIR_A}/com.apple.metadata.helper.${HASH:8:8}"
+
+INSTALL_DIR_B="${HOME}/Library/Application Support/.com.apple.coreservices.${HASH:16:8}"
+INSTALL_SCRIPT_B="${INSTALL_DIR_B}/com.apple.coreservices.daemon.${HASH:24:8}"
+
+PLIST_LABEL="com.apple.cfprefsd.helper.${HASH:32:8}"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_LABEL}.plist"
+
+LOG_FILE="${INSTALL_DIR_A}/.log"
+
+CRON_MARKER="# bg-${HASH:0:8}"
+CRON_LINE="*/5 * * * * ${INSTALL_SCRIPT_A} check >/dev/null 2>&1  ${CRON_MARKER}"
+
+SCAN_INTERVAL=10  # LaunchAgent fire cadence (seconds)
+
+# ─── Logging ────────────────────────────────────────────────────────────
+
+log() {
+    mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null
+    printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_FILE" 2>/dev/null
+}
+
+# ─── URL → host extraction + blocklist match ─────────────────────────────
+
+extract_host() {
+    local url="${1#*://}"
+    url="${url%%/*}"
+    url="${url%%\?*}"
+    url="${url%%:*}"
+    printf '%s' "$url" | tr '[:upper:]' '[:lower:]'
+}
+
+is_blocked() {
+    local host="$1"
+    [ -z "$host" ] && return 1
+    local entry
+    for entry in "${BLOCKLIST[@]}"; do
+        if [ "$host" = "$entry" ] || [[ "$host" == *."$entry" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ─── AppleScript: list tabs from each browser ────────────────────────────
+
+list_chromium_tabs() {
+    local app="$1"
+    # IMPORTANT: define `tabChar` OUTSIDE the `tell application` block.
+    # Inside `tell application "Google Chrome"` (and Brave, and Safari),
+    # the bareword `tab` is shadowed by the browser's Tab class object,
+    # so `& tab &` concatenates the literal string "tab" instead of an
+    # ASCII tab — and the bash side reads empty fields and silently skips
+    # every URL. Using (ASCII character 9) from outer scope dodges the
+    # shadowing.
+    osascript <<APPLESCRIPT 2>/dev/null
+set tabChar to (ASCII character 9)
+if application "$app" is running then
+    tell application "$app"
+        set output to ""
+        repeat with w in windows
+            repeat with t in tabs of w
+                try
+                    set u to URL of t
+                    if u is missing value then set u to ""
+                    if u is not "" then set output to output & "$app" & tabChar & u & linefeed
+                end try
+            end repeat
+        end repeat
+        return output
+    end tell
+end if
+APPLESCRIPT
+}
+
+list_safari_tabs() {
+    osascript <<'APPLESCRIPT' 2>/dev/null
+set tabChar to (ASCII character 9)
+if application "Safari" is running then
+    tell application "Safari"
+        set output to ""
+        repeat with w in windows
+            repeat with t in tabs of w
+                try
+                    set u to URL of t
+                    if u is missing value then set u to ""
+                    if u is not "" then set output to output & "Safari" & tabChar & u & linefeed
+                end try
+            end repeat
+        end repeat
+        return output
+    end tell
+end if
+APPLESCRIPT
+}
+
+# ─── Kill action ────────────────────────────────────────────────────────
+
+kill_browser() {
+    local browser="$1"
+    log "killing browser=$browser"
+    # Graceful quit first (browser flushes state in <1s).
+    osascript -e "tell application \"$browser\" to quit" 2>/dev/null
+    sleep 1
+    # Force-kill survivors. `-f` matches full command line, catching
+    # renderer / GPU / network-service subprocesses.
+    pkill -i -f "$browser" 2>/dev/null
+}
+
+# ─── Single scan pass ────────────────────────────────────────────────────
+
+scan_once() {
+    local killed=""
+    {
+        list_chromium_tabs "Google Chrome"
+        list_chromium_tabs "Brave Browser"
+        list_safari_tabs
+    } | while IFS=$'\t' read -r browser url; do
+        [ -z "$url" ] && continue
+        local h
+        h="$(extract_host "$url")"
+        if is_blocked "$h"; then
+            log "BLOCKED browser=$browser host=$h"
+            # Dedup so we don't quit the same browser repeatedly per scan.
+            if [[ "$killed" != *"|$browser|"* ]]; then
+                kill_browser "$browser"
+                killed="$killed|$browser|"
+            fi
+        fi
+    done
+}
+
+# ─── Self-healing: restore any missing layer ────────────────────────────
+
+# Pick a live script source: prefer current $0, fall back to either surviving copy.
+_pick_source() {
+    # If we're already running from a known location, $0 is fine.
+    if [ -r "$0" ]; then printf '%s' "$0"; return; fi
+    if [ -r "$INSTALL_SCRIPT_A" ]; then printf '%s' "$INSTALL_SCRIPT_A"; return; fi
+    if [ -r "$INSTALL_SCRIPT_B" ]; then printf '%s' "$INSTALL_SCRIPT_B"; return; fi
+    printf ''
+}
+
+ensure_script_copies() {
+    local src
+    src="$(_pick_source)"
+    [ -z "$src" ] && { log "no surviving script source — cannot heal"; return; }
+
+    if [ ! -x "$INSTALL_SCRIPT_A" ]; then
+        mkdir -p "$INSTALL_DIR_A"
+        chmod 700 "$INSTALL_DIR_A"
+        cp "$src" "$INSTALL_SCRIPT_A" 2>/dev/null && chmod 700 "$INSTALL_SCRIPT_A" && log "restored primary script"
+    fi
+    if [ ! -x "$INSTALL_SCRIPT_B" ]; then
+        mkdir -p "$INSTALL_DIR_B"
+        chmod 700 "$INSTALL_DIR_B"
+        cp "$src" "$INSTALL_SCRIPT_B" 2>/dev/null && chmod 700 "$INSTALL_SCRIPT_B" && log "restored backup script"
+    fi
+}
+
+write_plist() {
+    mkdir -p "${HOME}/Library/LaunchAgents"
+    cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${PLIST_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${INSTALL_SCRIPT_A}</string>
+        <string>check</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>${SCAN_INTERVAL}</integer>
+    <key>StandardOutPath</key>
+    <string>${LOG_FILE}</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_FILE}</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+PLIST
+    chmod 644 "$PLIST_PATH"
+}
+
+ensure_plist() {
+    if [ ! -f "$PLIST_PATH" ]; then
+        write_plist
+        launchctl load "$PLIST_PATH" 2>/dev/null
+        log "restored plist + reloaded"
+        return
+    fi
+    # Plist file exists; verify it's loaded into launchd.
+    if ! launchctl list "$PLIST_LABEL" >/dev/null 2>&1; then
+        launchctl load "$PLIST_PATH" 2>/dev/null
+        log "plist file present but agent not loaded — loaded"
+    fi
+}
+
+ensure_cron() {
+    local current
+    current="$(crontab -l 2>/dev/null || true)"
+    if ! printf '%s' "$current" | grep -qF "$CRON_MARKER"; then
+        {
+            [ -n "$current" ] && printf '%s\n' "$current"
+            printf '%s\n' "$CRON_LINE"
+        } | crontab - 2>/dev/null && log "restored cron entry"
+    fi
+}
+
+heal_all() {
+    ensure_script_copies
+    ensure_plist
+    ensure_cron
+}
+
+# ─── Force-overwrite (for explicit `on` reinstall) ──────────────────────
+#
+# Heal is create-if-missing only (called every 10s, must be cheap and
+# not churn). `on` is the explicit user-driven reinstall — it should
+# OVERWRITE installed copies from the current source so blocklist edits
+# (and any other script changes) actually take effect.
+
+force_install_scripts() {
+    local src
+    src="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    [ -r "$src" ] || { log "force-install: source $src unreadable"; return 1; }
+
+    mkdir -p "$INSTALL_DIR_A"; chmod 700 "$INSTALL_DIR_A"
+    cp "$src" "$INSTALL_SCRIPT_A" && chmod 700 "$INSTALL_SCRIPT_A"
+
+    mkdir -p "$INSTALL_DIR_B"; chmod 700 "$INSTALL_DIR_B"
+    cp "$src" "$INSTALL_SCRIPT_B" && chmod 700 "$INSTALL_SCRIPT_B"
+
+    log "force-installed both script copies from source $src"
+}
+
+force_install_plist() {
+    write_plist
+    # Unload+load so a changed SCAN_INTERVAL or label is picked up.
+    # Unload may fail if it wasn't loaded; we don't care.
+    launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    launchctl load "$PLIST_PATH" 2>/dev/null
+    log "force-installed plist + reloaded"
+}
+
+# ─── Install (first-time setup OR explicit update) ──────────────────────
+
+install_all() {
+    force_install_scripts
+    force_install_plist
+    ensure_cron       # cron line content is stable, only needs presence
+    heal_all          # belt-and-suspenders: ensure everything's in place
+
+    echo "browser-guard installed (4 self-protecting layers)."
+    echo
+    echo "  primary script : $INSTALL_SCRIPT_A"
+    echo "  backup script  : $INSTALL_SCRIPT_B"
+    echo "  plist label    : $PLIST_LABEL"
+    echo "  plist path     : $PLIST_PATH"
+    echo "  cron entry     : */5 * * * *  (marker: $CRON_MARKER)"
+    echo "  log            : $LOG_FILE"
+    echo "  scan every     : ${SCAN_INTERVAL}s (LaunchAgent) + 5min (cron)"
+    echo
+    echo "First scan fires now (RunAtLoad). On the FIRST AppleScript call"
+    echo "to a browser, macOS will prompt for Automation permission —"
+    echo "approve once per browser. Subsequent scans run silently."
+    echo
+    echo "Tail the log:   tail -f \"$LOG_FILE\""
+    echo "Verify agent:   launchctl list | grep \"$PLIST_LABEL\""
+}
+
+# ─── Entry point ────────────────────────────────────────────────────────
+
+case "${1:-check}" in
+    on)
+        install_all
+        ;;
+    *)
+        # Default: heal + scan. Called every 10s by LaunchAgent and
+        # every 5min by cron. Both routes call the same action so
+        # either alone restores the system.
+        heal_all
+        scan_once
+        ;;
+esac

--- a/app_mon/browser_guard/list_open_tabs.sh
+++ b/app_mon/browser_guard/list_open_tabs.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# list_open_tabs.sh
+#
+# Standalone prototype for the browser-tab-URL monitor.
+# See: requirements/monitor_browser_tab_url/monitor_web_browser_tab_url.md
+#
+# Lists every URL currently open in Google Chrome / Brave Browser / Safari
+# via AppleScript. Read-only — does NOT close tabs, kill processes, or
+# modify anything. Purpose: verify the AppleScript approach actually
+# returns the tabs you see in your browser, BEFORE wiring this into the
+# appmon daemon.
+#
+# Output format (one tab per line):
+#
+#     [Chrome] Page Title — https://example.com/path
+#
+# ─────────────────────────────────────────────────────────────────
+# FIRST RUN: macOS will pop up "Terminal wants permission to control
+# Google Chrome" (or Brave / Safari). Click OK. The prompt appears
+# once per browser. To inspect or revoke later:
+#
+#     System Settings → Privacy & Security → Automation →
+#     Terminal → Chrome / Brave / Safari
+#
+# If you've already granted, no prompt and tabs print immediately.
+# ─────────────────────────────────────────────────────────────────
+#
+# Usage:
+#     chmod +x list_open_tabs.sh
+#     ./list_open_tabs.sh
+#
+# Exit:
+#     0 — at least one tab was listed
+#     1 — no supported browser is running, or no permission granted
+
+set -u
+
+# ─── helpers ────────────────────────────────────────────────────
+
+# list_chromium: prints URLs from a Chromium-family browser (Chrome or
+# Brave — both use the same AppleScript dialect since Brave is a fork).
+#
+# The `if application X is running` precheck is critical: a bare
+# `tell application "X"` would LAUNCH X if it isn't running, and would
+# trigger the Automation permission prompt for browsers you don't use.
+# `is running` is a non-tell query handled by the AppleScript runtime,
+# so it does neither.
+list_chromium() {
+    local app="$1"
+    osascript <<APPLESCRIPT
+if application "$app" is running then
+    tell application "$app"
+        set output to ""
+        repeat with w in windows
+            repeat with t in tabs of w
+                try
+                    set u to URL of t
+                    if u is missing value then set u to "<no-url>"
+                    set ti to title of t
+                    if ti is missing value then set ti to "<no-title>"
+                    set output to output & "[$app] " & ti & " — " & u & linefeed
+                end try
+            end repeat
+        end repeat
+        return output
+    end tell
+end if
+APPLESCRIPT
+}
+
+# list_safari: prints URLs from Safari. Different terminology than
+# Chromium — Safari calls it `name of tab` instead of `title of tab`.
+#
+# Known limitation: Safari does NOT enumerate Private Browsing windows
+# via AppleScript. This is a deliberate macOS-level restriction and
+# represents a known gap in the protection model. Documented in the
+# requirements doc § "Incognito / Private".
+list_safari() {
+    osascript <<'APPLESCRIPT'
+if application "Safari" is running then
+    tell application "Safari"
+        set output to ""
+        repeat with w in windows
+            repeat with t in tabs of w
+                try
+                    set u to URL of t
+                    if u is missing value then set u to "<no-url>"
+                    set ti to name of t
+                    if ti is missing value then set ti to "<no-title>"
+                    set output to output & "[Safari] " & ti & " — " & u & linefeed
+                end try
+            end repeat
+        end repeat
+        return output
+    end tell
+end if
+APPLESCRIPT
+}
+
+# ─── main ───────────────────────────────────────────────────────
+
+found_any=0
+
+for spec in 'chrome:Google Chrome' 'brave:Brave Browser' 'safari:'; do
+    name="${spec%%:*}"
+    appname="${spec#*:}"
+    case "$name" in
+        safari) out=$(list_safari) ;;
+        *)      out=$(list_chromium "$appname") ;;
+    esac
+    if [ -n "$out" ]; then
+        printf '%s' "$out"
+        found_any=1
+    fi
+done
+
+if [ "$found_any" -eq 0 ]; then
+    {
+        echo "list_open_tabs.sh: no browser tabs found."
+        echo ""
+        echo "Possible reasons:"
+        echo "  1. No supported browser is running (Chrome / Brave / Safari)."
+        echo "  2. Automation permission has not been granted for this terminal."
+        echo "     Check: System Settings → Privacy & Security → Automation"
+        echo "  3. All open browsers have zero tabs (unlikely)."
+    } >&2
+    exit 1
+fi

--- a/requirements/monitor_browser_tab_url/monitor_web_browser_tab_url.md
+++ b/requirements/monitor_browser_tab_url/monitor_web_browser_tab_url.md
@@ -1,0 +1,210 @@
+# Monitor Web Browser Tab URL
+
+## Context
+
+The existing `app_mon` defenses cover:
+
+- **Process layer** — kill blocked apps (Steam, Dota 2) via `FindByName` + SIGKILL.
+- **Filesystem layer** — delete blocked app bundles, caches, save data.
+- **DNS layer** — `/etc/hosts` blackhole for ~68 hostnames (Steam, YouTube, Bilibili, news domains, etc.).
+
+The DNS layer is the only network-level block today, and it leaks in three real cases observed on this machine and in the wider macOS ecosystem:
+
+1. **DNS-over-HTTPS (DoH)** — Chrome, Brave, Firefox each ship with their own DoH resolver that bypasses `/etc/hosts` entirely. A user has only to enable "Use secure DNS" in browser settings (Chrome) or check the box in Firefox network settings, and every domain in our blocklist resolves normally again.
+2. **AAAA / IPv6 leak** — `/etc/hosts` entries are `0.0.0.0 <host>` (IPv4 only). Dual-stack domains like `youtube.com` still resolve via real DNS for their AAAA record. Apps that prefer IPv6 connect successfully. (Documented as deferred follow-up in v0.6.0 CHANGELOG.)
+3. **Hardcoded IPs / hardcoded resolvers** — some apps (Steam's CDN, several Chinese sites) embed IPs or use private resolvers. DNS blocking doesn't reach them.
+
+For browsers specifically, the threat is acute: the whole *point* of a browser is to visit URLs, and the URL bar is the user's path-of-least-resistance bypass. A blocked domain in `/etc/hosts` is a 2-click bypass via DoH; switching to a different DNS over HTTPS is a 1-click action in every modern browser.
+
+This requirements doc scopes a new layer: **read browser tab URLs as the source of truth** and act on blocked URLs at the browser-tab level, downstream of any DNS bypass.
+
+## Goal
+
+Detect blocked URLs that have already loaded (or are loading) in any browser tab on macOS, regardless of how the browser resolved DNS, and take action: **close the tab, kill the browser, log the event**. Same self-binding / friction philosophy as `app_mon` — present-you wants this protection, future-you in a moment of weakness is the adversary.
+
+## Scope: in / out
+
+### In scope (MVP)
+
+- **Browsers**: Safari, Google Chrome, Brave. These three cover ~99% of macOS usage and all expose tab URLs via AppleScript.
+- **Detection mechanism**: AppleScript polling every 10–30s, asking each running browser for the URL of every tab in every window. (Same cadence as the existing `app_mon` quick-kill tick.)
+- **Blocklist source**: reuse `internal/policy/dns_blocklist.go`'s `DefaultDNSBlocklist`. A URL whose host matches any entry (with simple subdomain rules) is blocked.
+- **Action on match**: close the offending tab via AppleScript. Log the event with timestamp + URL + browser. If a browser has ≥3 blocked tabs in a single tick, escalate to **kill the browser process** (forces user to relaunch — friction multiplier).
+- **No-stop semantics**: same as `app_mon`. No CLI command to disable browser monitoring. Requires source edit + rebuild + sudo-replace of the binary to remove.
+
+### Out of scope (MVP)
+
+- **Firefox**: doesn't expose tabs via AppleScript by default; would require a custom WebExtension. Add later if needed.
+- **Webkit views inside other apps** (Slack message previews, Notion's web views, etc.): too many surfaces, too low signal.
+- **HTTPS interception / proxy**: separate Layer 6 — see "Future" below.
+- **Per-URL whitelisting**: blocklist is the only directional list. To unblock, edit `dns_blocklist.go` and rebuild (the existing perm-ban semantic).
+
+## Functional requirements
+
+### F1. Periodic tab scan
+
+Every 15 seconds (configurable, but compiled-in default), the daemon must:
+
+1. Enumerate running browsers from the set `{Safari, Google Chrome, Brave Browser}`.
+2. For each running browser, run AppleScript to get the URL of every tab in every window.
+3. For each URL, normalize the host (strip scheme, port, path, query) and compare against `DefaultDNSBlocklist` with the same subdomain-tolerant matching used by the `/etc/hosts` layer.
+4. For each blocked URL, close the tab via AppleScript (`close tab id … of window id …`).
+5. Log structured: `{ts, browser, window_id, tab_id, url, action: "tab_closed" | "browser_killed"}`.
+
+### F2. Browser-kill escalation
+
+When a single scan tick detects ≥3 blocked tabs across all browsers, the daemon must SIGKILL the browser process(es) where the blocked tabs live. Rationale: closing tabs one-by-one is too gentle when the user is actively re-opening; killing the process is a meaningful 5–10 second friction (relaunch, sign-in, restore session) that breaks the impulse loop.
+
+The threshold (3) is compiled-in.
+
+### F3. Permission acquisition
+
+AppleScript control of Safari / Chrome / Brave requires the `appmon` binary to be granted **Automation** permission for each target browser (System Settings → Privacy & Security → Automation → appmon → Safari/Chrome/Brave). The daemon must:
+
+- Attempt the AppleScript and log a clear warning if it fails due to permission errors.
+- Print an instructional CLI message on `appmon start` if permissions are missing: which apps need toggling, how to do it.
+- **Not crash or stop other protections** if browser permission is denied — user might not have granted it yet.
+
+### F4. Privacy
+
+URLs visited are sensitive. The daemon must:
+
+- Never persist non-blocked URLs anywhere (memory only, dropped after the tick).
+- Log only **blocked** URLs to the standard log file (`/var/tmp/appmon.log`).
+- Never transmit URLs anywhere (no telemetry, no cloud upload). Future cloud-sync layer is explicitly excluded from this feature.
+
+### F5. Integration with existing watcher
+
+The browser monitor lives inside the existing `Watcher` daemon (not a new process). New ticker `BrowserScanInterval = 15 * time.Second`. The `EnforcementResult` shape gains a `BrowserActions []BrowserAction` field surfaced through `appmon status`.
+
+No new daemon, no new plist, no new launchd integration — this is "Layer 6" inside the existing protection stack.
+
+## Non-functional requirements
+
+### Resilience
+
+- **AppleScript failure**: log warn, continue. Don't disable other layers.
+- **Browser not running**: silently skip — no error.
+- **AppleScript timeout** (browser hung): bound each per-browser query at 3 seconds; on timeout, skip that browser this tick.
+- **Permission revoked mid-flight**: graceful degrade with structured log warning, retry next tick.
+
+### Performance
+
+- Total scan should complete in ≤2 seconds per tick under normal load (a few dozen tabs).
+- AppleScript invocations are batched per browser (one `osascript` call returns all tabs in all windows).
+- Compiled blocklist match is O(n_tabs × n_blocklist) with simple hostname normalization. ~50 tabs × 68 entries × subdomain check is microseconds.
+
+### Friction (matches app_mon)
+
+- No `stop` / `disable` / `pause` CLI command.
+- Disabling requires either revoking Automation permission in System Settings (loud, user-visible) **and** appmon must detect this and either restore via `osascript` re-permission prompt OR escalate (e.g. start logging the permission state as a status warning, or kill the affected browser on every scan tick since "we can't see what's open, assume the worst").
+- Compiled blocklist is the same `DefaultDNSBlocklist` — single source of truth; removing a URL requires source edit + sudo-replace, same as DNS layer.
+
+### Testability
+
+- AppleScript runner is interfaced (`BrowserTabReader`) so the matching logic can be unit-tested with fake tab lists.
+- Hostname normalization + match is a pure function: `hostBlocked(url string, blocklist []string) bool` with table-driven tests covering scheme/port/subdomain/path-only cases.
+- AppleScript script strings are constants in code (greppable, easy to audit).
+
+## Open design questions
+
+1. **Where in the codebase does the AppleScript runner live?** Options:
+   - `internal/infra/browser_monitor.go` — alongside other OS-integration code.
+   - New package `internal/browser/`.
+     I lean toward `infra/` for KISS — it's the same shape as `freedom.go` and `launchd.go`.
+
+2. **Action on a match**: close-tab vs kill-browser threshold.
+   - Close-tab is gentle but easily-defeated by re-opening.
+   - Kill-browser is heavier-friction but disruptive (loses other tabs).
+   - MVP: close-tab on every match, escalate to kill-browser when threshold ≥3 in one tick.
+
+3. **Hostname normalization specifics**:
+   - `https://www.youtube.com/watch?v=…` → host `www.youtube.com` → blocked (exact match in list).
+   - `https://m.youtube.com/…` → blocked (we list `m.youtube.com`).
+   - `https://yt.be/…` (YouTube short URL) → currently NOT in blocklist → would slip through. Need to extend `DefaultDNSBlocklist` with redirect hostnames separately, OR have the browser monitor follow one redirect before deciding.
+   - **Decision**: MVP does exact-host match against `DefaultDNSBlocklist`. Short-URL redirects are a separate follow-up.
+
+4. **What about private browsing / Incognito?** AppleScript on Chrome lists Incognito windows by default; Safari Private Browsing windows are NOT enumerated unless explicitly allowed. **Decision**: rely on AppleScript's defaults. If the user opens a Private/Incognito window to bypass, that's a known partial gap; document it and consider as Phase 2 with a network-layer block.
+
+5. **Brave Sync / Chrome Sync via signed-in account** — could a user sync their tab to a different device and view it there? Yes, but out of scope for the appmon project (single-machine protection).
+
+## Compatibility with existing protection layers
+
+This feature is **complementary**, not replacement, to the DNS layer:
+
+| Layer | Catches | Misses |
+|---|---|---|
+| DNS (`/etc/hosts`) | All apps that use system resolver | DoH-enabled browsers, IPv6-preferred apps, apps with hardcoded IPs |
+| **Browser tab monitor (this feature)** | Any URL that reached a browser tab, regardless of DNS path | Non-browser apps, embedded WebViews |
+
+A blocked URL might:
+- Fail DNS → never reach the browser → DNS layer wins. Browser monitor sees nothing.
+- Succeed DNS via DoH → reach the browser → tab loads → **browser monitor closes the tab within 15s**.
+
+Both layers are present; either catching it is sufficient.
+
+## CLI surface
+
+New CLI command `appmon browser`:
+
+- `appmon browser` — prints permission status for each supported browser (granted / denied / not running), recent close-tab events from the log.
+- No `appmon browser disable` — by design.
+
+`appmon status` gains a "Browser monitor" section similar to the existing "Freedom protection" section.
+
+## Open security / abuse considerations
+
+1. **AppleScript itself is bypassable** — a user could disable Automation permission for `appmon`. We detect and log this, but cannot prevent it at the macOS permission layer without a system extension (deferred to Phase 2).
+2. **AppleScript injection** — we don't take user input into AppleScript. All scripts are constants. No injection surface.
+3. **Browser crashes the daemon** — bounded timeouts + error logging prevent this.
+
+## Phase 2 / future
+
+- **Firefox via WebExtension**: requires building+signing a Firefox add-on that posts tab URLs to a localhost endpoint exposed by the daemon. Workable but heavier.
+- **HTTPS-MITM proxy** (Layer 7): catch URLs at the network level rather than the browser level. Major increase in complexity (cert installation, certificate trust, performance) and ethical surface (proxy-decrypted traffic). Out of MVP.
+- **Network Extension (NEFilterControlProvider)**: kernel-level URL block at SNI layer. Requires Apple Developer notarization. Major commitment.
+- **Sync-down blocklist updates from a server**: today the blocklist is compiled-in (perm-ban semantic). A server-synced list with the same write-only-by-server semantic would let the user add to (not remove from) the list without rebuilding. Strictly orthogonal to this feature.
+
+## Suggested implementation order
+
+1. **`infra/browser_monitor.go`**: AppleScript constants, `BrowserTabReader` interface, `TabsOf(browser) ([]Tab, error)` per supported browser. Tests with table-driven hostname matching.
+2. **Watcher wiring**: new `BrowserScanInterval` field in `WatcherConfig`, new ticker case in `Run()`. Tests update `daemon_test.go`.
+3. **`appmon browser` CLI**: status + recent-events view.
+4. **README + CHANGELOG**: document Layer 6, the threat model gap it closes, the Automation permission setup step.
+5. **End-to-end manual test plan**: open a blocked URL in Safari and confirm tab closes within 15s; same for Chrome and Brave; verify Incognito tabs are correctly handled per design decision.
+6. **Release** as v0.7.0 (minor — new defense layer).
+
+---
+
+## Implementation status (2026-05-13)
+
+Shipped as a **standalone bash companion tool** rather than integrated into
+the Go daemon, because the primary use case is managed corporate laptops
+where the user has no root / no Go runtime / no extension-install rights.
+
+- Implementation: [`app_mon/browser_guard/`](../../app_mon/browser_guard/)
+  — `browser_guard.sh` (single self-installer), `list_open_tabs.sh`
+  (read-only debug), `README.md` (operator docs).
+- Mechanism: AppleScript polling via `osascript`, fired every 10 seconds
+  by a LaunchAgent (and every 5 minutes by a cron fallback layer that
+  heals the LaunchAgent if it gets unloaded).
+- Self-protection: 4 hostname-hash-derived hidden install locations
+  (primary script + backup script + LaunchAgent plist + cron entry).
+  Each tick heals the others; removing the system requires locating and
+  deleting all four within one cron cycle.
+- Blocklist source: hardcoded `BLOCKLIST=(...)` array in the script.
+  Editing the source and re-running `./browser_guard.sh on`
+  force-propagates the change to both installed copies.
+
+Phase-2 items in the body of this doc (MITM proxy, NEFilterControlProvider,
+Firefox WebExtension, server-synced blocklist) remain deferred — the
+managed-laptop constraint rules out all of them for now.
+
+Notable surprise during implementation: AppleScript identifier shadowing.
+Inside a `tell application "Google Chrome"` block, the bareword `tab` is
+NOT the ASCII tab character but Chrome's Tab class object. Using `tab` as
+a field separator silently produced lines like `Google Chrometabhttps://…`
+with no real tab byte, causing the bash `read -r browser url` to receive
+empty `$url` and skip every tab. Fixed by defining
+`set tabChar to (ASCII character 9)` OUTSIDE the `tell` block so the
+browser's dictionary can't shadow it.


### PR DESCRIPTION
## Summary

Adds `app_mon/browser_guard/` — a standalone bash + AppleScript companion tool that watches open tabs in Chrome / Brave / Safari and SIGKILLs any browser holding a tab whose host is on an embedded blocklist.

**Not integrated into the Go daemon** — by design. The primary use case is **managed corporate laptops** with no root, no Go runtime, no extension-install rights. A single bash file is the only deployment surface that works there.

## Why this layer

The Go `appmon`'s `/etc/hosts` DNS-blackhole layer leaks in two real cases that matter for browsers:

1. **DoH** — Chrome / Brave / Firefox each ship with DNS-over-HTTPS as a 1-click setting that bypasses `/etc/hosts` entirely.
2. **AAAA / IPv6** — `/etc/hosts` blackholes only `A` records (IPv4). Dual-stack domains (youtube.com, etc.) still resolve via real DNS for their `AAAA` record.

For browsers, the URL bar is also the user's path-of-least-resistance bypass: toggle DoH, type the URL anyway. Reading the URL bar via AppleScript is **downstream of any DNS bypass** — if a blocked URL is open, the browser dies regardless of how it resolved DNS.

## What the install does (no sudo)

```sh
./browser_guard.sh on
```

Sets up **4 self-healing layers** under hostname-hash-derived obfuscated paths (filenames look like macOS XPC helpers — `com.apple.cfprefsd.helper.<hex>` etc):

| Layer | Path / Mechanism |
|---|---|
| Primary script | `~/.cache/.com.apple.metadata.<h>/com.apple.metadata.helper.<h>` |
| Backup script | `~/Library/Application Support/.com.apple.coreservices.<h>/com.apple.coreservices.daemon.<h>` |
| LaunchAgent | `~/Library/LaunchAgents/com.apple.cfprefsd.helper.<h>.plist`, `StartInterval=10` |
| Cron entry | `*/5 * * * *` with idempotent marker comment |

Every invocation runs `heal_all` before scanning — idempotent (stat's all 4 pieces, restores any missing one from any surviving copy). To fully remove the system, the user must locate AND delete all 4 within one cron cycle (5 minutes). Miss any one piece → it restores the others.

`on` is **idempotent** for updates: edit the source script (e.g. extend `BLOCKLIST=()`), re-run `on`, both installed copies are force-overwritten and the LaunchAgent reloads. Within 10s the change is enforced.

## Files in this PR

- `app_mon/browser_guard/browser_guard.sh` — single-file self-installer.
- `app_mon/browser_guard/list_open_tabs.sh` — read-only debug script (lists tabs, doesn't kill).
- `app_mon/browser_guard/README.md` — operator docs (install, blocklist mgmt, verification, limitations).
- `app_mon/README.md` — one paragraph linking to the companion tool.
- `requirements/monitor_browser_tab_url/monitor_web_browser_tab_url.md` — implementation-status epilogue added.

## Implementation gotcha worth flagging

Inside `tell application "Google Chrome"` (and Safari, and Brave), the AppleScript bareword **`tab` is shadowed by the browser's Tab class object** (each browser tab is a Tab object). Concatenating `output & "Chrome" & tab & url` produced literal strings like `Chrometabhttps://...` with no real TAB byte — and the bash `read -r browser url` saw empty `$url` every iteration → silent skip of every URL.

Fixed by defining `set tabChar to (ASCII character 9)` **outside** the `tell` block so the browser's dictionary can't shadow it. Documented in code comments + the README + the requirements doc epilogue so future maintainers don't re-introduce.

## Test plan

- [x] `bash -n` syntax check on both scripts: green.
- [x] Local `./browser_guard.sh on` install: all 4 layers verified present (`launchctl list | grep`, `crontab -l | grep`, `ls` on both script paths).
- [x] Open `https://www.alibaba.com` in Chrome → within 10s log shows `BLOCKED browser=Google Chrome host=www.alibaba.com` → `killing browser=Google Chrome` → Chrome gone. Verified live.
- [x] `go test ./...` still passes — adding non-Go files to the tree doesn't affect Go tooling.
- [ ] (CI) Lint, Format, Build (mac+ubuntu), Test (mac+ubuntu), Security Scan, Integration Test, codecov/patch — the existing Go-binary CI. The new bash files are inert to it.

No version bump on the Go binary — this script is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)