### PR TITLE
feat(kill-steam): auto-uninstall Steam.app + Dota appdata on detection (v2.0.0)

### DIFF
--- a/plugins/kill-steam/cmd/main.go
+++ b/plugins/kill-steam/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/killer"
+	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/uninstaller"
 )
 
 var version = "dev"
@@ -58,6 +59,7 @@ func run(args []string) int {
 		return 2
 	}
 
+	// Phase 1 — kill any live Steam/Dota processes (the existing logic).
 	out, err := killer.New(names).Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "kill error:", err)
@@ -65,21 +67,37 @@ func run(args []string) int {
 		return 2
 	}
 
+	// Phase 2 — if Steam.app exists on disk, full auto-uninstall:
+	// remove the app + every user's Steam appdata + caches + launchd
+	// helper. Cheap when Steam is absent (one os.Stat → return).
+	un := (&uninstaller.Reconciler{}).Reconcile()
+
 	res := result{
-		Status:  "ok",
-		Message: fmt.Sprintf("scanned %d, killed %d", out.Scanned, out.KilledCount()),
+		Status: "ok",
+		Message: fmt.Sprintf("scanned=%d killed=%d uninstall_detected=%v removed=%d",
+			out.Scanned, out.KilledCount(), un.Detected, len(un.Removed)),
 		Details: map[string]any{
-			"scanned":      out.Scanned,
-			"killed_count": out.KilledCount(),
-			"killed_pids":  out.KilledPIDs,
+			"scanned":            out.Scanned,
+			"killed_count":       out.KilledCount(),
+			"killed_pids":        out.KilledPIDs,
+			"uninstall_detected": un.Detected,
+			"uninstall_removed":  un.Removed,
+			"uninstall_errors":   un.Errors,
+			"uninstall_reason":   un.Reason,
 		},
 	}
 	if len(out.Failed) > 0 {
 		res.Status = "failed"
-		res.Message = fmt.Sprintf("killed %d, %d failed", out.KilledCount(), len(out.Failed))
+		res.Message = fmt.Sprintf("killed %d, %d failed; %s",
+			out.KilledCount(), len(out.Failed), res.Message)
 		res.Details["failed"] = out.Failed
 		emit(res)
 		return 1 // controlled failure
+	}
+	if len(un.Errors) > 0 {
+		res.Status = "failed"
+		emit(res)
+		return 1
 	}
 	emit(res)
 	return 0

--- a/plugins/kill-steam/internal/uninstaller/uninstaller.go
+++ b/plugins/kill-steam/internal/uninstaller/uninstaller.go
@@ -1,0 +1,199 @@
+// Package uninstaller is the "kill-steam takes the gloves off" half of
+// the plugin: when Steam.app is detected on disk, remove it AND the per-
+// user Steam appdata, caches, logs, launchd helper and saved state — so
+// a casual reinstall costs ~25 GB of Dota redownload + a Valve account
+// login, instead of double-click-and-go.
+//
+// Cheap-detect-first: a tick with no Steam.app costs one os.Stat and
+// returns. The expensive work only fires when Steam is actually present
+// (i.e. on an install event), then noops forever after.
+//
+// Casual-grade friction, same as the rest of focusd. A determined user
+// can reinstall again; this plugin will re-uninstall on the next tick.
+package uninstaller
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// systemTarget is a literal path removed if present.
+type systemTarget struct {
+	Path string
+	What string
+}
+
+// perUserTarget is a path relative to a home dir, removed if present in
+// any user's home.
+type perUserTarget struct {
+	RelPath string
+	What    string
+}
+
+// DefaultSystemTargets are the system-scoped Steam artifacts.
+var DefaultSystemTargets = []systemTarget{
+	{Path: "/Applications/Steam.app", What: "Steam application"},
+}
+
+// DefaultPerUserTargets are removed under every real user's home.
+var DefaultPerUserTargets = []perUserTarget{
+	{RelPath: "Library/Application Support/Steam", What: "Steam appdata (includes Dota 2)"},
+	{RelPath: "Library/Caches/com.valvesoftware.steam", What: "Steam cache (bundle id)"},
+	{RelPath: "Library/Caches/Steam", What: "Steam cache"},
+	{RelPath: "Library/Logs/Steam", What: "Steam logs"},
+	{RelPath: "Library/Saved Application State/com.valvesoftware.steam.savedState", What: "Steam saved state"},
+	{RelPath: "Library/LaunchAgents/com.valvesoftware.steamclean.plist", What: "Steam launch agent (auto-reinstall vector)"},
+	{RelPath: "Library/Preferences/com.valvesoftware.steam.plist", What: "Steam preferences"},
+	{RelPath: "Library/Logs/DiagnosticReports", What: "Dota 2 crash reports (best effort glob)"}, // filtered by name
+}
+
+// Reconciler is the testable surface. Override AppPath / UsersDir for
+// tests; defaults are the real macOS paths.
+type Reconciler struct {
+	// AppPath is the trigger / first-check. Default: /Applications/Steam.app.
+	AppPath string
+	// UsersDir is the dir holding per-user homes. Default: /Users.
+	UsersDir string
+	// System and PerUser default to Default*Targets unless overridden.
+	System  []systemTarget
+	PerUser []perUserTarget
+}
+
+// Outcome summarises a single Reconcile pass.
+type Outcome struct {
+	Detected bool     `json:"detected"`
+	Removed  []string `json:"removed,omitempty"`
+	Errors   []string `json:"errors,omitempty"`
+	Reason   string   `json:"reason"`
+}
+
+// Detect is the cheap path: does Steam.app exist? Used as the gate
+// before any expensive enumeration / removal. Steady-state noop ticks
+// hit this and return in <1 ms.
+func (r *Reconciler) Detect() bool {
+	_, err := os.Stat(r.appPath())
+	return err == nil
+}
+
+// Reconcile is the full pass: detect, then if found, sweep every known
+// Steam artifact (system + per-user). Idempotent — noop when Steam is
+// not installed; total removal when it is.
+func (r *Reconciler) Reconcile() Outcome {
+	o := Outcome{Detected: r.Detect()}
+	if !o.Detected {
+		o.Reason = "noop (no Steam.app)"
+		return o
+	}
+
+	for _, t := range r.systemTargets() {
+		r.tryRemove(t.Path, t.What, &o)
+	}
+
+	homes, err := r.findUserHomes()
+	if err != nil {
+		o.Errors = append(o.Errors, fmt.Sprintf("enumerate users: %v", err))
+	}
+	for _, home := range homes {
+		for _, t := range r.perUserTargets() {
+			full := filepath.Join(home, t.RelPath)
+			// Special-case the DiagnosticReports dir — don't rm the dir,
+			// just the dota2-*.ips files in it.
+			if strings.HasSuffix(t.RelPath, "DiagnosticReports") {
+				r.cleanCrashReports(full, &o)
+				continue
+			}
+			r.tryRemove(full, t.What, &o)
+		}
+	}
+
+	switch len(o.Removed) {
+	case 0:
+		o.Reason = "detected but nothing to remove (likely already partial)"
+	default:
+		o.Reason = fmt.Sprintf("removed %d artifact(s)", len(o.Removed))
+	}
+	return o
+}
+
+func (r *Reconciler) tryRemove(path, what string, o *Outcome) {
+	if _, err := os.Stat(path); err != nil {
+		return // not present
+	}
+	if err := os.RemoveAll(path); err != nil {
+		o.Errors = append(o.Errors, fmt.Sprintf("%s (%s): %v", what, path, err))
+		return
+	}
+	o.Removed = append(o.Removed, path)
+}
+
+func (r *Reconciler) cleanCrashReports(dir string, o *Outcome) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return // dir doesn't exist or unreadable — fine
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(strings.ToLower(name), "dota2") {
+			continue
+		}
+		full := filepath.Join(dir, name)
+		if err := os.Remove(full); err == nil {
+			o.Removed = append(o.Removed, full)
+		}
+	}
+}
+
+func (r *Reconciler) appPath() string {
+	if r.AppPath != "" {
+		return r.AppPath
+	}
+	return "/Applications/Steam.app"
+}
+
+func (r *Reconciler) usersDir() string {
+	if r.UsersDir != "" {
+		return r.UsersDir
+	}
+	return "/Users"
+}
+
+func (r *Reconciler) systemTargets() []systemTarget {
+	if r.System != nil {
+		return r.System
+	}
+	return DefaultSystemTargets
+}
+
+func (r *Reconciler) perUserTargets() []perUserTarget {
+	if r.PerUser != nil {
+		return r.PerUser
+	}
+	return DefaultPerUserTargets
+}
+
+// findUserHomes returns the home directories of real users on this Mac
+// (skips dotted dirs, Shared, and anything that isn't a directory).
+func (r *Reconciler) findUserHomes() ([]string, error) {
+	entries, err := os.ReadDir(r.usersDir())
+	if err != nil {
+		return nil, err
+	}
+	var homes []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") || name == "Shared" {
+			continue
+		}
+		homes = append(homes, filepath.Join(r.usersDir(), name))
+	}
+	if len(homes) == 0 {
+		return nil, errors.New("no user homes found")
+	}
+	return homes, nil
+}

--- a/plugins/kill-steam/internal/uninstaller/uninstaller_test.go
+++ b/plugins/kill-steam/internal/uninstaller/uninstaller_test.go
@@ -1,0 +1,94 @@
+package uninstaller
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetect_AbsentIsCheap(t *testing.T) {
+	r := &Reconciler{AppPath: filepath.Join(t.TempDir(), "does-not-exist.app")}
+	if r.Detect() {
+		t.Fatal("expected Detect() false when AppPath missing")
+	}
+	o := r.Reconcile()
+	if o.Detected || len(o.Removed) != 0 {
+		t.Fatalf("unexpected outcome on absent: %+v", o)
+	}
+}
+
+func TestReconcile_RemovesEverything(t *testing.T) {
+	root := t.TempDir()
+	// Fake "/Applications/Steam.app"
+	app := filepath.Join(root, "Apps", "Steam.app")
+	os.MkdirAll(app, 0o755)
+	os.WriteFile(filepath.Join(app, "Info.plist"), []byte("x"), 0o644)
+	// Fake users dir with two homes
+	usersDir := filepath.Join(root, "Users")
+	for _, u := range []string{"alice", "bob", ".hidden", "Shared"} {
+		os.MkdirAll(filepath.Join(usersDir, u, "Library", "Application Support"), 0o755)
+	}
+	// Drop the Steam appdata under each REAL user (alice + bob)
+	for _, u := range []string{"alice", "bob"} {
+		appdata := filepath.Join(usersDir, u, "Library", "Application Support", "Steam")
+		os.MkdirAll(filepath.Join(appdata, "steamapps", "common", "dota 2 beta"), 0o755)
+		os.WriteFile(filepath.Join(appdata, "config.vdf"), []byte("x"), 0o644)
+	}
+	// Plus a Steam LaunchAgent for alice
+	os.MkdirAll(filepath.Join(usersDir, "alice", "Library", "LaunchAgents"), 0o755)
+	os.WriteFile(
+		filepath.Join(usersDir, "alice", "Library", "LaunchAgents", "com.valvesoftware.steamclean.plist"),
+		[]byte("<?xml ?>"), 0o644)
+
+	r := &Reconciler{
+		AppPath:  app,
+		UsersDir: usersDir,
+		System:   []systemTarget{{Path: app, What: "test Steam.app"}},
+	}
+
+	o := r.Reconcile()
+	if !o.Detected {
+		t.Fatal("expected Detected=true")
+	}
+	if _, err := os.Stat(app); !os.IsNotExist(err) {
+		t.Fatalf("Steam.app must be removed: %v", err)
+	}
+	for _, u := range []string{"alice", "bob"} {
+		appdata := filepath.Join(usersDir, u, "Library", "Application Support", "Steam")
+		if _, err := os.Stat(appdata); !os.IsNotExist(err) {
+			t.Fatalf("%s appdata must be removed", u)
+		}
+	}
+	aliceAgent := filepath.Join(usersDir, "alice", "Library", "LaunchAgents", "com.valvesoftware.steamclean.plist")
+	if _, err := os.Stat(aliceAgent); !os.IsNotExist(err) {
+		t.Fatal("alice's Steam LaunchAgent must be removed")
+	}
+	// Hidden + Shared dirs were NOT iterated (we'd have failed to remove
+	// nonexistent paths under them, that's fine — just sanity-check we
+	// didn't crash). At least one removal recorded:
+	if len(o.Removed) < 3 {
+		t.Fatalf("expected ≥3 removals, got %d: %+v", len(o.Removed), o.Removed)
+	}
+}
+
+func TestReconcile_IdempotentAfterRemoval(t *testing.T) {
+	root := t.TempDir()
+	app := filepath.Join(root, "Steam.app")
+	os.MkdirAll(app, 0o755)
+	r := &Reconciler{
+		AppPath:  app,
+		UsersDir: filepath.Join(root, "Users"),
+		System:   []systemTarget{{Path: app, What: "test"}},
+	}
+	os.MkdirAll(filepath.Join(root, "Users", "alice"), 0o755)
+	// First pass: removes
+	o1 := r.Reconcile()
+	if !o1.Detected || len(o1.Removed) == 0 {
+		t.Fatalf("first pass should remove: %+v", o1)
+	}
+	// Second pass: noop (Steam.app gone => Detect=false)
+	o2 := r.Reconcile()
+	if o2.Detected {
+		t.Fatalf("second pass should be noop, got: %+v", o2)
+	}
+}

--- a/plugins/kill-steam/plugin.json
+++ b/plugins/kill-steam/plugin.json
@@ -1,13 +1,13 @@
 {
   "id": "kill-steam",
-  "name": "Kill Steam",
-  "version": "1.0.0",
+  "name": "Kill Steam (process + on-disk uninstall)",
+  "version": "2.0.0",
   "type": "job",
   "runtime": "native_binary",
   "protocol_version": "1",
   "entrypoint": "./kill-steam",
   "supported_os": ["darwin"],
   "supported_arch": ["arm64", "amd64"],
-  "required_privilege": "user",
-  "run_as": "current_user"
+  "required_privilege": "system",
+  "run_as": "system"
 }


### PR DESCRIPTION
## Why

The dns-block plugin shipped in platform v0.8.0 only manages `/etc/hosts` — which **modern browsers (DoH) and the Steam client (direct CDN IPs) both bypass**. Demonstrated on this Mac: Steam + Dota worked despite a 68-entry `/etc/hosts` block, because Cloudflare WARP + NextDNS were intercepting DNS upstream of the hosts file.

The actually-effective Steam block is "the app and appdata don't exist on disk, and get re-uninstalled within one cron tick if reinstalled." That's this plugin.

## What

- **New `internal/uninstaller`** (pure, tested): `Reconciler` with injectable `AppPath` + `UsersDir` for testability. `Detect()` = one `os.Stat`; `Reconcile()` only fires the expensive sweep when Steam.app is actually present.
- **System targets**: `/Applications/Steam.app`.
- **Per-user targets** (under every real user's home — skips dotted dirs + Shared):
  - `Library/Application Support/Steam` (includes Dota 2 beta — typically 60+ GB)
  - `Library/Caches/com.valvesoftware.steam` / `Library/Caches/Steam`
  - `Library/Logs/Steam`
  - `Library/Saved Application State/com.valvesoftware.steam.savedState`
  - `Library/LaunchAgents/com.valvesoftware.steamclean.plist` (Steam's auto-reinstall vector)
  - `Library/Preferences/com.valvesoftware.steam.plist`
  - `Library/Logs/DiagnosticReports/dota2-*.ips` (best-effort glob)
- **`cmd/main.go`**: Phase 1 kills processes (existing `killer`), Phase 2 runs `uninstaller.Reconcile()`. Both outcomes emitted in the plugin `Result`.
- **`plugin.json`** bumped to **v2.0.0**: `required_privilege` and `run_as` are now `system` so the plugin can `rm /Applications/Steam.app` (admin-owned on most macOS installs).

## Tests (race, count=1)

- `TestDetect_AbsentIsCheap` — no Steam.app → one stat, no sweep.
- `TestReconcile_RemovesEverything` — fake `/Applications/Steam.app`, two real user homes with full Steam appdata + LaunchAgent → all gone post-reconcile.
- `TestReconcile_IdempotentAfterRemoval` — second pass is noop because Detect=false.

## Verified locally

- gofmt + vet clean
- all tests pass (race, count=1)
- plugin builds for darwin/arm64

## Out of scope (follow-ups)

- pf-firewall plugin for the network-layer block (issue to file).
- DNS-bypass detours (WARP / browser DoH) — deliberate not-in-this-PR.
- Bundling into platform release v0.9.0 — separate piece of work after merge.

## E2E plan after merge

Plant a stub `/Applications/Steam.app` (fake dir) on the running system-mode install, wait one cron tick (10s), confirm it's removed by the plugin's logs + the file vanishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)