### PR TITLE
refactor(relocate): widen disguise pool from 2M to ~5e15 combinations

### DIFF
--- a/daemon/internal/relocate/relocate.go
+++ b/daemon/internal/relocate/relocate.go
@@ -5,6 +5,17 @@
 //
 // Casual-grade friction only (a determined/AI user reading a plist still
 // learns the path) — the durable commitment weight is the server.
+//
+// Pool sizing: the prefix and suffix pools are intentionally wide
+// (60+ × 60+) and mix Apple subsystem prefixes with plausible
+// third-party launchd labels commonly seen on a typical Mac developer
+// machine (Adobe, Microsoft, Google, Docker, Slack, JetBrains, etc.).
+// Combined with the 10-hex-char random tail (40 bits of entropy in the
+// tail alone) this gives ~3.6e15 combinations vs the ~2M of the old
+// 6×5×16-bit pool. Enumeration via a regex over `launchctl print` is
+// no longer practical, and a single disguised label is now
+// indistinguishable from any of the dozens of third-party background
+// agents already present on a normal developer machine.
 package relocate
 
 import (
@@ -16,11 +27,186 @@ import (
 	"path/filepath"
 )
 
+// prefixes is the disguise pool of launchd-label prefixes. The mix is
+// deliberately heterogeneous so a grep for "com.apple." against an
+// enumerated label set is not sufficient — any of these entries is
+// plausible on a real machine.
+//
+//   - Apple subsystems: the dominant family of legitimate launchd
+//     labels on macOS (Spotlight, security, networking, identity,
+//     telemetry, file providers). Common enough that one more "apple
+//     metadata helper" agent draws zero attention.
+//   - Adobe / Microsoft / Google / Mozilla / Dropbox / Spotify /
+//     Zoom: ubiquitous consumer/productivity apps that all install
+//     LaunchAgents (autoupdaters, signin helpers, notification
+//     daemons).
+//   - Developer tools (Docker, JetBrains, GitHub Desktop, VS Code,
+//     Tailscale, 1Password, Slack, Notion, Figma, Linear, Brave,
+//     Firefox, Arc): the target persona is a developer, so these
+//     are the labels most likely already present.
 var prefixes = []string{
-	"com.apple.metadata", "com.apple.cfprefsd", "com.apple.xpc",
-	"com.apple.security", "com.apple.coreservices", "com.apple.spotlight",
+	// Apple subsystems (heavily over-represented on real machines).
+	"com.apple.metadata",
+	"com.apple.cfprefsd",
+	"com.apple.xpc",
+	"com.apple.security",
+	"com.apple.coreservices",
+	"com.apple.spotlight",
+	"com.apple.LaunchServices",
+	"com.apple.networkserviceproxy",
+	"com.apple.symptomsd",
+	"com.apple.akd",
+	"com.apple.assistantd",
+	"com.apple.bird",
+	"com.apple.diagnosticd",
+	"com.apple.identityservicesd",
+	"com.apple.locationd",
+	"com.apple.mdworker",
+	"com.apple.nsurlsessiond",
+	"com.apple.pkd",
+	"com.apple.trustd",
+	"com.apple.containermanagerd",
+	"com.apple.accountsd",
+	"com.apple.routined",
+	"com.apple.appleaccountd",
+	"com.apple.commerce",
+	"com.apple.cloudpaird",
+	"com.apple.searchpartyd",
+	"com.apple.notificationcenterd",
+	"com.apple.usbmuxd",
+	"com.apple.WindowServer.helper",
+	"com.apple.UserEventAgent",
+	// Adobe.
+	"com.adobe.acc.installer",
+	"com.adobe.AdobeIPCBroker",
+	"com.adobe.CCXProcess",
+	"com.adobe.GCInvoker",
+	// Microsoft.
+	"com.microsoft.autoupdate.helper",
+	"com.microsoft.OneAuth",
+	"com.microsoft.intune.mam",
+	"com.microsoft.VSCode.helper",
+	"com.microsoft.teams.TeamsUpdaterDaemon",
+	// Google.
+	"com.google.keystone.daemon",
+	"com.google.GoogleUpdater.wake",
+	"com.google.Chrome.helper",
+	"com.google.drivefs",
+	// Mozilla.
+	"org.mozilla.updater",
+	"org.mozilla.firefox.helper",
+	// File-sync / cloud storage.
+	"com.dropbox.DropboxMacUpdate",
+	"com.box.desktop.helper",
+	// Media.
+	"com.spotify.webhelper",
+	// Conferencing.
+	"us.zoom.ZoomDaemon",
+	"us.zoom.ZoomAutoUpdater",
+	// Containers / virtualization.
+	"com.docker.helper",
+	"com.docker.vmnetd",
+	// Networking.
+	"io.tailscale.ipnextension",
+	// Security / password managers.
+	"com.1password.1password-launcher",
+	"com.1password.1password-browser-helper",
+	"com.bitwarden.desktop.helper",
+	// Collaboration / productivity.
+	"com.slack.Update",
+	"com.slack.helper",
+	"notion.id.helper",
+	"com.figma.agent",
+	"com.linear.helper",
+	// VCS / dev tooling.
+	"com.github.GitHubDesktop.helper",
+	"com.jetbrains.toolbox.helper",
+	"com.jetbrains.AppCode",
+	"com.jetbrains.intellij.helper",
+	// Browsers.
+	"com.brave.Browser.helper",
+	"company.thebrowser.Browser.helper",
+	// Misc developer tools.
+	"com.postmanlabs.mac.helper",
+	"com.electron.helper",
 }
-var suffixes = []string{"helper", "worker", "xpc", "agent", "service"}
+
+// suffixes is the launchd-label role suffix pool. All entries are
+// lowercase ASCII so the generated base satisfies a strict
+// "<prefix>.<role>.<hex>" shape (see RandomBase).
+var suffixes = []string{
+	"helper",
+	"agent",
+	"daemon",
+	"service",
+	"updater",
+	"sync",
+	"analytics",
+	"telemetry",
+	"diagnostics",
+	"crashreporter",
+	"keyhelper",
+	"loginitems",
+	"bg",
+	"mgr",
+	"notifier",
+	"relay",
+	"proxy",
+	"gateway",
+	"cache",
+	"index",
+	"monitor",
+	"watchdog",
+	"installer",
+	"uninstaller",
+	"configd",
+	"prefsd",
+	"sessionhelper",
+	"webhelper",
+	"auth",
+	"signin",
+	"oauth",
+	"pushd",
+	"keystored",
+	"xpcservice",
+	"eventd",
+	"metricsd",
+	"reportd",
+	"crashd",
+	"gpud",
+	"bird",
+	"tcd",
+	"mdmd",
+	"nlcd",
+	"assistd",
+	"quicklookd",
+	"routined",
+	"accountsd",
+	"nehelper",
+	"sandboxd",
+	"coreaudiod",
+	"bluetoothd",
+	"worker",
+	"xpc",
+	"broker",
+	"dispatcher",
+	"scheduler",
+	"poller",
+	"fetcher",
+	"renderer",
+	"indexer",
+	"compositor",
+	"observer",
+	"reporter",
+	"uploader",
+	"downloader",
+}
+
+// randomTailBytes is the number of random bytes used for the hex tail
+// in RandomBase / RandomBinaryName. 5 bytes → 10 lowercase-hex chars
+// → 40 bits of entropy in the tail alone (≈10^12), which together with
+// the (≥60)×(≥60) prefix/suffix pool yields ≈3.6e15 combinations.
+const randomTailBytes = 5
 
 func randHex(n int) string {
 	b := make([]byte, n)
@@ -34,13 +220,20 @@ func pick(s []string) string {
 	return s[int(b[0])%len(s)]
 }
 
-// RandomBase is a disguised, Apple-looking launchd label base, e.g.
-// "com.apple.metadata.helper.7f3a2c11". Generated once at install and
-// persisted (baked into the plists); never re-randomized. The SAME base
-// is shared by all three mesh roles — see [RoleLabel] for the per-role
-// label scheme and the deferred-review note.
+// RandomBase is a disguised, plausible-launchd-label base, e.g.
+// "com.apple.metadata.helper.7f3a2c11ab" or
+// "com.jetbrains.toolbox.helper.proxy.8c1f4e9d22". Generated once at
+// install and persisted (baked into the plists); never re-randomized.
+// The SAME base is shared by all three mesh roles — see [RoleLabel]
+// for the per-role label scheme and the deferred-review note.
+//
+// Format: "<prefix>.<suffix>.<10-hex>". The prefix is drawn from a
+// pool that mixes Apple subsystems and plausible third-party bundle
+// IDs so a single label is indistinguishable from the dozens of
+// third-party background agents present on a normal Mac developer
+// machine.
 func RandomBase() string {
-	return fmt.Sprintf("%s.%s.%s", pick(prefixes), pick(suffixes), randHex(4))
+	return fmt.Sprintf("%s.%s.%s", pick(prefixes), pick(suffixes), randHex(randomTailBytes))
 }
 
 // RoleLabel is the SINGLE authoritative function that turns an install
@@ -51,7 +244,7 @@ func RandomBase() string {
 // Current implementation (intentionally kept): all three roles share one
 // random base, so the label set is:
 //
-//	<base>.a   <base>.b   <base>.ensure      e.g. com.apple.security.worker.ca800c0c.{a,b,ensure}
+//	<base>.a   <base>.b   <base>.ensure      e.g. com.apple.security.worker.ca800c0c11.{a,b,ensure}
 //
 // Known trade-off (accepted for now): the shared prefix means finding one
 // label reveals the other two via a prefix grep. This is acceptable under
@@ -74,14 +267,14 @@ func HiddenWorkdir(supportRoot string) string {
 
 // RandomBinaryName is the disguised basename pattern used for the
 // daemon binary inside its hidden workdir, e.g.
-// "com.apple.metadata.helper.7f3a2c4d" (randHex(4) yields 8 hex chars,
-// not 4 — Copilot #7). Extracted as its own primitive so the
-// self-update path can rotate the binary path on every update
-// (macOS AMFI caches the CDHash per executable path, so re-using the
-// same path defeats adhoc-resign + restart for the swap; see
+// "com.apple.metadata.helper.7f3a2c4d11" (5 random bytes → 10 hex
+// chars). Extracted as its own primitive so the self-update path can
+// rotate the binary path on every update (macOS AMFI caches the
+// CDHash per executable path, so re-using the same path defeats
+// adhoc-resign + restart for the swap; see
 // internal/osadapter/selfupdate.go).
 func RandomBinaryName() string {
-	return pick(prefixes) + "." + pick(suffixes) + "." + randHex(4)
+	return pick(prefixes) + "." + pick(suffixes) + "." + randHex(randomTailBytes)
 }
 
 // RelocateInto copies src into dir under a random disguised basename,

--- a/daemon/internal/relocate/relocate_test.go
+++ b/daemon/internal/relocate/relocate_test.go
@@ -3,15 +3,16 @@ package relocate
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
 
 func TestRandomBaseDisguisedAndUnique(t *testing.T) {
 	a, b := RandomBase(), RandomBase()
-	if !strings.HasPrefix(a, "com.apple.") {
-		t.Fatalf("base must look Apple-ish: %s", a)
-	}
+	// The base must NOT leak the project name. We no longer assert a
+	// "com.apple." prefix — the pool is intentionally widened to mix
+	// Apple subsystems with plausible third-party bundle IDs.
 	if strings.Contains(a, "focusd") {
 		t.Fatalf("base must NOT contain 'focusd': %s", a)
 	}
@@ -25,19 +26,19 @@ func TestRandomBaseDisguisedAndUnique(t *testing.T) {
 
 func TestRandomBinaryNameShapeAndUnique(t *testing.T) {
 	a, b := RandomBinaryName(), RandomBinaryName()
-	if strings.Contains(a, "focusd") || strings.Contains(a, "daemon") {
+	if strings.Contains(a, "focusd") {
 		t.Fatalf("disguised name leaked project string: %s", a)
 	}
-	// Shape: <prefix>.<suffix>.<8hex> → 3 dots minimum (prefixes are
-	// dotted Apple-style themselves), suffix is alpha, 8-hex tail
-	// (4 random bytes hex-encoded — Copilot #8 doc fix).
+	// Shape: <prefix>.<suffix>.<10hex> → 3 dots minimum (prefixes are
+	// themselves dotted bundle-ID style), suffix is alpha lowercase,
+	// 10-hex tail (5 random bytes hex-encoded).
 	if n := strings.Count(a, "."); n < 3 {
-		t.Fatalf("name should have at least 3 dots (apple-style prefix.suffix.hex): %s", a)
+		t.Fatalf("name should have at least 3 dots (bundle-id prefix.suffix.hex): %s", a)
 	}
 	parts := strings.Split(a, ".")
 	tail := parts[len(parts)-1]
-	if len(tail) != 8 { // 4 bytes hex-encoded = 8 chars
-		t.Fatalf("tail must be 8 hex chars (4 random bytes), got %q in %s", tail, a)
+	if len(tail) != 10 { // 5 bytes hex-encoded = 10 chars
+		t.Fatalf("tail must be 10 hex chars (5 random bytes), got %q in %s", tail, a)
 	}
 	for _, c := range tail {
 		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
@@ -82,5 +83,110 @@ func TestRelocateIntoCopiesExecutable(t *testing.T) {
 	fi, _ := os.Stat(dst)
 	if fi.Mode()&0o100 == 0 {
 		t.Fatal("relocated binary must be executable")
+	}
+}
+
+// TestPoolSizesMeetThreshold guards against accidental shrinkage of the
+// disguise pool. The architect-specified floor is 60 entries each;
+// dropping below that pushes the total combination count back toward
+// the old "enumerable in seconds" regime.
+func TestPoolSizesMeetThreshold(t *testing.T) {
+	if len(prefixes) < 60 {
+		t.Fatalf("prefixes pool too small: got %d, want >= 60", len(prefixes))
+	}
+	if len(suffixes) < 60 {
+		t.Fatalf("suffixes pool too small: got %d, want >= 60", len(suffixes))
+	}
+
+	// Defense-in-depth: catch accidental duplicates that silently
+	// shrink the effective pool.
+	seen := make(map[string]struct{}, len(prefixes))
+	for _, p := range prefixes {
+		if _, dup := seen[p]; dup {
+			t.Fatalf("duplicate prefix entry: %q", p)
+		}
+		seen[p] = struct{}{}
+	}
+	seen = make(map[string]struct{}, len(suffixes))
+	for _, s := range suffixes {
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate suffix entry: %q", s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+// TestRandomBaseHighEntropy generates 10000 bases and asserts the
+// uniqueness rate is overwhelming. With 60×60×10^12 combinations the
+// expected number of collisions across 10000 samples is effectively
+// zero; we tolerate up to 10 to absorb the unlikely 256-mod bias in
+// pick() without flaking.
+func TestRandomBaseHighEntropy(t *testing.T) {
+	const n = 10000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		seen[RandomBase()] = struct{}{}
+	}
+	if len(seen) < n-10 {
+		t.Fatalf("low uniqueness: got %d unique out of %d, want >= %d", len(seen), n, n-10)
+	}
+}
+
+// TestRandomBaseLooksPlausible asserts the generated base matches the
+// architect-specified shape: bundle-id-style prefix, lowercase ASCII
+// role suffix, 10-hex random tail.
+func TestRandomBaseLooksPlausible(t *testing.T) {
+	re := regexp.MustCompile(`^[a-zA-Z0-9._-]+\.[a-z]+\.[0-9a-f]{10}$`)
+	for i := 0; i < 200; i++ {
+		base := RandomBase()
+		if !re.MatchString(base) {
+			t.Fatalf("base does not match plausible shape: %s", base)
+		}
+	}
+}
+
+// TestRandomBaseNoLeakedProjectStrings asserts no generated base
+// contains any of the project-revealing tokens from the OLD codebase.
+// A grep for any of these on a real machine would immediately point
+// at our daemon.
+//
+// The list is split into two flavours:
+//   - whole-word tokens ("focus", "appmon", "guard", "watcher",
+//     "kill"): rejected if they appear ANYWHERE in the base
+//     (these are not substrings of any legitimate prefix/suffix
+//     we ship).
+//   - identifier-context tokens ("daemon", "ensure"): rejected only
+//     when they appear as a standalone dot-separated component, since
+//     "daemon" is a legitimate role suffix and substrings of it could
+//     legitimately appear in a third-party bundle ID.
+func TestRandomBaseNoLeakedProjectStrings(t *testing.T) {
+	whole := []string{"focus", "appmon", "guard", "watcher", "kill"}
+	standalone := []string{"ensure"}
+
+	for i := 0; i < 1000; i++ {
+		base := RandomBase()
+		lower := strings.ToLower(base)
+		for _, tok := range whole {
+			if strings.Contains(lower, tok) {
+				t.Fatalf("base %q leaks project token %q", base, tok)
+			}
+		}
+		parts := strings.Split(lower, ".")
+		for _, tok := range standalone {
+			for _, p := range parts {
+				if p == tok {
+					t.Fatalf("base %q leaks standalone token %q", base, tok)
+				}
+			}
+		}
+	}
+}
+
+// TestRandomBaseSamplesVerbose prints 5 sample bases for human
+// inspection (visible under `go test -v`). Useful for verifying at
+// review time that the labels actually look plausible.
+func TestRandomBaseSamplesVerbose(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		t.Logf("sample %d: %s", i+1, RandomBase())
 	}
 }


### PR DESCRIPTION
## Summary
Widens \`daemon/internal/relocate/relocate.go\` pools:
- **prefixes**: 6 (all \`com.apple.*\`) → **69** (Apple subsystems + Adobe, Microsoft, Google, Mozilla, Dropbox, Spotify, Zoom, Docker, Tailscale, 1Password, Slack, Notion, Figma, Linear, GitHub Desktop, JetBrains, Brave, Firefox, VS Code, etc.)
- **suffixes**: 5 → **65** (common launchd role names: helper, agent, daemon, updater, sync, telemetry, crashreporter, configd, prefsd, …)
- **random hex tail**: 4 → **5 random bytes (10 hex chars)** in both \`RandomBase()\` and \`RandomBinaryName()\`

**Total entropy: ~2M → ~4.93e15 combinations.** Defeats \`launchctl print system | grep com.apple.\(metadata\|cfprefsd\|...\)\` glob attack.

Bonus: new labels are indistinguishable from legitimate third-party launchd labels found on any Mac developer machine.

## API stable
- \`RandomBase()\` and \`RandomBinaryName()\` signatures unchanged
- \`RoleLabel\`, \`RelocateInto\`, \`HiddenWorkdir\` untouched
- Existing callers in \`osadapter/spec.go\` and \`cmd/daemon/main.go\` work unchanged

## Sample outputs
\`\`\`
org.mozilla.updater.installer.2d4da230a8
com.apple.locationd.reportd.faa607be4f
com.apple.cfprefsd.quicklookd.44e96f92b5
com.apple.spotlight.poller.31fbd18c43
com.microsoft.OneAuth.pushd.c40efe0d5a
\`\`\`

## Honesty
- This is **friction not crypto**. The pool is in source — anyone who can read the repo knows the set. Defeats enumeration, not insider attack.
- **Existing installs keep their old narrow-pool names** until they next reinstall or run \`daemon self-update <new-daemon-tag>\` (which now rotates to a fresh disguised name drawn from the wider pool).

## Test plan
- [x] 9 tests in \`daemon/internal/relocate\` pass \`-race -count=1\`
- [x] All 8 daemon packages green locally
- [x] \`gofmt -s -l daemon\` clean
- [ ] CI green
- [ ] Copilot review addressed
- [ ] Tag daemon-v0.2.0, \`sudo daemon self-update daemon-v0.2.0\` on laptop — confirm new install uses a fresh name from the wider pool

## Notes
- \`TestRandomBaseNoLeakedProjectStrings\` checks generated bases don't contain "focus", "appmon", "guard", "watcher", "kill", "ensure" (alone). Excludes "daemon" — that's a legitimate launchd role suffix on many third-party labels (\`com.google.keystone.daemon\`, \`us.zoom.ZoomDaemon\`).