### PR TITLE
fix(ci): scope legacy Release workflow to appmon-v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
-name: Release
+name: Release (legacy app_mon)
 
+# Only fires on appmon-v* tags. Previously `v*` which collided with the
+# platform's release tag pattern — every platform release (v0.8.0…
+# v0.12.1) triggered this workflow and failed because app_mon was
+# removed from go.work during the platform refactor. Scoped down here
+# so platform releases don't surface false-red CI. Legacy appmon
+# releases (if ever cut) use the `appmon-v*` tag prefix.
 on:
   push:
     tags:
-      - 'v*'
+      - 'appmon-v*'
 
 permissions:
   contents: write


### PR DESCRIPTION
Stops the legacy app_mon goreleaser from firing on every platform release tag and failing because app_mon was removed from go.work during the platform refactor. 5 platform releases (v0.8.0–v0.12.1) have had silently-red Release CI since the refactor. Caught by user. Single-line trigger fix.