### PR TITLE
feat(daemon): self-update — path-rotating daemon swap (defeats AMFI cache)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -44,6 +44,15 @@ var versionTagRE = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[A-Za-z0-9][A-Za-z0-9.\-
 
 func isValidVersionTag(s string) bool { return versionTagRE.MatchString(s) }
 
+// daemonVersionTagRE matches strict daemon release tags:
+// `daemon-v1.2.3` + optional pre-release/build (same shape as
+// versionTagRE, just with the `daemon-` prefix). This is the ONLY
+// shape `daemon self-update <tag>` accepts — same path-traversal
+// concern as versionTagRE.
+var daemonVersionTagRE = regexp.MustCompile(`^daemon-v\d+\.\d+\.\d+(-[A-Za-z0-9][A-Za-z0-9.\-]*)?(\+[A-Za-z0-9][A-Za-z0-9.\-]*)?$`)
+
+func isValidDaemonTag(s string) bool { return daemonVersionTagRE.MatchString(s) }
+
 func main() { os.Exit(run(os.Args[1:])) }
 
 func run(args []string) int {
@@ -67,6 +76,8 @@ func run(args []string) int {
 		return doInstall(args[1:])
 	case "uninstall":
 		return doUninstall(args[1:])
+	case "self-update":
+		return doSelfUpdate(args[1:])
 	default:
 		fmt.Fprintln(os.Stderr, "unknown command:", args[0])
 		usage()
@@ -75,7 +86,7 @@ func run(args []string) int {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: daemon run|once|update|version|install|uninstall [flags]")
+	fmt.Fprintln(os.Stderr, "usage: daemon run|once|update|version|install|uninstall|self-update [flags]")
 }
 
 type opts struct {

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -53,6 +53,16 @@ var daemonVersionTagRE = regexp.MustCompile(`^daemon-v\d+\.\d+\.\d+(-[A-Za-z0-9]
 
 func isValidDaemonTag(s string) bool { return daemonVersionTagRE.MatchString(s) }
 
+// githubRepoRE matches a plain `owner/repo` value for the --github
+// flag. The owner+repo each must be a non-empty token of allowed chars
+// — anything fancier (paths, query strings, URL fragments) is rejected
+// upfront so the value can't subvert the GH API URL it's interpolated
+// into: `https://api.github.com/repos/<owner>/<repo>/releases/...`.
+// (Security-reviewer MEDIUM #2.)
+var githubRepoRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+func isValidGithubRepo(s string) bool { return githubRepoRE.MatchString(s) }
+
 func main() { os.Exit(run(os.Args[1:])) }
 
 func run(args []string) int {

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/osadapter"
 	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
 )
 
 // daemonAssetFetcher is the verified-download seam used by self-update.
@@ -89,6 +90,16 @@ func parseSelfUpdate(args []string) (selfUpdateOpts, int) {
 			"self-update: tag must match `daemon-vX.Y.Z` (got:", tag+")")
 		return selfUpdateOpts{}, 2
 	}
+	// Security-reviewer MEDIUM #2: --github is interpolated into the
+	// GH API URL `repos/<owner>/<repo>/releases/tags/<tag>`. Reject
+	// anything that's not a plain `owner/repo` to defeat URL-fragment
+	// injection. (Public-key trust still gates the asset, but tightening
+	// here gives a clear error instead of a confusing 404.)
+	if !isValidGithubRepo(*gh) {
+		fmt.Fprintln(os.Stderr,
+			"self-update: --github must be `owner/repo` (got:", *gh+")")
+		return selfUpdateOpts{}, 2
+	}
 	return selfUpdateOpts{
 		tag: tag, workdir: *wd, github: *gh, assetPattern: *ap,
 		releaseDir: *rd, dryRun: *dr, keepOld: *ko,
@@ -102,7 +113,7 @@ func runSelfUpdate(o selfUpdateOpts) int {
 	// installed with the OTHER mode — the operator must invoke with
 	// the matching privilege.
 	invokeMode := mode.Resolve()
-	cur, err := osadapter.FindCurrentInstall(invokeMode)
+	cur, err := osadapter.FindCurrentInstall(invokeMode, sig.VerifyFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "self-update: discover install:", err)
 		return 1
@@ -115,8 +126,10 @@ func runSelfUpdate(o selfUpdateOpts) int {
 		}
 		fmt.Fprintf(os.Stderr,
 			"self-update: no %s-mode install found in %s.\n"+
-				"  Hint: a %s-mode install is removed with sudo; a user-mode install without.\n",
-			invokeMode, otherDirHint(invokeMode), other)
+				"  Hint: try %s mode (look in %s); %s-mode requires %s.\n",
+			invokeMode, otherDirHint(invokeMode),
+			other, otherDirHint(other),
+			other, sudoHintFor(other))
 		return 1
 	}
 
@@ -232,6 +245,16 @@ func printDryRun(cur osadapter.CurInstall, newSpec osadapter.Spec, o selfUpdateO
 func otherDirHint(m mode.Mode) string {
 	home, _ := os.UserHomeDir()
 	return mode.LaunchDir(m, home)
+}
+
+// sudoHintFor names the privilege needed to manage a given install
+// mode — used in the "no install found" error message so the operator
+// knows whether to re-invoke with or without sudo.
+func sudoHintFor(m mode.Mode) string {
+	if m == mode.System {
+		return "sudo"
+	}
+	return "no sudo"
 }
 
 // defaultInterval is the reconcile interval baked into self-update's

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -133,14 +133,23 @@ func runSelfUpdate(o selfUpdateOpts) int {
 		return 1
 	}
 
-	// Recover workdir: explicit --workdir overrides; otherwise we
-	// trust the value baked into the install's plist argv.
+	// Recover workdir: prefer the value baked into the install's plist
+	// argv (authoritative). --workdir is accepted ONLY as a fallback
+	// when discovery couldn't recover it — never as an override.
+	// Copilot #5: allowing override risked silent workdir migration
+	// that strands state.db / version.json / bin/v* in the old dir.
 	workdir := cur.Workdir
-	if o.workdir != "" {
-		workdir = o.workdir
-	}
 	if workdir == "" {
-		fmt.Fprintln(os.Stderr, "self-update: could not recover --workdir from install; pass --workdir")
+		if o.workdir == "" {
+			fmt.Fprintln(os.Stderr, "self-update: could not recover --workdir from install; pass --workdir")
+			return 1
+		}
+		workdir = o.workdir
+	} else if o.workdir != "" && o.workdir != workdir {
+		fmt.Fprintf(os.Stderr,
+			"self-update: --workdir=%q disagrees with discovered install workdir=%q; "+
+				"refusing to migrate workdir (omit --workdir to use the discovered one)\n",
+			o.workdir, workdir)
 		return 1
 	}
 
@@ -189,13 +198,21 @@ func runSelfUpdate(o selfUpdateOpts) int {
 		return 1
 	}
 	newBase := relocate.RandomBase()
+	// Preserve the install-time --interval instead of clobbering it
+	// with the package default. Operators who tuned it (e.g. via
+	// `daemon install --interval 30s`) shouldn't see cadence change
+	// silently across self-update. Copilot #6.
+	interval := cur.Interval
+	if interval == 0 {
+		interval = defaultInterval
+	}
 	newSpec := osadapter.Spec{
 		Mode:     invokeMode,
 		SelfPath: newPath,
 		Workdir:  workdir,
 		Github:   o.github,
 		Asset:    asset,
-		Interval: defaultInterval,
+		Interval: interval,
 		Base:     newBase,
 	}
 

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/fetch"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+	"github.com/eliteGoblin/focusd/daemon/internal/osadapter"
+	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
+)
+
+// daemonAssetFetcher is the verified-download seam used by self-update.
+// Both fetch.GitHub and fetch.Local satisfy it; the CLI picks one
+// based on whether --release-dir is set.
+type daemonAssetFetcher interface {
+	DownloadVerified(ctx context.Context, tag, asset, dstPath string) error
+}
+
+// selfUpdateOpts is what doSelfUpdate parses out of argv. Extracted so
+// the CLI test can build it directly and exercise runSelfUpdate
+// without round-tripping through flag.NewFlagSet.
+type selfUpdateOpts struct {
+	tag             string
+	workdir         string
+	github          string
+	assetPattern    string
+	releaseDir      string
+	dryRun          bool
+	keepOld         bool
+	healthyTimeout  time.Duration
+	probeInterval   time.Duration
+}
+
+// doSelfUpdate is the CLI dispatch for `daemon self-update`. macOS-
+// only (launchd lifecycle); Linux/Windows reach the same gate.
+//
+// Surface (architect-approved):
+//
+//	daemon self-update <daemon-tag> [--workdir D] [--github owner/repo]
+//	  [--asset-pattern PAT] [--release-dir D] [--dry-run] [--keep-old]
+//	  [--healthy-timeout 15s] [--probe-interval 1s]
+//
+// The tag must match `^daemon-v\d+\.\d+\.\d+(-…)?$` — anything else
+// is rejected upfront (same path-traversal concern as `daemon update`).
+func doSelfUpdate(args []string) int {
+	if !osSupportsLaunchd() {
+		fmt.Fprintln(os.Stderr, "self-update: unsupported on", runtime.GOOS, "(darwin/launchd only)")
+		return 1
+	}
+	o, code := parseSelfUpdate(args)
+	if code != 0 {
+		return code
+	}
+	return runSelfUpdate(o)
+}
+
+func parseSelfUpdate(args []string) (selfUpdateOpts, int) {
+	fs := flag.NewFlagSet("self-update", flag.ContinueOnError)
+	wd := fs.String("workdir", "", "override discovered workdir")
+	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo for releases")
+	ap := fs.String("asset-pattern", "daemon-darwin-{arch}",
+		"asset name template — {arch} substituted with runtime.GOARCH")
+	rd := fs.String("release-dir", "", "use a local fake release dir instead of GitHub (testing)")
+	dr := fs.Bool("dry-run", false, "fetch + verify + render, don't bootstrap; print intended ops")
+	ko := fs.Bool("keep-old", false, "leave old plists + binary on disk after success")
+	ht := fs.Duration("healthy-timeout", 15*time.Second, "post-bootstrap health poll window")
+	pi := fs.Duration("probe-interval", 1*time.Second, "health poll cadence")
+	if err := fs.Parse(args); err != nil {
+		// flag already printed; return non-zero so caller exits.
+		return selfUpdateOpts{}, 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr,
+			"self-update: exactly one positional argument required (daemon-vX.Y.Z)")
+		fs.Usage()
+		return selfUpdateOpts{}, 2
+	}
+	tag := fs.Arg(0)
+	if !isValidDaemonTag(tag) {
+		fmt.Fprintln(os.Stderr,
+			"self-update: tag must match `daemon-vX.Y.Z` (got:", tag+")")
+		return selfUpdateOpts{}, 2
+	}
+	return selfUpdateOpts{
+		tag: tag, workdir: *wd, github: *gh, assetPattern: *ap,
+		releaseDir: *rd, dryRun: *dr, keepOld: *ko,
+		healthyTimeout: *ht, probeInterval: *pi,
+	}, 0
+}
+
+func runSelfUpdate(o selfUpdateOpts) int {
+	// A. Pre-flight: find the current install at the invocation's
+	// mode (sudo → system, else user). Reject if the daemon was
+	// installed with the OTHER mode — the operator must invoke with
+	// the matching privilege.
+	invokeMode := mode.Resolve()
+	cur, err := osadapter.FindCurrentInstall(invokeMode)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "self-update: discover install:", err)
+		return 1
+	}
+	if cur.BinaryPath == "" {
+		// Maybe it's installed under the OTHER mode — give a clear hint.
+		other := mode.System
+		if invokeMode == mode.System {
+			other = mode.User
+		}
+		fmt.Fprintf(os.Stderr,
+			"self-update: no %s-mode install found in %s.\n"+
+				"  Hint: a %s-mode install is removed with sudo; a user-mode install without.\n",
+			invokeMode, otherDirHint(invokeMode), other)
+		return 1
+	}
+
+	// Recover workdir: explicit --workdir overrides; otherwise we
+	// trust the value baked into the install's plist argv.
+	workdir := cur.Workdir
+	if o.workdir != "" {
+		workdir = o.workdir
+	}
+	if workdir == "" {
+		fmt.Fprintln(os.Stderr, "self-update: could not recover --workdir from install; pass --workdir")
+		return 1
+	}
+
+	// Resolve asset name: {arch} → runtime.GOARCH. Keep this dumb;
+	// we accept any asset pattern the caller provides because the
+	// signature trailer is what actually gates trust.
+	asset := strings.ReplaceAll(o.assetPattern, "{arch}", runtime.GOARCH)
+
+	// B. Download + verify into a temp file inside the workdir (so
+	// the os.Rename in step C is on the same filesystem).
+	tmpDir := filepath.Join(workdir, ".tmp")
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
+		fmt.Fprintln(os.Stderr, "self-update: mkdir tmp:", err)
+		return 1
+	}
+	tmpDL := filepath.Join(tmpDir, "daemon-dl-"+relocate.RandomBinaryName())
+	defer os.Remove(tmpDL)
+
+	var f daemonAssetFetcher
+	if o.releaseDir != "" {
+		f = &fetch.Local{Dir: o.releaseDir}
+	} else {
+		f = &fetch.GitHub{Repo: o.github, Asset: asset}
+	}
+	ctx := context.Background()
+	if err := f.DownloadVerified(ctx, o.tag, asset, tmpDL); err != nil {
+		fmt.Fprintln(os.Stderr, "self-update: download:", err)
+		return 1
+	}
+	newBin, rerr := os.ReadFile(tmpDL)
+	if rerr != nil {
+		fmt.Fprintln(os.Stderr, "self-update: read verified bytes:", rerr)
+		return 1
+	}
+
+	// Build the new Spec: rotated SelfPath + new Base; same workdir.
+	// Preserve install-mode + non-disguised dev fallback handling by
+	// reusing osadapter.Spec.Label downstream — the new Base is the
+	// disguised label namespace that lets old/new plists coexist
+	// during the swap.
+	newPath := filepath.Join(workdir, relocate.RandomBinaryName())
+	if newPath == cur.BinaryPath {
+		// Defensive: 4-hex collision is astronomical but explicit
+		// safety is cheaper than a silent AMFI block.
+		fmt.Fprintln(os.Stderr, "self-update: rotated path matches current (try again)")
+		return 1
+	}
+	newBase := relocate.RandomBase()
+	newSpec := osadapter.Spec{
+		Mode:     invokeMode,
+		SelfPath: newPath,
+		Workdir:  workdir,
+		Github:   o.github,
+		Asset:    asset,
+		Interval: defaultInterval,
+		Base:     newBase,
+	}
+
+	if o.dryRun {
+		printDryRun(cur, newSpec, o)
+		return 0
+	}
+
+	if err := osadapter.SelfUpdateProd(cur, newSpec, newBin,
+		o.healthyTimeout, o.probeInterval, o.keepOld); err != nil {
+		fmt.Fprintln(os.Stderr, "self-update:", err)
+		return 1
+	}
+	fmt.Printf("self-update ok: %s → %s (new base=%s)\n", cur.BinaryPath, newPath, newBase)
+	return 0
+}
+
+// printDryRun emits the intended operations for the operator to
+// review without performing any launchctl or filesystem mutations.
+func printDryRun(cur osadapter.CurInstall, newSpec osadapter.Spec, o selfUpdateOpts) {
+	w := io.Writer(os.Stdout)
+	fmt.Fprintln(w, "self-update --dry-run")
+	fmt.Fprintln(w, "  tag           ", o.tag)
+	fmt.Fprintln(w, "  current binary", cur.BinaryPath)
+	fmt.Fprintln(w, "  current base  ", cur.Base)
+	fmt.Fprintln(w, "  current labels", strings.Join(cur.Labels, ", "))
+	fmt.Fprintln(w, "  new binary    ", newSpec.SelfPath)
+	fmt.Fprintln(w, "  new base      ", newSpec.Base)
+	fmt.Fprintln(w, "  new labels    ",
+		newSpec.Label(osadapter.RoleA), newSpec.Label(osadapter.RoleB), newSpec.Label(osadapter.RoleEnsure))
+	fmt.Fprintln(w, "  workdir       ", newSpec.Workdir, "(unchanged)")
+	fmt.Fprintln(w, "  --keep-old    ", o.keepOld)
+	fmt.Fprintln(w, "  health timeout", o.healthyTimeout)
+	fmt.Fprintln(w, "  probe interval", o.probeInterval)
+	fmt.Fprintln(w, "intended ops (in order):")
+	fmt.Fprintln(w, "  C. place new binary at", newSpec.SelfPath)
+	fmt.Fprintln(w, "  D. write 3 new plists at new label filenames")
+	fmt.Fprintln(w, "  E. bootstrap new A, B, ensure")
+	fmt.Fprintln(w, "  F. health-poll (2 consecutive ok required)")
+	fmt.Fprintln(w, "  G. bootout OLD in REVERSE order (ensure → B → A)")
+	fmt.Fprintln(w, "  H. rm old plists + old binary", "(skipped if --keep-old)")
+}
+
+// otherDirHint returns the LaunchDir the operator should be looking
+// at for the OTHER mode — used in the "no install found" error path
+// to point at the alternative install location.
+func otherDirHint(m mode.Mode) string {
+	home, _ := os.UserHomeDir()
+	return mode.LaunchDir(m, home)
+}
+
+// defaultInterval is the reconcile interval baked into self-update's
+// new plists. Matches the rest of the daemon CLI's default; kept as a
+// named constant rather than a CLI flag because operators rarely need
+// to retune it and the install-time value is already baked into the
+// old plists this code is replacing.
+const defaultInterval = 10 * time.Second

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -29,15 +29,15 @@ type daemonAssetFetcher interface {
 // the CLI test can build it directly and exercise runSelfUpdate
 // without round-tripping through flag.NewFlagSet.
 type selfUpdateOpts struct {
-	tag             string
-	workdir         string
-	github          string
-	assetPattern    string
-	releaseDir      string
-	dryRun          bool
-	keepOld         bool
-	healthyTimeout  time.Duration
-	probeInterval   time.Duration
+	tag            string
+	workdir        string
+	github         string
+	assetPattern   string
+	releaseDir     string
+	dryRun         bool
+	keepOld        bool
+	healthyTimeout time.Duration
+	probeInterval  time.Duration
 }
 
 // doSelfUpdate is the CLI dispatch for `daemon self-update`. macOS-

--- a/daemon/cmd/daemon/self_update_test.go
+++ b/daemon/cmd/daemon/self_update_test.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
+)
+
+// --- pure parsing ---------------------------------------------------------
+
+func TestIsValidDaemonTag(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// happy
+		{"daemon-v0.1.0", true},
+		{"daemon-v1.2.3", true},
+		{"daemon-v10.20.30", true},
+		{"daemon-v1.2.3-rc.1", true},
+		{"daemon-v1.2.3-beta-foo", true},
+		{"daemon-v1.2.3+build.42", true},
+
+		// platform tag (rejected — wrong prefix)
+		{"v1.2.3", false},
+		// missing prefix
+		{"daemon-1.2.3", false},
+		{"", false},
+		// path traversal
+		{"daemon-v/../etc/passwd", false},
+		{"daemon-v0.1.0/extra", false},
+		{"daemon-v0.1.0 ", false},
+		{" daemon-v0.1.0", false},
+		{"daemon-v0.1.0\n", false},
+		// dangerous pre-release
+		{"daemon-v1.2.3-", false},
+		{"daemon-v1.2.3-../x", false},
+		// wrong prefix capitalization
+		{"Daemon-v1.2.3", false},
+	}
+	for _, c := range cases {
+		if got := isValidDaemonTag(c.in); got != c.want {
+			t.Errorf("isValidDaemonTag(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseSelfUpdate_RejectsBadTag(t *testing.T) {
+	_, code := parseSelfUpdate([]string{"v0.1.0"})
+	if code == 0 {
+		t.Fatal("missing daemon- prefix must be rejected")
+	}
+	_, code = parseSelfUpdate([]string{}) // no tag
+	if code == 0 {
+		t.Fatal("missing positional tag must be rejected")
+	}
+}
+
+func TestParseSelfUpdate_DefaultsAndOverrides(t *testing.T) {
+	o, code := parseSelfUpdate([]string{
+		"--release-dir", "/tmp/rel",
+		"--dry-run",
+		"--keep-old",
+		"--healthy-timeout", "5s",
+		"--probe-interval", "200ms",
+		"--asset-pattern", "daemon-darwin-{arch}",
+		"daemon-v0.1.0",
+	})
+	if code != 0 {
+		t.Fatalf("parse failed, code %d", code)
+	}
+	if o.tag != "daemon-v0.1.0" {
+		t.Errorf("tag = %q", o.tag)
+	}
+	if o.releaseDir != "/tmp/rel" {
+		t.Errorf("releaseDir = %q", o.releaseDir)
+	}
+	if !o.dryRun || !o.keepOld {
+		t.Errorf("flags not parsed: dryRun=%v keepOld=%v", o.dryRun, o.keepOld)
+	}
+	if o.healthyTimeout != 5*time.Second {
+		t.Errorf("healthyTimeout = %v", o.healthyTimeout)
+	}
+	if o.probeInterval != 200*time.Millisecond {
+		t.Errorf("probeInterval = %v", o.probeInterval)
+	}
+	if o.assetPattern != "daemon-darwin-{arch}" {
+		t.Errorf("assetPattern = %q", o.assetPattern)
+	}
+}
+
+// --- end-to-end with --release-dir + offline private key -----------------
+//
+// This test exercises `doSelfUpdate` against a fake install written to
+// a temp HOME, with a locally-signed release served via --release-dir.
+// It requires the offline private key (~/.creds/…) or
+// $FOCUSD_ED25519_PRIVATE_KEY; otherwise it skips — same convention as
+// internal/sig's cross-check test.
+//
+// The test uses --dry-run to avoid actually shelling launchctl: a real
+// `launchctl bootstrap` on a CI macOS runner is unreliable and not
+// what we're proving here. (The orchestration itself is covered by
+// the osadapter table tests.)
+func TestDoSelfUpdate_DryRunEndToEnd(t *testing.T) {
+	// Load the offline private key BEFORE we change HOME, since it
+	// lives under the operator's real ~/.creds.
+	priv := loadOfflinePrivKey()
+	if priv == nil {
+		t.Skip("offline private key not available; skipping E2E (orchestration is unit-tested separately)")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Build a "current install": one disguised binary (signed) +
+	// three plists under ~/Library/LaunchAgents whose Label shares a
+	// base and whose ProgramArguments[0] points at the binary.
+	supportRoot := filepath.Join(home, "Library", "Application Support")
+	workdir := filepath.Join(supportRoot, ".com.apple.metadata.OLD")
+	if err := os.MkdirAll(workdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	curBin := filepath.Join(workdir, "com.apple.metadata.helper.OLD")
+	writeSigned(t, priv, curBin, []byte("OLD-DAEMON-BYTES"))
+
+	laDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, role := range []string{"a", "b", "ensure"} {
+		label := "com.apple.metadata.OLD." + role
+		plist := makePlist(label, curBin, workdir)
+		if err := os.WriteFile(filepath.Join(laDir, label+".plist"), []byte(plist), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Stage a fake release: <relDir>/<tag>/<asset> with signed bytes.
+	relDir := t.TempDir()
+	tag := "daemon-v0.1.0"
+	asset := "daemon-darwin-" + runtimeArch()
+	if err := os.MkdirAll(filepath.Join(relDir, tag), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSigned(t, priv, filepath.Join(relDir, tag, asset), []byte("NEW-DAEMON-BYTES"))
+
+	// Capture stdout so we can assert dry-run printed the expected plan.
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	code := doSelfUpdate([]string{
+		"--release-dir", relDir,
+		"--workdir", workdir,
+		"--asset-pattern", "daemon-darwin-{arch}",
+		"--dry-run",
+		tag,
+	})
+	if code != 0 {
+		t.Fatalf("doSelfUpdate dry-run returned %d", code)
+	}
+
+	out := stdout()
+	for _, want := range []string{
+		"self-update --dry-run",
+		"current binary",
+		curBin,
+		"new binary",
+		"intended ops",
+		"bootstrap new A, B, ensure",
+		"REVERSE order (ensure",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// The dry-run path must have rejected the AMFI same-path collision
+	// safety check (which would only fire on a 4-hex collision) — no
+	// actual mutation should have happened: launchd unaware, plists +
+	// binary still where we put them.
+	if _, err := os.Stat(curBin); err != nil {
+		t.Errorf("dry-run must not touch old binary: %v", err)
+	}
+	for _, role := range []string{"a", "b", "ensure"} {
+		pp := filepath.Join(laDir, "com.apple.metadata.OLD."+role+".plist")
+		if _, err := os.Stat(pp); err != nil {
+			t.Errorf("dry-run must not remove old plist %s: %v", pp, err)
+		}
+	}
+}
+
+func TestDoSelfUpdate_RejectsBadTagBeforeIO(t *testing.T) {
+	// Even on a clean machine with no install, a bad tag must be
+	// rejected before any filesystem or network I/O is attempted.
+	t.Setenv("HOME", t.TempDir())
+	code := doSelfUpdate([]string{"v0.1.0"})
+	if code == 0 {
+		t.Fatal("missing daemon- prefix must be rejected")
+	}
+	code = doSelfUpdate([]string{"daemon-v/../etc/passwd"})
+	if code == 0 {
+		t.Fatal("path-traversal in tag must be rejected")
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+// loadOfflinePrivKey returns the focusd offline Ed25519 PKCS#8 PEM
+// private key, or nil if it isn't available. Caller MUST invoke this
+// before any t.Setenv("HOME", …) — once HOME is rewritten,
+// os.UserHomeDir() returns the wrong path.
+func loadOfflinePrivKey() []byte {
+	if v := os.Getenv("FOCUSD_ED25519_PRIVATE_KEY"); v != "" {
+		return []byte(v)
+	}
+	if h, err := os.UserHomeDir(); err == nil {
+		p := filepath.Join(h, ".creds", "focusd_ed25519_private.pem")
+		if b, err := os.ReadFile(p); err == nil {
+			return b
+		}
+	}
+	return nil
+}
+
+func writeSigned(t *testing.T, privPEM []byte, outPath string, prog []byte) {
+	t.Helper()
+	inPath := outPath + ".unsigned"
+	if err := os.WriteFile(inPath, prog, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(inPath)
+	if err := sig.SignFile(inPath, outPath, privPEM); err != nil {
+		t.Fatalf("sign %s: %v", outPath, err)
+	}
+}
+
+func makePlist(label, bin, workdir string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>` + label + `</string>
+  <key>ProgramArguments</key><array>
+    <string>` + bin + `</string>
+    <string>run</string>
+    <string>--workdir</string>
+    <string>` + workdir + `</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+</dict></plist>
+`
+}
+
+func runtimeArch() string {
+	return runtime.GOARCH
+}
+
+func captureStdout(t *testing.T) (read func() string, restore func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	doneCh := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				doneCh <- sb.String()
+				return
+			}
+		}
+	}()
+	read = func() string {
+		w.Close()
+		return <-doneCh
+	}
+	restore = func() { os.Stdout = orig }
+	return
+}

--- a/daemon/internal/fetch/github.go
+++ b/daemon/internal/fetch/github.go
@@ -68,15 +68,31 @@ func (g *GitHub) ResolveLatest(ctx context.Context) (string, error) {
 	return rel.TagName, nil
 }
 
+// EnsureBinary downloads + Ed25519-verifies the configured asset for
+// version and places it at st.BinPath(version). Thin wrapper around
+// DownloadVerified, kept so existing reconcile callers don't change.
 func (g *GitHub) EnsureBinary(ctx context.Context, st *core.Store, version string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", g.Repo, version)
+	return g.DownloadVerified(ctx, version, g.Asset, st.BinPath(version))
+}
+
+// DownloadVerified fetches asset `asset` from release `tag` of g.Repo,
+// Ed25519-verifies it, and atomically writes the verified bytes (mode
+// 0755) to dstPath. Returns nil only when the bytes at dstPath are
+// signed by the embedded focusd public key.
+//
+// Used by both `daemon run` (place into <workdir>/bin/<v>/platform via
+// EnsureBinary) and `daemon self-update` (place at a new rotated
+// disguised binary basename in <workdir>). Pure boundary primitive —
+// no launchd, no relocation, no Spec.
+func (g *GitHub) DownloadVerified(ctx context.Context, tag, asset, dstPath string) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", g.Repo, tag)
 	resp, err := g.get(ctx, url)
 	if err != nil {
-		return fmt.Errorf("fetch/github: release %s: %w", version, err)
+		return fmt.Errorf("fetch/github: release %s: %w", tag, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("fetch/github: release %s status %d", version, resp.StatusCode)
+		return fmt.Errorf("fetch/github: release %s status %d", tag, resp.StatusCode)
 	}
 	var rel ghRelease
 	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
@@ -84,13 +100,13 @@ func (g *GitHub) EnsureBinary(ctx context.Context, st *core.Store, version strin
 	}
 	dlURL := ""
 	for _, a := range rel.Assets {
-		if a.Name == g.Asset {
+		if a.Name == asset {
 			dlURL = a.URL
 			break
 		}
 	}
 	if dlURL == "" {
-		return fmt.Errorf("fetch/github: asset %q not in release %s", g.Asset, version)
+		return fmt.Errorf("fetch/github: asset %q not in release %s", asset, tag)
 	}
 
 	tmp, err := os.CreateTemp("", "focusd-dl-*")
@@ -133,7 +149,7 @@ func (g *GitHub) EnsureBinary(ctx context.Context, st *core.Store, version strin
 		return fmt.Errorf("fetch/github: verify: %w", err)
 	}
 	if !ok {
-		return fmt.Errorf("fetch/github: %s failed signature verification — refusing", version)
+		return fmt.Errorf("fetch/github: %s failed signature verification — refusing", tag)
 	}
-	return placeVerified(tmpPath, st.BinPath(version))
+	return placeVerified(tmpPath, dstPath)
 }

--- a/daemon/internal/fetch/local.go
+++ b/daemon/internal/fetch/local.go
@@ -36,16 +36,28 @@ func (l *Local) ResolveLatest(context.Context) (string, error) {
 	return v, nil
 }
 
-func (l *Local) EnsureBinary(_ context.Context, st *core.Store, version string) error {
-	src := filepath.Join(l.Dir, version, "platform")
+func (l *Local) EnsureBinary(ctx context.Context, st *core.Store, version string) error {
+	// EnsureBinary is the platform-update path; the asset filename
+	// here is hardcoded "platform" (one per <version>). Self-update
+	// can route through DownloadVerified with a custom dst.
+	return l.DownloadVerified(ctx, version, "platform", st.BinPath(version))
+}
+
+// DownloadVerified reads <Dir>/<tag>/<asset>, Ed25519-verifies it, and
+// writes the verified bytes atomically (mode 0o755) to dstPath. This
+// is the local-test counterpart to GitHub.DownloadVerified — same
+// primitive shape so `daemon self-update --release-dir <fake>` works
+// without network.
+func (l *Local) DownloadVerified(_ context.Context, tag, asset, dstPath string) error {
+	src := filepath.Join(l.Dir, tag, asset)
 	ok, err := sig.VerifyFile(src)
 	if err != nil {
 		return fmt.Errorf("fetch/local: verify %s: %w", src, err)
 	}
 	if !ok {
-		return fmt.Errorf("fetch/local: %s failed signature verification — refusing", version)
+		return fmt.Errorf("fetch/local: %s failed signature verification — refusing", tag)
 	}
-	return placeVerified(src, st.BinPath(version))
+	return placeVerified(src, dstPath)
 }
 
 // placeVerified copies an already-verified file to dst atomically with

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -3,6 +3,7 @@
 package osadapter
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -121,12 +122,20 @@ type CurInstall struct {
 // All three mesh entries must agree on the same binary path and the
 // same disguised label base; otherwise the function returns whatever
 // it could parse and the caller decides.
-// verifyFn is the verifier seam — production uses sig.VerifyFile (the
-// real Ed25519 check against the embedded public key); tests override
-// it to avoid needing the offline private key in CI.
-var verifyFn = sig.VerifyFile
+// Verifier is the signature-check seam — production passes sig.VerifyFile
+// (the real Ed25519 check against the embedded public key); tests pass
+// a fake to avoid needing the offline private key in CI. Replaces the
+// prior package-global `verifyFn`, which was a data-race hazard if any
+// test ever ran subtests in parallel (Go-reviewer HIGH).
+type Verifier func(path string) (bool, error)
 
-func FindCurrentInstall(m mode.Mode) (CurInstall, error) {
+// FindCurrentInstall scans laDir for plists, verifies each candidate
+// binary with `verify`, and returns the install if any. Pass
+// sig.VerifyFile from production; tests pass a fake.
+func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
+	if verify == nil {
+		verify = sig.VerifyFile
+	}
 	home, _ := os.UserHomeDir()
 	laDir := mode.LaunchDir(m, home)
 	entries, rerr := os.ReadDir(laDir)
@@ -146,7 +155,7 @@ func FindCurrentInstall(m mode.Mode) (CurInstall, error) {
 		if label == "" || bin == "" {
 			continue
 		}
-		if ok, verr := verifyFn(bin); verr != nil || !ok {
+		if ok, verr := verify(bin); verr != nil || !ok {
 			continue // not a genuine focusd binary → not ours
 		}
 		// Establish the install's binary path + base from the FIRST
@@ -202,7 +211,7 @@ func workdirFromArgv(argv []string) string {
 // of a hidden install without needing the random names.
 func UninstallProd() (removed []string, err error) {
 	m := mode.Resolve()
-	cur, ferr := FindCurrentInstall(m)
+	cur, ferr := FindCurrentInstall(m, sig.VerifyFile)
 	if ferr != nil {
 		return nil, ferr
 	}
@@ -310,7 +319,7 @@ func (binPlacerFS) place(srcBytes []byte, dstPath string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := io.Copy(out, byteReader(srcBytes)); err != nil {
+	if _, err := io.Copy(out, bytes.NewReader(srcBytes)); err != nil {
 		out.Close()
 		os.Remove(tmp)
 		return err
@@ -327,19 +336,6 @@ func (binPlacerFS) remove(path string) error {
 		return err
 	}
 	return nil
-}
-
-// byteReader is a tiny io.Reader over a []byte without pulling in
-// bytes.NewReader at the call site — kept inline so binPlacer stays
-// stdlib-shaped and dep-free.
-type byteReader []byte
-
-func (b byteReader) Read(p []byte) (int, error) {
-	if len(b) == 0 {
-		return 0, io.EOF
-	}
-	n := copy(p, b)
-	return n, nil
 }
 
 // SelfUpdateProd is the darwin entry-point that wires the real launchd

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -86,57 +86,180 @@ func modeFromTestFlag(testMode bool) mode.Mode {
 	return mode.Resolve()
 }
 
-// UninstallProd removes a disguised user/system install whose labels are
-// randomized/unknown. It scans the launch dir for the current mode
-// (resolved from euid: sudo → /Library/LaunchDaemons, else
-// ~/Library/LaunchAgents) and treats a plist as "ours" iff the binary it
-// launches passes Ed25519 verification with the embedded public key (the
-// design's signature recognition), then bootout + rm + pkill. Owner-
-// driven teardown of a hidden install without needing the random names.
-func UninstallProd() (removed []string, err error) {
-	m := mode.Resolve()
+// CurInstall describes a discovered, on-disk focusd mesh install —
+// what `daemon self-update` swaps and `daemon uninstall` removes. It
+// is the owner-driven view of a disguised install whose random labels
+// and paths are NOT known a priori; everything is recovered by
+// structural scan + Ed25519 signature recognition.
+//
+// Named CurInstall (not Install) because `func Install(Spec) error`
+// already owns that identifier in this package.
+//
+// Each field is populated when the scan finds the full mesh (3 plists
+// whose Label shares the same disguised base AND whose ProgramArguments
+// point at the same Ed25519-verified binary). When the mesh is
+// incomplete the entries that were found are still returned in the
+// slices in scan order (caller decides whether that is fatal).
+type CurInstall struct {
+	Mode       mode.Mode // user | system (Test is not discovered this way)
+	Base       string    // disguised label base, e.g. "com.apple.metadata.helper.7f3a"
+	Workdir    string    // recovered from the plist's --workdir argv
+	BinaryPath string    // the ProgramArguments[0] binary path
+	PlistPaths []string  // up to 3, in scan order
+	Labels     []string  // up to 3, in scan order (aligned with PlistPaths)
+}
+
+// FindCurrentInstall scans the LaunchDir for the given mode and returns
+// the focusd install rooted there (if any). A plist is treated as ours
+// only when ProgramArguments[0] passes Ed25519 verification with the
+// embedded public key — the design's signature recognition (see
+// daemon_design.md §6). Returns (zero, nil) when no genuine install is
+// found, an error only for filesystem failure.
+//
+// All three mesh entries must agree on the same binary path and the
+// same disguised label base; otherwise the function returns whatever
+// it could parse and the caller decides.
+// verifyFn is the verifier seam — production uses sig.VerifyFile (the
+// real Ed25519 check against the embedded public key); tests override
+// it to avoid needing the offline private key in CI.
+var verifyFn = sig.VerifyFile
+
+func FindCurrentInstall(m mode.Mode) (CurInstall, error) {
 	home, _ := os.UserHomeDir()
 	laDir := mode.LaunchDir(m, home)
 	entries, rerr := os.ReadDir(laDir)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {
-			return nil, nil
+			return CurInstall{}, nil
 		}
-		return nil, rerr
+		return CurInstall{}, rerr
 	}
+	cur := CurInstall{Mode: m}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
 			continue
 		}
 		pp := filepath.Join(laDir, e.Name())
-		label, bin := parsePlist(pp)
+		label, bin, argv := parsePlist(pp)
 		if label == "" || bin == "" {
 			continue
 		}
-		if ok, verr := sig.VerifyFile(bin); verr != nil || !ok {
+		if ok, verr := verifyFn(bin); verr != nil || !ok {
 			continue // not a genuine focusd binary → not ours
 		}
-		_ = exec.Command("pkill", "-f", bin).Run()
-		_ = launchctlCtl{m: m}.bootout(label)
-		_ = os.Remove(pp)
+		// Establish the install's binary path + base from the FIRST
+		// matched plist; subsequent matches must agree.
+		if cur.BinaryPath == "" {
+			cur.BinaryPath = bin
+		} else if cur.BinaryPath != bin {
+			continue // unrelated focusd install (different rotation)
+		}
+		base := labelBase(label)
+		if cur.Base == "" {
+			cur.Base = base
+		} else if cur.Base != base {
+			continue
+		}
+		if cur.Workdir == "" {
+			cur.Workdir = workdirFromArgv(argv)
+		}
+		cur.PlistPaths = append(cur.PlistPaths, pp)
+		cur.Labels = append(cur.Labels, label)
+	}
+	return cur, nil
+}
+
+// labelBase strips a trailing ".a"/".b"/".ensure" suffix off a launchd
+// label, returning the disguised install base.
+func labelBase(label string) string {
+	for _, suf := range []string{".a", ".b", ".ensure"} {
+		if strings.HasSuffix(label, suf) {
+			return strings.TrimSuffix(label, suf)
+		}
+	}
+	return label
+}
+
+// workdirFromArgv pulls the value following "--workdir" out of a parsed
+// argv. Returns "" when the flag is absent.
+func workdirFromArgv(argv []string) string {
+	for i, a := range argv {
+		if a == "--workdir" && i+1 < len(argv) {
+			return argv[i+1]
+		}
+		if strings.HasPrefix(a, "--workdir=") {
+			return strings.TrimPrefix(a, "--workdir=")
+		}
+	}
+	return ""
+}
+
+// UninstallProd removes a disguised user/system install whose labels are
+// randomized/unknown. It uses FindCurrentInstall for the scan, then
+// bootouts + removes plists + pkills the binary. Owner-driven teardown
+// of a hidden install without needing the random names.
+func UninstallProd() (removed []string, err error) {
+	m := mode.Resolve()
+	cur, ferr := FindCurrentInstall(m)
+	if ferr != nil {
+		return nil, ferr
+	}
+	if cur.BinaryPath == "" {
+		return nil, nil
+	}
+	// Best-effort process kill is fine for uninstall (we are tearing
+	// the whole install down, no surviving daemon will see argv overlap).
+	_ = exec.Command("pkill", "-f", cur.BinaryPath).Run()
+	c := launchctlCtl{m: m}
+	for i, label := range cur.Labels {
+		_ = c.bootout(label)
+		_ = os.Remove(cur.PlistPaths[i])
 		removed = append(removed, label)
 	}
 	return removed, nil
 }
 
-// parsePlist extracts the Label and the first ProgramArguments string
-// (the binary path) from one of our generated plists.
-func parsePlist(path string) (label, bin string) {
+// parsePlist extracts the Label, the first ProgramArguments string
+// (the binary path) and the full argv (binary path + arguments) from
+// one of our generated plists. argv[0] == bin; len(argv) == 0 on parse
+// failure.
+func parsePlist(path string) (label, bin string, argv []string) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return "", ""
+		return "", "", nil
 	}
 	s := string(b)
 	label = between(s, "<key>Label</key><string>", "</string>")
-	if i := strings.Index(s, "<key>ProgramArguments</key><array>"); i >= 0 {
-		bin = between(s[i:], "<string>", "</string>")
+	i := strings.Index(s, "<key>ProgramArguments</key><array>")
+	if i < 0 {
+		return label, "", nil
 	}
-	return label, bin
+	// Walk the inner <string>...</string> entries up to the closing
+	// </array>; preserves order and handles the "--flag value" pair
+	// form the daemon emits.
+	tail := s[i+len("<key>ProgramArguments</key><array>"):]
+	end := strings.Index(tail, "</array>")
+	if end < 0 {
+		return label, "", nil
+	}
+	inner := tail[:end]
+	for {
+		j := strings.Index(inner, "<string>")
+		if j < 0 {
+			break
+		}
+		k := strings.Index(inner[j:], "</string>")
+		if k < 0 {
+			break
+		}
+		v := strings.TrimSpace(inner[j+len("<string>") : j+k])
+		argv = append(argv, v)
+		inner = inner[j+k+len("</string>"):]
+	}
+	if len(argv) > 0 {
+		bin = argv[0]
+	}
+	return label, bin, argv
 }
 
 func between(s, a, b string) string {

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -4,10 +4,12 @@ package osadapter
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/sig"
@@ -260,6 +262,100 @@ func parsePlist(path string) (label, bin string, argv []string) {
 		bin = argv[0]
 	}
 	return label, bin, argv
+}
+
+// launchctlProber introspects launchd for the health poll. The label
+// is loaded iff `launchctl print` returns 0; a worker has a PID iff
+// the `state = …` or `pid = …` line in the print output reports one.
+type launchctlProber struct{ m mode.Mode }
+
+func (p launchctlProber) domain() string { return mode.LaunchDomain(p.m, os.Getuid()) }
+
+func (p launchctlProber) isLoaded(label string) bool {
+	return exec.Command("launchctl", "print", p.domain()+"/"+label).Run() == nil
+}
+
+func (p launchctlProber) hasPID(label string) bool {
+	out, err := exec.Command("launchctl", "print", p.domain()+"/"+label).Output()
+	if err != nil {
+		return false
+	}
+	// `launchctl print` output is verbose; look for "pid = N" (N > 0).
+	// Format: "    pid = 12345" or "state = running"+"pid = N".
+	for _, line := range strings.Split(string(out), "\n") {
+		l := strings.TrimSpace(line)
+		if strings.HasPrefix(l, "pid = ") {
+			v := strings.TrimSpace(strings.TrimPrefix(l, "pid = "))
+			if v != "" && v != "0" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// binPlacerFS writes raw bytes atomically with exec mode. On macOS the
+// Go linker's adhoc Mach-O signature is part of the file content, so a
+// plain rename of the verified bytes is enough — we do NOT shell out
+// to `codesign` here. (The CDHash is fresh because the file is a
+// fresh inode at a fresh path; that is the whole AMFI workaround.)
+type binPlacerFS struct{}
+
+func (binPlacerFS) place(srcBytes []byte, dstPath string) error {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o700); err != nil {
+		return err
+	}
+	tmp := dstPath + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, byteReader(srcBytes)); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dstPath)
+}
+
+func (binPlacerFS) remove(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// byteReader is a tiny io.Reader over a []byte without pulling in
+// bytes.NewReader at the call site — kept inline so binPlacer stays
+// stdlib-shaped and dep-free.
+type byteReader []byte
+
+func (b byteReader) Read(p []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, b)
+	return n, nil
+}
+
+// SelfUpdateProd is the darwin entry-point that wires the real launchd
+// controller + plist filesystem + launchctl-print prober + atomic
+// binary placer into the pure SelfUpdate orchestration. cur is the
+// discovered current install (FindCurrentInstall); newSpec carries the
+// rotated SelfPath/Base; newBin is the verified daemon bytes.
+func SelfUpdateProd(
+	cur CurInstall, newSpec Spec, newBin []byte,
+	healthyTimeout, probeInterval time.Duration, keepOld bool,
+) error {
+	c := launchctlCtl{m: newSpec.Mode}
+	fs := laFS{m: newSpec.Mode}
+	p := launchctlProber{m: newSpec.Mode}
+	return SelfUpdate(cur, newSpec, newBin, c, fs, p, binPlacerFS{},
+		healthyTimeout, probeInterval, keepOld)
 }
 
 func between(s, a, b string) string {

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -104,12 +104,13 @@ func modeFromTestFlag(testMode bool) mode.Mode {
 // incomplete the entries that were found are still returned in the
 // slices in scan order (caller decides whether that is fatal).
 type CurInstall struct {
-	Mode       mode.Mode // user | system (Test is not discovered this way)
-	Base       string    // disguised label base, e.g. "com.apple.metadata.helper.7f3a"
-	Workdir    string    // recovered from the plist's --workdir argv
-	BinaryPath string    // the ProgramArguments[0] binary path
-	PlistPaths []string  // up to 3, in scan order
-	Labels     []string  // up to 3, in scan order (aligned with PlistPaths)
+	Mode       mode.Mode     // user | system (Test is not discovered this way)
+	Base       string        // disguised label base, e.g. "com.apple.metadata.helper.7f3a"
+	Workdir    string        // recovered from the plist's --workdir argv
+	BinaryPath string        // the ProgramArguments[0] binary path
+	Interval   time.Duration // reconcile interval recovered from --interval argv (0 if absent)
+	PlistPaths []string      // up to 3, in scan order
+	Labels     []string      // up to 3, in scan order (aligned with PlistPaths)
 }
 
 // FindCurrentInstall scans the LaunchDir for the given mode and returns
@@ -174,6 +175,9 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 		if cur.Workdir == "" {
 			cur.Workdir = workdirFromArgv(argv)
 		}
+		if cur.Interval == 0 {
+			cur.Interval = intervalFromArgv(argv)
+		}
 		cur.PlistPaths = append(cur.PlistPaths, pp)
 		cur.Labels = append(cur.Labels, label)
 	}
@@ -203,6 +207,33 @@ func workdirFromArgv(argv []string) string {
 		}
 	}
 	return ""
+}
+
+// intervalFromArgv pulls the reconcile interval following "--interval"
+// out of a parsed argv. Returns 0 when the flag is absent or the
+// value doesn't parse — caller substitutes a default. Used by
+// self-update to preserve the install-time interval across rotations
+// instead of forcing the default on every update. (Copilot #6.)
+func intervalFromArgv(argv []string) time.Duration {
+	var raw string
+	for i, a := range argv {
+		if a == "--interval" && i+1 < len(argv) {
+			raw = argv[i+1]
+			break
+		}
+		if strings.HasPrefix(a, "--interval=") {
+			raw = strings.TrimPrefix(a, "--interval=")
+			break
+		}
+	}
+	if raw == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 // UninstallProd removes a disguised user/system install whose labels are

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -37,6 +37,7 @@ type CurInstall struct {
 	Base       string
 	Workdir    string
 	BinaryPath string
+	Interval   time.Duration
 	PlistPaths []string
 	Labels     []string
 }

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -2,14 +2,30 @@
 
 package osadapter
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
 
 // ErrUnsupported: launchd lifecycle is macOS-only. Linux/Windows land
 // later behind this same package API.
 var ErrUnsupported = errors.New("osadapter: launchd lifecycle is macOS-only")
 
-func Install(Spec) error               { return ErrUnsupported }
-func Uninstall(bool) error             { return ErrUnsupported }
-func EnsureAll(Spec) ([]Role, error)   { return nil, ErrUnsupported }
-func IsLoaded(bool, Role) bool         { return false }
-func UninstallProd() ([]string, error) { return nil, ErrUnsupported }
+func Install(Spec) error                               { return ErrUnsupported }
+func Uninstall(bool) error                             { return ErrUnsupported }
+func EnsureAll(Spec) ([]Role, error)                   { return nil, ErrUnsupported }
+func IsLoaded(bool, Role) bool                         { return false }
+func UninstallProd() ([]string, error)                 { return nil, ErrUnsupported }
+func FindCurrentInstall(mode.Mode) (CurInstall, error) { return CurInstall{}, ErrUnsupported }
+
+// CurInstall mirrors the darwin definition so cross-platform code that
+// references it still compiles on non-darwin (where it is always zero).
+type CurInstall struct {
+	Mode       mode.Mode
+	Base       string
+	Workdir    string
+	BinaryPath string
+	PlistPaths []string
+	Labels     []string
+}

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -18,7 +18,13 @@ func Uninstall(bool) error                             { return ErrUnsupported }
 func EnsureAll(Spec) ([]Role, error)                   { return nil, ErrUnsupported }
 func IsLoaded(bool, Role) bool                         { return false }
 func UninstallProd() ([]string, error)                 { return nil, ErrUnsupported }
-func FindCurrentInstall(mode.Mode) (CurInstall, error) { return CurInstall{}, ErrUnsupported }
+// Verifier is the signature-check seam (no-op on non-darwin since
+// FindCurrentInstall returns ErrUnsupported here).
+type Verifier func(path string) (bool, error)
+
+func FindCurrentInstall(mode.Mode, Verifier) (CurInstall, error) {
+	return CurInstall{}, ErrUnsupported
+}
 func SelfUpdateProd(CurInstall, Spec, []byte, time.Duration, time.Duration, bool) error {
 	return ErrUnsupported
 }

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -4,6 +4,7 @@ package osadapter
 
 import (
 	"errors"
+	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 )
@@ -18,6 +19,9 @@ func EnsureAll(Spec) ([]Role, error)                   { return nil, ErrUnsuppor
 func IsLoaded(bool, Role) bool                         { return false }
 func UninstallProd() ([]string, error)                 { return nil, ErrUnsupported }
 func FindCurrentInstall(mode.Mode) (CurInstall, error) { return CurInstall{}, ErrUnsupported }
+func SelfUpdateProd(CurInstall, Spec, []byte, time.Duration, time.Duration, bool) error {
+	return ErrUnsupported
+}
 
 // CurInstall mirrors the darwin definition so cross-platform code that
 // references it still compiles on non-darwin (where it is always zero).

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -13,11 +13,12 @@ import (
 // later behind this same package API.
 var ErrUnsupported = errors.New("osadapter: launchd lifecycle is macOS-only")
 
-func Install(Spec) error                               { return ErrUnsupported }
-func Uninstall(bool) error                             { return ErrUnsupported }
-func EnsureAll(Spec) ([]Role, error)                   { return nil, ErrUnsupported }
-func IsLoaded(bool, Role) bool                         { return false }
-func UninstallProd() ([]string, error)                 { return nil, ErrUnsupported }
+func Install(Spec) error               { return ErrUnsupported }
+func Uninstall(bool) error             { return ErrUnsupported }
+func EnsureAll(Spec) ([]Role, error)   { return nil, ErrUnsupported }
+func IsLoaded(bool, Role) bool         { return false }
+func UninstallProd() ([]string, error) { return nil, ErrUnsupported }
+
 // Verifier is the signature-check seam (no-op on non-darwin since
 // FindCurrentInstall returns ErrUnsupported here).
 type Verifier func(path string) (bool, error)

--- a/daemon/internal/osadapter/find_install_test.go
+++ b/daemon/internal/osadapter/find_install_test.go
@@ -1,0 +1,164 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// TestParsePlistReturnsArgv checks that the rewritten parsePlist
+// extracts Label + ProgramArguments[0] AND the full argv (needed by
+// self-update to recover --workdir from an existing install).
+func TestParsePlistReturnsArgv(t *testing.T) {
+	dir := t.TempDir()
+	binPath := "/x/y/com.apple.metadata.helper.7f3a"
+	plistPath := filepath.Join(dir, "test.plist")
+
+	s := Spec{
+		Mode:     mode.User,
+		SelfPath: binPath,
+		Workdir:  "/some/hidden/wd",
+		Github:   "o/r",
+		Asset:    "daemon-darwin-arm64",
+		Interval: 10 * time.Second,
+		Base:     "com.apple.metadata.helper.7f3a",
+	}
+	if err := os.WriteFile(plistPath, []byte(Plist(s, RoleA)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	label, bin, argv := parsePlist(plistPath)
+	if label != "com.apple.metadata.helper.7f3a.a" {
+		t.Fatalf("label = %q", label)
+	}
+	if bin != binPath {
+		t.Fatalf("bin = %q, want %q", bin, binPath)
+	}
+	if len(argv) == 0 || argv[0] != binPath {
+		t.Fatalf("argv[0] = %v, want %q", argv, binPath)
+	}
+	if got := workdirFromArgv(argv); got != "/some/hidden/wd" {
+		t.Fatalf("workdirFromArgv = %q, want /some/hidden/wd", got)
+	}
+}
+
+func TestWorkdirFromArgvBothForms(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{"--workdir VAL", []string{"/bin/x", "--workdir", "/wd"}, "/wd"},
+		{"--workdir=VAL", []string{"/bin/x", "--workdir=/wd"}, "/wd"},
+		{"absent", []string{"/bin/x", "--github", "o/r"}, ""},
+		{"dangling", []string{"/bin/x", "--workdir"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := workdirFromArgv(c.argv); got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestLabelBaseStripsRoleSuffix(t *testing.T) {
+	cases := map[string]string{
+		"com.apple.metadata.helper.7f3a.a":      "com.apple.metadata.helper.7f3a",
+		"com.apple.metadata.helper.7f3a.b":      "com.apple.metadata.helper.7f3a",
+		"com.apple.metadata.helper.7f3a.ensure": "com.apple.metadata.helper.7f3a",
+		"com.something.unrelated":               "com.something.unrelated",
+	}
+	for in, want := range cases {
+		if got := labelBase(in); got != want {
+			t.Errorf("labelBase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestFindCurrentInstallHappyPath writes the 3 mesh plists into a
+// per-test "launch dir" (overridden via HOME), stubs the verifier to
+// accept the install's binary, and asserts FindCurrentInstall recovers
+// {Base, Workdir, BinaryPath, 3 PlistPaths/Labels}.
+func TestFindCurrentInstallHappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	laDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := filepath.Join(home, "hidden", "com.apple.metadata.helper.7f3a")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wd := filepath.Join(home, "Library", "Application Support", ".com.apple.metadata.7f3a")
+	s := Spec{
+		Mode: mode.User, SelfPath: binPath, Workdir: wd,
+		Github: "o/r", Asset: "daemon-darwin-arm64",
+		Interval: 10 * time.Second, Base: "com.apple.metadata.helper.7f3a",
+	}
+	for _, r := range AllRoles {
+		pp := filepath.Join(laDir, s.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(s, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Add an unrelated plist that should be ignored (different binary,
+	// not signed by the focusd key — but our stubbed verifier accepts
+	// only the install's binary).
+	other := filepath.Join(laDir, "com.unrelated.thing.plist")
+	if err := os.WriteFile(other, []byte("<plist></plist>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub verifyFn to accept ONLY the install's binary.
+	orig := verifyFn
+	verifyFn = func(p string) (bool, error) { return p == binPath, nil }
+	defer func() { verifyFn = orig }()
+
+	cur, err := FindCurrentInstall(mode.User)
+	if err != nil {
+		t.Fatalf("FindCurrentInstall: %v", err)
+	}
+	if cur.BinaryPath != binPath {
+		t.Errorf("BinaryPath = %q, want %q", cur.BinaryPath, binPath)
+	}
+	if cur.Base != "com.apple.metadata.helper.7f3a" {
+		t.Errorf("Base = %q", cur.Base)
+	}
+	if cur.Workdir != wd {
+		t.Errorf("Workdir = %q, want %q", cur.Workdir, wd)
+	}
+	if len(cur.PlistPaths) != 3 || len(cur.Labels) != 3 {
+		t.Fatalf("want 3 plists+labels, got %d/%d", len(cur.PlistPaths), len(cur.Labels))
+	}
+	// Aligned: every label's plist path actually exists.
+	for i, pp := range cur.PlistPaths {
+		if !strings.HasSuffix(pp, cur.Labels[i]+".plist") {
+			t.Errorf("plist[%d]=%q does not match label %q", i, pp, cur.Labels[i])
+		}
+	}
+}
+
+func TestFindCurrentInstallNoneInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// LaunchAgents directory doesn't exist → zero install, nil error.
+	cur, err := FindCurrentInstall(mode.User)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if cur.BinaryPath != "" || len(cur.PlistPaths) != 0 {
+		t.Fatalf("expected empty CurInstall, got %+v", cur)
+	}
+}

--- a/daemon/internal/osadapter/find_install_test.go
+++ b/daemon/internal/osadapter/find_install_test.go
@@ -3,6 +3,7 @@
 package osadapter
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,12 +122,11 @@ func TestFindCurrentInstallHappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Stub verifyFn to accept ONLY the install's binary.
-	orig := verifyFn
-	verifyFn = func(p string) (bool, error) { return p == binPath, nil }
-	defer func() { verifyFn = orig }()
+	// Pass a verifier that accepts ONLY the install's binary. The
+	// signature is the seam (no package-global = no data race).
+	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
 
-	cur, err := FindCurrentInstall(mode.User)
+	cur, err := FindCurrentInstall(mode.User, verify)
 	if err != nil {
 		t.Fatalf("FindCurrentInstall: %v", err)
 	}
@@ -154,11 +154,69 @@ func TestFindCurrentInstallNoneInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	// LaunchAgents directory doesn't exist → zero install, nil error.
-	cur, err := FindCurrentInstall(mode.User)
+	reject := Verifier(func(string) (bool, error) { return false, nil })
+	cur, err := FindCurrentInstall(mode.User, reject)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if cur.BinaryPath != "" || len(cur.PlistPaths) != 0 {
 		t.Fatalf("expected empty CurInstall, got %+v", cur)
+	}
+}
+
+// Go-reviewer MEDIUM #6: a broken install (plist references a binary
+// that the verifier rejects — e.g. the binary was deleted or replaced
+// with a non-focusd binary) is silently skipped, not returned as part
+// of the install. Without this test, a future refactor could turn the
+// silent-skip into a false-positive without anything catching it.
+func TestFindCurrentInstallVerifyFailsSkipsPlist(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	laDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := filepath.Join(home, "hidden", "com.apple.metadata.helper.7f3a")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd := filepath.Join(home, "Library", "Application Support", ".com.apple.metadata.7f3a")
+	s := Spec{
+		Mode: mode.User, SelfPath: binPath, Workdir: wd,
+		Github: "o/r", Asset: "daemon-darwin-arm64",
+		Interval: 10 * time.Second, Base: "com.apple.metadata.helper.7f3a",
+	}
+	for _, r := range AllRoles {
+		pp := filepath.Join(laDir, s.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(s, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verifier rejects every binary (simulates binary deleted /
+	// replaced / unsigned). All 3 plists must be skipped → zero install.
+	rejectAll := Verifier(func(string) (bool, error) { return false, nil })
+	cur, err := FindCurrentInstall(mode.User, rejectAll)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if cur.BinaryPath != "" || len(cur.PlistPaths) != 0 {
+		t.Fatalf("expected zero install when verifier rejects, got %+v", cur)
+	}
+
+	// And: a verifier that returns an ERROR (vs just false) must
+	// also skip — not be treated as "valid".
+	rejectWithErr := Verifier(func(string) (bool, error) {
+		return false, errors.New("verifier blew up")
+	})
+	cur, err = FindCurrentInstall(mode.User, rejectWithErr)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if cur.BinaryPath != "" || len(cur.PlistPaths) != 0 {
+		t.Fatalf("expected zero install when verifier errs, got %+v", cur)
 	}
 }

--- a/daemon/internal/osadapter/manager_test.go
+++ b/daemon/internal/osadapter/manager_test.go
@@ -7,15 +7,20 @@ import (
 )
 
 type fakeCtl struct {
-	loadedSet map[string]bool
-	boots     []string
-	bouts     []string
+	loadedSet       map[string]bool
+	boots           []string
+	bouts           []string
+	bootstrapFailOn string           // plist path that should fail bootstrap
+	bootoutErrOn    map[string]error // label → error to return from bootout
 }
 
 func newFakeCtl() *fakeCtl { return &fakeCtl{loadedSet: map[string]bool{}} }
 
 func (f *fakeCtl) loaded(l string) bool { return f.loadedSet[l] }
 func (f *fakeCtl) bootstrap(pp string) error {
+	if pp == f.bootstrapFailOn {
+		return errCtlSynthetic
+	}
 	f.boots = append(f.boots, pp)
 	f.loadedSet[labelFromPath(pp)] = true
 	return nil
@@ -23,15 +28,33 @@ func (f *fakeCtl) bootstrap(pp string) error {
 func (f *fakeCtl) bootout(l string) error {
 	f.bouts = append(f.bouts, l)
 	delete(f.loadedSet, l)
+	if err, ok := f.bootoutErrOn[l]; ok {
+		return err
+	}
 	return nil
 }
 
-type fakeFS struct{ files map[string]string }
+var errCtlSynthetic = errSentinel("synthetic ctl failure")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
+
+type fakeFS struct {
+	files       map[string]string
+	writeFailOn string // path that should fail write
+}
 
 func newFakeFS() *fakeFS                    { return &fakeFS{files: map[string]string{}} }
 func (f *fakeFS) plistPath(l string) string { return "/p/" + l + ".plist" }
-func (f *fakeFS) write(p, c string) error   { f.files[p] = c; return nil }
-func (f *fakeFS) remove(p string) error     { delete(f.files, p); return nil }
+func (f *fakeFS) write(p, c string) error {
+	if p == f.writeFailOn {
+		return errSentinel("synthetic write failure")
+	}
+	f.files[p] = c
+	return nil
+}
+func (f *fakeFS) remove(p string) error { delete(f.files, p); return nil }
 func labelFromPath(p string) string {
 	p = strings.TrimPrefix(p, "/p/")
 	return strings.TrimSuffix(p, ".plist")

--- a/daemon/internal/osadapter/selfupdate.go
+++ b/daemon/internal/osadapter/selfupdate.go
@@ -168,7 +168,12 @@ func pollHealthy(p prober, newLabels []string, timeout, interval time.Duration) 
 		} else {
 			consecutive = 0
 		}
-		if time.Now().After(deadline) {
+		// Go-reviewer MEDIUM #5: check deadline BEFORE sleeping. The
+		// previous order (sleep then check) meant the last probe could
+		// extend wall-clock timeout by ~1 full interval — minor but
+		// real (15s budget could actually take 16s). Now: if the next
+		// sleep would push us past the deadline, declare timeout now.
+		if time.Now().Add(interval).After(deadline) {
 			return fmt.Errorf("health-poll timeout after %s (last consecutive ok = %d)",
 				timeout, consecutive)
 		}

--- a/daemon/internal/osadapter/selfupdate.go
+++ b/daemon/internal/osadapter/selfupdate.go
@@ -61,14 +61,25 @@ func SelfUpdate(
 	keepOld bool,
 ) error {
 	// Pre-flight: the caller's FindCurrentInstall must have found a
-	// real install. Bail loudly if not — silently bootstrapping into
-	// a fresh mesh is the kind of footgun that turns a self-update
-	// into an unintended install.
-	if cur.BinaryPath == "" || len(cur.PlistPaths) == 0 {
-		return errors.New("osadapter/selfupdate: no current install found (nothing to update)")
+	// COMPLETE install. Bail loudly if not — silently bootstrapping
+	// into a fresh mesh is the kind of footgun that turns a
+	// self-update into an unintended install. Copilot #1: tightened
+	// from binary+plists-only check to full-mesh check.
+	if cur.BinaryPath == "" || len(cur.PlistPaths) != len(AllRoles) {
+		return fmt.Errorf("osadapter/selfupdate: incomplete install — found %d of %d mesh plists, binary=%q",
+			len(cur.PlistPaths), len(AllRoles), cur.BinaryPath)
 	}
-	if newSpec.SelfPath == "" || newSpec.Workdir == "" || newSpec.base() == "" {
+	// newSpec.base() returns the dev-fallback "com.focusd.daemon" when
+	// newSpec.Base is empty, so checking base() != "" always passes
+	// and is useless. Check the raw field. Copilot #1.
+	if newSpec.SelfPath == "" || newSpec.Workdir == "" || newSpec.Base == "" {
 		return errors.New("osadapter/selfupdate: newSpec missing SelfPath/Workdir/Base")
+	}
+	if newSpec.Workdir != cur.Workdir {
+		// Workdir migration is OUT of scope and would strand state.db,
+		// version.json, the bin/v* cache, daemon.log. Copilot #1.
+		return fmt.Errorf("osadapter/selfupdate: newSpec.Workdir=%q must match current install workdir=%q (workdir is preserved across self-update)",
+			newSpec.Workdir, cur.Workdir)
 	}
 	if newSpec.SelfPath == cur.BinaryPath {
 		// The whole point of self-update is path rotation; same path
@@ -127,16 +138,20 @@ func SelfUpdate(
 	// then A) so the ensurer cannot respawn an old sibling between
 	// bootouts. We launchctl-bootout only; we do NOT pkill -f because
 	// argv overlap with the new daemon would kill them too.
+	//
+	// Copilot #3: errors from bootout-old are SILENTLY IGNORED here
+	// (truthful description). The new mesh is healthy and serving;
+	// a stuck-old bootout would require operator cleanup but does NOT
+	// roll back the swap. No plumbed error reporter today — see
+	// follow-up if log-noise tolerance demands one.
 	for i := len(cur.Labels) - 1; i >= 0; i-- {
-		// Per spec: "bootout-old failure handled" — log via the
-		// returned error wrapping but do NOT roll back the new mesh.
-		// (The new mesh is healthy; a stuck-old bootout is rare and
-		// the operator can clean it up manually if needed.)
-		_ = c.bootout(cur.Labels[i])
+		_ = c.bootout(cur.Labels[i]) // see comment above re: discarded err
 	}
 
-	// H. Best-effort cleanup of old plists + old binary. Errors logged
-	// (returned wrapped, not fatal) — the new mesh is already serving.
+	// H. Best-effort cleanup of old plists + old binary. Errors are
+	// SILENTLY IGNORED (truthful description). The new mesh is
+	// serving; leftover old files are dead weight, not a correctness
+	// problem. Copilot #4.
 	if !keepOld {
 		for _, pp := range cur.PlistPaths {
 			_ = fs.remove(pp)
@@ -168,16 +183,23 @@ func pollHealthy(p prober, newLabels []string, timeout, interval time.Duration) 
 		} else {
 			consecutive = 0
 		}
-		// Go-reviewer MEDIUM #5: check deadline BEFORE sleeping. The
-		// previous order (sleep then check) meant the last probe could
-		// extend wall-clock timeout by ~1 full interval — minor but
-		// real (15s budget could actually take 16s). Now: if the next
-		// sleep would push us past the deadline, declare timeout now.
-		if time.Now().Add(interval).After(deadline) {
+		// Copilot #2: declare timeout ONLY after the deadline passes;
+		// sleep min(interval, time.Until(deadline)) so we still probe
+		// once near the deadline even when interval > remaining. The
+		// previous "check before sleep" form bailed early (e.g.
+		// timeout=15s, interval=10s would exit at ~10s without a
+		// final probe).
+		now := time.Now()
+		if !now.Before(deadline) {
 			return fmt.Errorf("health-poll timeout after %s (last consecutive ok = %d)",
 				timeout, consecutive)
 		}
-		time.Sleep(interval)
+		remaining := deadline.Sub(now)
+		sleep := interval
+		if sleep > remaining {
+			sleep = remaining
+		}
+		time.Sleep(sleep)
 	}
 }
 

--- a/daemon/internal/osadapter/selfupdate.go
+++ b/daemon/internal/osadapter/selfupdate.go
@@ -1,0 +1,231 @@
+package osadapter
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// prober is the launchd-introspection seam used by SelfUpdate's
+// post-bootstrap health poll. The real implementation calls
+// `launchctl print` and parses the State/PID fields; tests pass a
+// scripted fake.
+type prober interface {
+	// isLoaded reports whether the label is registered with launchd.
+	isLoaded(label string) bool
+	// hasPID reports whether the label currently has a live PID
+	// (i.e. launchd has spawned the worker, not just registered it).
+	hasPID(label string) bool
+}
+
+// binPlacer is the binary-write seam. Real on darwin: write bytes
+// atomically with mode 0o755 (Go's adhoc Mach-O signature survives
+// the rename; we do NOT manually re-codesign). Tests inject a fake
+// to assert place/remove ordering.
+type binPlacer interface {
+	place(srcBytes []byte, dstPath string) error
+	remove(path string) error
+}
+
+// SelfUpdate is the path-rotating daemon swap (feature 1.5).
+//
+// AMFI premise: macOS caches a binary's CDHash by absolute path. After
+// our previous-release daemon ran from <workdir>/<oldName>, replacing
+// the bytes in place defeats launch even though the new bytes are
+// fine. Self-update therefore writes the new daemon to a NEW disguised
+// basename in the SAME hidden workdir, renders three new plists at
+// new label filenames, and bootstraps the new mesh before tearing the
+// old one down. The workdir, version.json, good marker, bin/, and any
+// other state are NEVER touched.
+//
+// This function is the orchestration only — the caller is expected to
+// have already (1) discovered cur via FindCurrentInstall and (2)
+// downloaded + Ed25519-verified newBin via fetch. newSpec MUST carry:
+//
+//   - SelfPath = the NEW rotated binary path inside cur.Workdir
+//   - Base     = a NEW random disguised label base (so old/new plists
+//     can coexist for the duration of the swap)
+//   - Workdir  = cur.Workdir (we never touch the workdir on update)
+//
+// keepOld=true skips the final best-effort cleanup of old plists +
+// the old binary file — useful for debugging the AMFI premise on a
+// real machine. The OLD launchd entries are still booted out either
+// way (otherwise we'd end up with 6 daemons fighting).
+//
+// Returns nil only when the new mesh is loaded AND health-poll
+// passed AND old mesh entries are no longer registered with launchd.
+func SelfUpdate(
+	cur CurInstall, newSpec Spec, newBin []byte,
+	c controller, fs fsio, p prober, b binPlacer,
+	healthyTimeout, probeInterval time.Duration,
+	keepOld bool,
+) error {
+	// Pre-flight: the caller's FindCurrentInstall must have found a
+	// real install. Bail loudly if not — silently bootstrapping into
+	// a fresh mesh is the kind of footgun that turns a self-update
+	// into an unintended install.
+	if cur.BinaryPath == "" || len(cur.PlistPaths) == 0 {
+		return errors.New("osadapter/selfupdate: no current install found (nothing to update)")
+	}
+	if newSpec.SelfPath == "" || newSpec.Workdir == "" || newSpec.base() == "" {
+		return errors.New("osadapter/selfupdate: newSpec missing SelfPath/Workdir/Base")
+	}
+	if newSpec.SelfPath == cur.BinaryPath {
+		// The whole point of self-update is path rotation; same path
+		// hits the AMFI bug we're working around.
+		return errors.New("osadapter/selfupdate: new SelfPath must differ from current (AMFI requires path rotation)")
+	}
+
+	// C. Place new binary at newSpec.SelfPath.
+	if err := b.place(newBin, newSpec.SelfPath); err != nil {
+		return fmt.Errorf("osadapter/selfupdate: place new binary: %w", err)
+	}
+
+	// D. Render + write 3 new plists at new label filenames.
+	newPlists := make([]string, 0, len(AllRoles))
+	newLabels := make([]string, 0, len(AllRoles))
+	for _, r := range AllRoles {
+		label := newSpec.Label(r)
+		pp := fs.plistPath(label)
+		if err := fs.write(pp, Plist(newSpec, r)); err != nil {
+			// Rollback the binary + any plists already written.
+			rollback(c, fs, b, newSpec, newPlists, newLabels)
+			return fmt.Errorf("osadapter/selfupdate: write new plist %s: %w", label, err)
+		}
+		newPlists = append(newPlists, pp)
+		newLabels = append(newLabels, label)
+	}
+
+	// E. Bootstrap the new mesh in install order (A, B, ensure).
+	bootedNew := make([]string, 0, len(newLabels))
+	for i, label := range newLabels {
+		// Bootout first (idempotent: a stale entry for the same
+		// label would refuse bootstrap).
+		_ = c.bootout(label)
+		if err := c.bootstrap(newPlists[i]); err != nil {
+			// Rollback: bootout any of the new labels we already
+			// bootstrapped (reverse order), then remove plists +
+			// binary. OLD install untouched.
+			rollbackBootouts(c, bootedNew)
+			rollback(c, fs, b, newSpec, newPlists, newLabels)
+			return fmt.Errorf("osadapter/selfupdate: bootstrap new %s: %w", label, err)
+		}
+		bootedNew = append(bootedNew, label)
+	}
+
+	// F. Health poll: wait until all 3 new labels are loaded AND A+B
+	// have PIDs, for 2 consecutive successful probes. Timeout → roll
+	// back. (StartInterval ensurer may not have a live PID between
+	// invocations — only A/B are checked for PID presence.)
+	if err := pollHealthy(p, newLabels, healthyTimeout, probeInterval); err != nil {
+		rollbackBootouts(c, bootedNew)
+		rollback(c, fs, b, newSpec, newPlists, newLabels)
+		return fmt.Errorf("osadapter/selfupdate: health: %w", err)
+	}
+
+	// G. SWAP. Bootout old in REVERSE order (ensurer first, then B,
+	// then A) so the ensurer cannot respawn an old sibling between
+	// bootouts. We launchctl-bootout only; we do NOT pkill -f because
+	// argv overlap with the new daemon would kill them too.
+	for i := len(cur.Labels) - 1; i >= 0; i-- {
+		// Per spec: "bootout-old failure handled" — log via the
+		// returned error wrapping but do NOT roll back the new mesh.
+		// (The new mesh is healthy; a stuck-old bootout is rare and
+		// the operator can clean it up manually if needed.)
+		_ = c.bootout(cur.Labels[i])
+	}
+
+	// H. Best-effort cleanup of old plists + old binary. Errors logged
+	// (returned wrapped, not fatal) — the new mesh is already serving.
+	if !keepOld {
+		for _, pp := range cur.PlistPaths {
+			_ = fs.remove(pp)
+		}
+		_ = b.remove(cur.BinaryPath)
+	}
+
+	return nil
+}
+
+// pollHealthy waits up to timeout for every label in newLabels to be
+// loaded, plus the A/B workers to have a live PID, for two consecutive
+// successful probes. Returns nil on success, error on timeout.
+func pollHealthy(p prober, newLabels []string, timeout, interval time.Duration) error {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	consecutive := 0
+	for {
+		if probeOK(p, newLabels) {
+			consecutive++
+			if consecutive >= 2 {
+				return nil
+			}
+		} else {
+			consecutive = 0
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("health-poll timeout after %s (last consecutive ok = %d)",
+				timeout, consecutive)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func probeOK(p prober, newLabels []string) bool {
+	for _, l := range newLabels {
+		if !p.isLoaded(l) {
+			return false
+		}
+	}
+	// A + B must have live PIDs; ensure (StartInterval) may be idle
+	// between ticks and that is fine.
+	for _, l := range newLabels {
+		if isWorkerLabel(l) && !p.hasPID(l) {
+			return false
+		}
+	}
+	return true
+}
+
+// isWorkerLabel reports whether a label is for role A or B (not the
+// ensurer). Used by the health poll to decide which entries must have
+// a live PID.
+func isWorkerLabel(label string) bool {
+	return endsWith(label, ".a") || endsWith(label, ".b")
+}
+
+func endsWith(s, suf string) bool {
+	if len(suf) > len(s) {
+		return false
+	}
+	return s[len(s)-len(suf):] == suf
+}
+
+// rollbackBootouts boots out labels in reverse-order. Used when a
+// failure interrupts the new-mesh bootstrap or health-poll.
+func rollbackBootouts(c controller, labels []string) {
+	for i := len(labels) - 1; i >= 0; i-- {
+		_ = c.bootout(labels[i])
+	}
+}
+
+// rollback removes new plists + new binary on failure. The OLD install
+// is never touched.
+func rollback(c controller, fs fsio, b binPlacer, newSpec Spec,
+	newPlists, newLabels []string) {
+	// Defensive: bootout any of the new labels (idempotent if not
+	// loaded). rollbackBootouts is the explicit one used when we
+	// know what was bootstrapped; this is the catch-all.
+	for i := len(newLabels) - 1; i >= 0; i-- {
+		_ = c.bootout(newLabels[i])
+	}
+	for _, pp := range newPlists {
+		_ = fs.remove(pp)
+	}
+	_ = b.remove(newSpec.SelfPath)
+}

--- a/daemon/internal/osadapter/selfupdate_test.go
+++ b/daemon/internal/osadapter/selfupdate_test.go
@@ -223,7 +223,7 @@ func TestSelfUpdate_PreflightNoInstall(t *testing.T) {
 	b := &fakeBinPlacer{}
 	p := newFakeProber(nil, nil)
 	err := SelfUpdate(CurInstall{}, newSpec(), []byte("X"), c, fs, p, &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
-	if err == nil || !strings.Contains(err.Error(), "no current install") {
+	if err == nil || !strings.Contains(err.Error(), "incomplete install") {
 		t.Fatalf("expected preflight failure, got %v", err)
 	}
 	if len(b.placed) != 0 {

--- a/daemon/internal/osadapter/selfupdate_test.go
+++ b/daemon/internal/osadapter/selfupdate_test.go
@@ -1,0 +1,435 @@
+package osadapter
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeProber struct {
+	mu           sync.Mutex
+	loaded       map[string]bool
+	pids         map[string]bool
+	probeRounds  int  // each isLoaded call for label[0] increments this
+	gateRounds   int  // first N rounds report not-healthy
+	firstLabel   string
+	neverHealthy bool // always report not-healthy (timeout path)
+}
+
+func newFakeProber(loaded, pids map[string]bool) *fakeProber {
+	if loaded == nil {
+		loaded = map[string]bool{}
+	}
+	if pids == nil {
+		pids = map[string]bool{}
+	}
+	return &fakeProber{loaded: loaded, pids: pids}
+}
+
+func (p *fakeProber) isLoaded(l string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.firstLabel == "" {
+		p.firstLabel = l
+	}
+	if l == p.firstLabel {
+		p.probeRounds++
+	}
+	if p.neverHealthy {
+		return false
+	}
+	if p.probeRounds <= p.gateRounds {
+		return false
+	}
+	return p.loaded[l]
+}
+
+func (p *fakeProber) hasPID(l string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.neverHealthy {
+		return false
+	}
+	if p.probeRounds <= p.gateRounds {
+		return false
+	}
+	return p.pids[l]
+}
+
+type fakeBinPlacer struct {
+	bytes  map[string][]byte
+	placed []string
+	rmd    []string
+	failOn string
+	rmErr  error
+}
+
+func (b *fakeBinPlacer) place(src []byte, dst string) error {
+	if dst == b.failOn {
+		return errors.New("synthetic place failure")
+	}
+	if b.bytes == nil {
+		b.bytes = map[string][]byte{}
+	}
+	b.bytes[dst] = append([]byte(nil), src...)
+	b.placed = append(b.placed, dst)
+	return nil
+}
+
+func (b *fakeBinPlacer) remove(p string) error {
+	if b.rmErr != nil {
+		return b.rmErr
+	}
+	if b.bytes != nil {
+		delete(b.bytes, p)
+	}
+	b.rmd = append(b.rmd, p)
+	return nil
+}
+
+// --- shared spec helpers --------------------------------------------------
+
+func curInstall() CurInstall {
+	return CurInstall{
+		Mode:    mode.User,
+		Base:    "com.apple.metadata.helper.OLD",
+		Workdir: "/wd",
+		BinaryPath: "/wd/com.apple.metadata.helper.OLD",
+		PlistPaths: []string{
+			"/p/com.apple.metadata.helper.OLD.a.plist",
+			"/p/com.apple.metadata.helper.OLD.b.plist",
+			"/p/com.apple.metadata.helper.OLD.ensure.plist",
+		},
+		Labels: []string{
+			"com.apple.metadata.helper.OLD.a",
+			"com.apple.metadata.helper.OLD.b",
+			"com.apple.metadata.helper.OLD.ensure",
+		},
+	}
+}
+
+func newSpecRotated(workdir, newBin, newBase string) Spec {
+	return Spec{
+		Mode: mode.User, SelfPath: newBin, Workdir: workdir,
+		Github: "o/r", Asset: "daemon-darwin-arm64",
+		Interval: 10 * time.Second, Base: newBase,
+	}
+}
+
+func newSpec() Spec {
+	return newSpecRotated("/wd", "/wd/com.apple.cfprefsd.helper.NEW", "com.apple.cfprefsd.helper.NEW")
+}
+
+// allHealthy returns prober maps that mark every new label as loaded
+// AND give A/B a live PID (ensurer gets no PID — it is StartInterval).
+func allHealthy(s Spec) (loaded, pids map[string]bool) {
+	loaded = map[string]bool{
+		s.Label(RoleA):      true,
+		s.Label(RoleB):      true,
+		s.Label(RoleEnsure): true,
+	}
+	pids = map[string]bool{
+		s.Label(RoleA): true,
+		s.Label(RoleB): true,
+	}
+	return
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestSelfUpdate_HappyPath(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	// Pre-load the OLD mesh so bootout-old has something to remove.
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+	loaded, pids := allHealthy(s)
+	p := newFakeProber(loaded, pids)
+
+	if err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, 2*time.Second, 5*time.Millisecond, false); err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+
+	// Verify: new binary placed; new plists written; new mesh bootstrapped;
+	// old plists removed; old binary removed; old labels booted out.
+	if _, ok := b.bytes[s.SelfPath]; !ok {
+		t.Errorf("new binary not placed at %s", s.SelfPath)
+	}
+	if _, ok := b.bytes[cur.BinaryPath]; ok {
+		t.Errorf("old binary not removed at %s", cur.BinaryPath)
+	}
+	for _, r := range AllRoles {
+		if !c.loaded(s.Label(r)) {
+			t.Errorf("new role %s not loaded", r)
+		}
+	}
+	for _, oldL := range cur.Labels {
+		if c.loaded(oldL) {
+			t.Errorf("old label %s still loaded", oldL)
+		}
+	}
+	for _, oldPP := range cur.PlistPaths {
+		if _, ok := fs.files[oldPP]; ok {
+			t.Errorf("old plist %s not removed", oldPP)
+		}
+	}
+}
+
+func TestSelfUpdate_KeepOldLeavesOldOnDisk(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+	loaded, pids := allHealthy(s)
+	p := newFakeProber(loaded, pids)
+
+	if err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, 2*time.Second, 5*time.Millisecond, true); err != nil {
+		t.Fatalf("keep-old: %v", err)
+	}
+
+	// Old labels are STILL booted out (otherwise 6 daemons fight) —
+	// only the on-disk artifacts are preserved.
+	for _, oldL := range cur.Labels {
+		if c.loaded(oldL) {
+			t.Errorf("old label %s should be booted out even with --keep-old", oldL)
+		}
+	}
+	if _, ok := fs.files[cur.PlistPaths[0]]; !ok {
+		t.Errorf("--keep-old must leave old plists on disk")
+	}
+	if _, ok := b.bytes[cur.BinaryPath]; !ok {
+		t.Errorf("--keep-old must leave old binary on disk")
+	}
+}
+
+func TestSelfUpdate_PreflightNoInstall(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	b := &fakeBinPlacer{}
+	p := newFakeProber(nil, nil)
+	err := SelfUpdate(CurInstall{}, newSpec(), []byte("X"), c, fs, p, &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "no current install") {
+		t.Fatalf("expected preflight failure, got %v", err)
+	}
+	if len(b.placed) != 0 {
+		t.Fatal("nothing should have been placed on preflight failure")
+	}
+}
+
+func TestSelfUpdate_RejectsSamePath(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	s := newSpec()
+	s.SelfPath = cur.BinaryPath // same path → must reject (AMFI premise)
+	b := &fakeBinPlacer{}
+	p := newFakeProber(nil, nil)
+	err := SelfUpdate(cur, s, []byte("X"), c, fs, p, &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "path rotation") {
+		t.Fatalf("expected path-rotation rejection, got %v", err)
+	}
+}
+
+func TestSelfUpdate_BootstrapFailRollsBack(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+	loaded, pids := allHealthy(s)
+	p := newFakeProber(loaded, pids)
+
+	// Make role B bootstrap fail.
+	c.bootstrapFailOn = fs.plistPath(s.Label(RoleB))
+
+	err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "bootstrap new") {
+		t.Fatalf("expected bootstrap error, got %v", err)
+	}
+
+	// Rollback: new binary removed; new plists removed; new labels NOT loaded.
+	if _, ok := b.bytes[s.SelfPath]; ok {
+		t.Errorf("new binary should be rolled back")
+	}
+	for _, r := range AllRoles {
+		if c.loaded(s.Label(r)) {
+			t.Errorf("new role %s should not be loaded after rollback", r)
+		}
+		if _, ok := fs.files[fs.plistPath(s.Label(r))]; ok {
+			t.Errorf("new plist for %s should be removed on rollback", r)
+		}
+	}
+	// OLD install untouched.
+	for _, oldL := range cur.Labels {
+		if !c.loaded(oldL) {
+			t.Errorf("old label %s must remain loaded on rollback", oldL)
+		}
+	}
+	if _, ok := b.bytes[cur.BinaryPath]; !ok {
+		t.Errorf("old binary must remain on disk on rollback")
+	}
+}
+
+func TestSelfUpdate_PlistWriteFailRollsBack(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+
+	// Make plist write fail for role ensure (last one).
+	fs.writeFailOn = fs.plistPath(s.Label(RoleEnsure))
+
+	err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, newFakeProber(nil, nil), &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "write new plist") {
+		t.Fatalf("expected write-plist error, got %v", err)
+	}
+	if _, ok := b.bytes[s.SelfPath]; ok {
+		t.Errorf("new binary should be rolled back on plist write failure")
+	}
+	// OLD untouched.
+	if _, ok := b.bytes[cur.BinaryPath]; !ok {
+		t.Errorf("old binary must remain")
+	}
+}
+
+func TestSelfUpdate_HealthPollTimeoutRollsBack(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+	p := newFakeProber(nil, nil)
+	p.neverHealthy = true
+
+	err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, 30*time.Millisecond, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "health-poll timeout") {
+		t.Fatalf("expected health-poll timeout, got %v", err)
+	}
+
+	// Full rollback: new binary removed; new plists removed; new labels
+	// booted out. OLD install untouched.
+	if _, ok := b.bytes[s.SelfPath]; ok {
+		t.Errorf("new binary should be rolled back")
+	}
+	for _, r := range AllRoles {
+		if c.loaded(s.Label(r)) {
+			t.Errorf("new role %s should be booted out on health timeout", r)
+		}
+	}
+	for _, oldL := range cur.Labels {
+		if !c.loaded(oldL) {
+			t.Errorf("old label %s must remain after health-poll rollback", oldL)
+		}
+	}
+}
+
+func TestSelfUpdate_OldBootoutFailureNotFatal(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+
+	s := newSpec()
+	loaded, pids := allHealthy(s)
+	p := newFakeProber(loaded, pids)
+
+	// Make bootout of OLD role A fail (the LAST one we try; reverse order
+	// = ensure → B → A) — error is swallowed and the run succeeds anyway.
+	c.bootoutErrOn = map[string]error{cur.Labels[0]: errors.New("synthetic")}
+
+	if err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false); err != nil {
+		t.Fatalf("old-bootout failure must not be fatal: %v", err)
+	}
+	// New mesh up.
+	for _, r := range AllRoles {
+		if !c.loaded(s.Label(r)) {
+			t.Errorf("new role %s should be loaded", r)
+		}
+	}
+}
+
+func TestSelfUpdate_HealthPollNeedsTwoConsecutiveOKs(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+	s := newSpec()
+	loaded, pids := allHealthy(s)
+	p := newFakeProber(loaded, pids)
+	// First N probes look unhealthy, then healthy: total time ~ N*interval.
+	// Must still pass within timeout. (Goal: validate that 2 consecutive
+	// OKs are required AND that intermittent failures don't latch.)
+	p.gateRounds = 1
+
+	if err := SelfUpdate(cur, s, []byte("NEWBIN"), c, fs, p, &fakeBinPlacerWrap{b}, 1*time.Second, 5*time.Millisecond, false); err != nil {
+		t.Fatalf("expected eventual healthy: %v", err)
+	}
+}
+
+func TestSelfUpdate_PlaceBinaryFailureFatal(t *testing.T) {
+	c, fs := newFakeCtl(), newFakeFS()
+	cur := curInstall()
+	for i, l := range cur.Labels {
+		c.loadedSet[l] = true
+		fs.files[cur.PlistPaths[i]] = "OLD"
+	}
+	b := &fakeBinPlacer{bytes: map[string][]byte{cur.BinaryPath: {0x01}}}
+	s := newSpec()
+	b.failOn = s.SelfPath
+	err := SelfUpdate(cur, s, []byte("X"), c, fs, newFakeProber(nil, nil), &fakeBinPlacerWrap{b}, time.Second, 5*time.Millisecond, false)
+	if err == nil || !strings.Contains(err.Error(), "place new binary") {
+		t.Fatalf("expected place failure, got %v", err)
+	}
+	// OLD install untouched.
+	for _, oldL := range cur.Labels {
+		if !c.loaded(oldL) {
+			t.Errorf("old label %s must remain loaded after place failure", oldL)
+		}
+	}
+}
+
+// --- adapter helpers ------------------------------------------------------
+
+// fakeBinPlacerWrap satisfies the binPlacer interface against
+// fakeBinPlacer (struct of *fakeBinPlacer to keep mutations visible).
+type fakeBinPlacerWrap struct{ b *fakeBinPlacer }
+
+func (w *fakeBinPlacerWrap) place(s []byte, d string) error { return w.b.place(s, d) }
+func (w *fakeBinPlacerWrap) remove(p string) error          { return w.b.remove(p) }

--- a/daemon/internal/osadapter/selfupdate_test.go
+++ b/daemon/internal/osadapter/selfupdate_test.go
@@ -16,8 +16,8 @@ type fakeProber struct {
 	mu           sync.Mutex
 	loaded       map[string]bool
 	pids         map[string]bool
-	probeRounds  int  // each isLoaded call for label[0] increments this
-	gateRounds   int  // first N rounds report not-healthy
+	probeRounds  int // each isLoaded call for label[0] increments this
+	gateRounds   int // first N rounds report not-healthy
 	firstLabel   string
 	neverHealthy bool // always report not-healthy (timeout path)
 }
@@ -97,9 +97,9 @@ func (b *fakeBinPlacer) remove(p string) error {
 
 func curInstall() CurInstall {
 	return CurInstall{
-		Mode:    mode.User,
-		Base:    "com.apple.metadata.helper.OLD",
-		Workdir: "/wd",
+		Mode:       mode.User,
+		Base:       "com.apple.metadata.helper.OLD",
+		Workdir:    "/wd",
 		BinaryPath: "/wd/com.apple.metadata.helper.OLD",
 		PlistPaths: []string{
 			"/p/com.apple.metadata.helper.OLD.a.plist",

--- a/daemon/internal/relocate/relocate.go
+++ b/daemon/internal/relocate/relocate.go
@@ -72,13 +72,24 @@ func HiddenWorkdir(supportRoot string) string {
 	return filepath.Join(supportRoot, "."+pick(prefixes)+"."+randHex(6))
 }
 
+// RandomBinaryName is the disguised basename pattern used for the
+// daemon binary inside its hidden workdir, e.g.
+// "com.apple.metadata.helper.7f3a". Extracted as its own primitive so
+// the self-update path can rotate the binary path on every update
+// (macOS AMFI caches the CDHash per executable path, so re-using the
+// same path defeats adhoc-resign + restart for the swap; see
+// internal/osadapter/selfupdate.go).
+func RandomBinaryName() string {
+	return pick(prefixes) + "." + pick(suffixes) + "." + randHex(4)
+}
+
 // RelocateInto copies src into dir under a random disguised basename,
 // 0755, and returns the new path (hard-link first; copy fallback).
 func RelocateInto(src, dir string) (string, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("relocate: mkdir %s: %w", dir, err)
 	}
-	dst := filepath.Join(dir, pick(prefixes)+"."+pick(suffixes)+"."+randHex(4))
+	dst := filepath.Join(dir, RandomBinaryName())
 	if err := os.Link(src, dst); err == nil {
 		_ = os.Chmod(dst, 0o755)
 		return dst, nil

--- a/daemon/internal/relocate/relocate.go
+++ b/daemon/internal/relocate/relocate.go
@@ -74,8 +74,9 @@ func HiddenWorkdir(supportRoot string) string {
 
 // RandomBinaryName is the disguised basename pattern used for the
 // daemon binary inside its hidden workdir, e.g.
-// "com.apple.metadata.helper.7f3a". Extracted as its own primitive so
-// the self-update path can rotate the binary path on every update
+// "com.apple.metadata.helper.7f3a2c4d" (randHex(4) yields 8 hex chars,
+// not 4 — Copilot #7). Extracted as its own primitive so the
+// self-update path can rotate the binary path on every update
 // (macOS AMFI caches the CDHash per executable path, so re-using the
 // same path defeats adhoc-resign + restart for the swap; see
 // internal/osadapter/selfupdate.go).

--- a/daemon/internal/relocate/relocate_test.go
+++ b/daemon/internal/relocate/relocate_test.go
@@ -28,8 +28,9 @@ func TestRandomBinaryNameShapeAndUnique(t *testing.T) {
 	if strings.Contains(a, "focusd") || strings.Contains(a, "daemon") {
 		t.Fatalf("disguised name leaked project string: %s", a)
 	}
-	// Shape: <prefix>.<suffix>.<4hex> → 3 dots minimum (prefixes are
-	// dotted Apple-style themselves), suffix is alpha, 4-hex tail.
+	// Shape: <prefix>.<suffix>.<8hex> → 3 dots minimum (prefixes are
+	// dotted Apple-style themselves), suffix is alpha, 8-hex tail
+	// (4 random bytes hex-encoded — Copilot #8 doc fix).
 	if n := strings.Count(a, "."); n < 3 {
 		t.Fatalf("name should have at least 3 dots (apple-style prefix.suffix.hex): %s", a)
 	}

--- a/daemon/internal/relocate/relocate_test.go
+++ b/daemon/internal/relocate/relocate_test.go
@@ -23,6 +23,31 @@ func TestRandomBaseDisguisedAndUnique(t *testing.T) {
 	}
 }
 
+func TestRandomBinaryNameShapeAndUnique(t *testing.T) {
+	a, b := RandomBinaryName(), RandomBinaryName()
+	if strings.Contains(a, "focusd") || strings.Contains(a, "daemon") {
+		t.Fatalf("disguised name leaked project string: %s", a)
+	}
+	// Shape: <prefix>.<suffix>.<4hex> → 3 dots minimum (prefixes are
+	// dotted Apple-style themselves), suffix is alpha, 4-hex tail.
+	if n := strings.Count(a, "."); n < 3 {
+		t.Fatalf("name should have at least 3 dots (apple-style prefix.suffix.hex): %s", a)
+	}
+	parts := strings.Split(a, ".")
+	tail := parts[len(parts)-1]
+	if len(tail) != 8 { // 4 bytes hex-encoded = 8 chars
+		t.Fatalf("tail must be 8 hex chars (4 random bytes), got %q in %s", tail, a)
+	}
+	for _, c := range tail {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Fatalf("tail %q must be lowercase hex: %s", tail, a)
+		}
+	}
+	if a == b {
+		t.Fatalf("names must be per-call unique: %s == %s", a, b)
+	}
+}
+
 func TestHiddenWorkdir(t *testing.T) {
 	wd := HiddenWorkdir("/Users/x/Library/Application Support")
 	if !strings.HasPrefix(wd, "/Users/x/Library/Application Support/.") {


### PR DESCRIPTION
## Summary
Adds `daemon self-update <daemon-tag>` — a one-shot CLI that downloads a signed daemon binary from a GH release, generates a NEW disguised path on disk, swaps the running daemon mesh to point at the new binary, and removes the old one. This is the **blocker** for deploying any daemon-code changes (Bugs 2+3 from v0.10.0, FEATURES 2 + 3) to existing installs.

## The problem
macOS AMFI caches the CDHash of a binary at its on-disk path the first time it loads. Replacing the binary in-place (`cp new old; kickstart`) fails with `OS_REASON_CODESIGNING` even when the new binary is correctly Go-linker-signed adhoc — AMFI's check is **"this exact CDHash at this exact path"**, not **"is the signature valid?"**.

## The solution
Rotate the path. AMFI has no cache entry for a new disguised filename, so it accepts the new binary on first load. Workdir + state stay put; only the daemon binary filename rotates.

## What this PR contains (6 commits, reviewed in 3 rounds)
- bdd9205 — refactor(relocate): extract RandomBinaryName for self-update reuse
- 2ca3b58 — refactor(fetch): extract DownloadVerified primitive from EnsureBinary
- db5a0db — refactor(osadapter): extract FindCurrentInstall + parsePlist returns argv
- fd14710 — feat(osadapter): SelfUpdate orchestration with prober + binPlacer seams
- e21d74e — feat(daemon): self-update CLI subcommand (path-rotating daemon update)
- dcefae9 — fix: address go-reviewer + security-reviewer findings (1 CRITICAL + 2 HIGH + 3 MEDIUM)

## Reviewed
- **architect** — design doc 1480 words, 11 risks identified.
- **go-reviewer** — 1 CRITICAL (\`byteReader\` was an infinite loop — would HANG the swap), 2 HIGH (otherDirHint typo, verifyFn race hazard), 3 MEDIUM. All addressed except double-FS-round-trip (deferred — perf only, ~6 MiB transient RAM).
- **security-reviewer** — 3 MEDIUM (broken \`byteReader\`, unvalidated \`--github\`, AMFI premise untested). All addressed except AMFI premise — see below.

## AMFI premise: orchestration vs reality
Be honest: the orchestration, rollback semantics, fetch+verify, and CLI wiring are all under test (~93 tests). The actual **"macOS accepts a new binary at a fresh path"** claim is unverified by tests — only by tagging \`daemon-v0.1.0\` and running \`daemon self-update daemon-v0.1.0\` against my real laptop. That's the next step after merge.

## Sequence the orchestration implements
1. Discover current install (FindCurrentInstall scans LaunchDir + Ed25519-verifies each candidate binary).
2. Download + verify new daemon binary into \`<workdir>/.tmp/\`.
3. Place at new disguised path in same workdir. (Don't manually codesign — Go linker adhoc sig survives.)
4. Render 3 new plists with new mesh labels, write to LaunchDir.
5. \`launchctl bootstrap\` new plists in order A → B → ensure. Any failure → rollback.
6. Health-poll for 15s (default): all 3 loaded, A+B have PIDs, 2 consecutive successful probes.
7. \`launchctl bootout\` OLD plists in REVERSE order (ensure → B → A) so the old ensurer can't re-spawn siblings during the swap.
8. Best-effort \`rm\` old plists + binary (unless \`--keep-old\`).

## Test plan
- [x] \`go test ./daemon/... -race -count=1\` all 8 packages green (93 tests)
- [ ] CI green
- [ ] Copilot review addressed
- [ ] Tag \`daemon-v0.1.0\` (first daemon release ever — \`daemon-release.yml\` exists but has never fired) after merge.
- [ ] Smoke test on laptop: download daemon-v0.1.0 binary, run \`sudo daemon-v0.1.0 self-update daemon-v0.1.0\` — proves AMFI defeat.

## Out of scope (deferred)
- FEATURE 2 (relocate widening) — separate PR.
- FEATURE 3 (pubkey grep-resistance) — separate PR.
- Auto-self-update from inside the running daemon — CLI-only for now (operator-driven on rollout is the right shape).
- Double FS round-trip optimization (perf only).