### PR TITLE
feat: single-engine install with runtime privilege-drop (FEATURE 8)

### DIFF
--- a/daemon/cmd/daemon/install_msg_test.go
+++ b/daemon/cmd/daemon/install_msg_test.go
@@ -7,6 +7,34 @@ import (
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 )
 
+// FEATURE 08 / ADR-0010: a failed SYSTEM install must fail fast with an
+// explicit "re-run without sudo for the degraded user install" hint and
+// MUST NOT silently fall back. A failed user/test install gets no hint
+// (there is nothing lower to downgrade to).
+func TestInstallFailureHint(t *testing.T) {
+	sys := installFailureHint(mode.System, "v1.2.3")
+	if len(sys) == 0 {
+		t.Fatal("system-install failure must produce an explicit hint")
+	}
+	joined := strings.Join(sys, "\n")
+	if !strings.Contains(joined, "NOT falling back") {
+		t.Errorf("hint must state no auto-fallback, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "WITHOUT sudo") {
+		t.Errorf("hint must tell operator to re-run without sudo, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "v1.2.3") {
+		t.Errorf("hint must echo the desired version, got:\n%s", joined)
+	}
+
+	if installFailureHint(mode.User, "v1.2.3") != nil {
+		t.Error("user-install failure must NOT print a downgrade hint")
+	}
+	if installFailureHint(mode.Test, "v1.2.3") != nil {
+		t.Error("test-install failure must NOT print a downgrade hint")
+	}
+}
+
 // A successful USER install is the deliberate degraded fallback: it must
 // honestly report that the system-level protections are unavailable.
 // System/Test installs print no such notice.

--- a/daemon/cmd/daemon/install_msg_test.go
+++ b/daemon/cmd/daemon/install_msg_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// A successful USER install is the deliberate degraded fallback: it must
+// honestly report that the system-level protections are unavailable.
+// System/Test installs print no such notice.
+func TestInstallCoverageNotice(t *testing.T) {
+	usr := installCoverageNotice(mode.User)
+	if len(usr) == 0 {
+		t.Fatal("user-mode install must print a coverage notice")
+	}
+	joined := strings.Join(usr, "\n")
+	if !strings.Contains(joined, "UNAVAILABLE") {
+		t.Errorf("notice must mark system protections unavailable, got:\n%s", joined)
+	}
+	if !strings.Contains(strings.ToLower(joined), "sudo") {
+		t.Errorf("notice must point at the sudo (full) install, got:\n%s", joined)
+	}
+
+	if installCoverageNotice(mode.System) != nil {
+		t.Error("system-mode install must NOT print the degraded notice")
+	}
+	if installCoverageNotice(mode.Test) != nil {
+		t.Error("test-mode install must NOT print the degraded notice")
+	}
+}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -321,8 +321,21 @@ func doInstall(args []string) int {
 		fmt.Fprintln(os.Stderr, "executable:", err)
 		return 1
 	}
-	// The daemon decides the install mode at bootstrap: test (e2e builds
-	// only), else system when run as root (sudo), else user.
+	// Single mesh per install (FEATURE 08 / ADR-0010). The operator's
+	// invocation chooses ONE mode — there is never a second simultaneous
+	// mesh:
+	//
+	//   sudo daemon install  → System mesh: runs EVERY plugin. system
+	//                          plugins run as root; current_user plugins
+	//                          (skill-protector) run via the platform's
+	//                          runtime privilege-drop to the console user.
+	//   daemon install       → User mesh: degraded fallback. Runs ONLY
+	//                          current_user plugins; system plugins are
+	//                          reported unavailable (reinstall with sudo
+	//                          for full coverage).
+	//
+	// We never install both, and we never silently downgrade system→user
+	// (see the fail-fast handling on osadapter.Install below).
 	m := mode.Resolve()
 	if wantTest() {
 		m = mode.Test
@@ -364,8 +377,25 @@ func doInstall(args []string) int {
 		fmt.Fprintln(os.Stderr, "install:", err)
 		return 1
 	}
-	fmt.Printf("installed (desired platform = %s)\n", *desired)
+	fmt.Printf("installed %s mesh (desired platform = %s)\n", m, *desired)
+	for _, line := range installCoverageNotice(m) {
+		fmt.Println(line)
+	}
 	return 0
+}
+
+// installCoverageNotice returns the honest coverage notice printed after
+// a successful install. A USER install is the deliberate degraded
+// fallback, so we say the system-level protections are unavailable and
+// how to get them. System/Test installs get no notice (nil). Pure + tested.
+func installCoverageNotice(m mode.Mode) []string {
+	if m != mode.User {
+		return nil
+	}
+	return []string{
+		"note: user-mode install — only the Claude skill protector runs.",
+		"note: site/game/packet protections are UNAVAILABLE; reinstall with sudo for full coverage.",
+	}
 }
 
 // doEnsure is the ensurer role (StartInterval): recreate any missing

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -374,7 +374,15 @@ func doInstall(args []string) int {
 		return 1
 	}
 	if err := osadapter.Install(spec); err != nil {
+		// Fail fast, no silent downgrade (FEATURE 08 / ADR-0010). If the
+		// operator clearly intended the full (system) install — they ran
+		// with sudo, so euid is root — and it failed, we exit non-zero and
+		// tell them how to choose the degraded user install EXPLICITLY. We
+		// do NOT auto-retry as user: switching is the operator's decision.
 		fmt.Fprintln(os.Stderr, "install:", err)
+		for _, line := range installFailureHint(m, *desired) {
+			fmt.Fprintln(os.Stderr, line)
+		}
 		return 1
 	}
 	fmt.Printf("installed %s mesh (desired platform = %s)\n", m, *desired)
@@ -382,6 +390,22 @@ func doInstall(args []string) int {
 		fmt.Println(line)
 	}
 	return 0
+}
+
+// installFailureHint returns the operator guidance printed when
+// osadapter.Install fails. Only a failed SYSTEM install gets the
+// "re-run without sudo for the degraded user install" hint — we never
+// auto-downgrade; switching is an explicit operator choice. User/Test
+// installs get no extra hint (nil). Pure + tested.
+func installFailureHint(m mode.Mode, desired string) []string {
+	if m != mode.System {
+		return nil
+	}
+	return []string{
+		"install: full (system) install failed; NOT falling back to the limited user install.",
+		"install: to install the degraded user-only mode explicitly, re-run WITHOUT sudo:",
+		"install:   daemon install -v " + desired + "   (user mode: only the skill protector runs)",
+	}
 }
 
 // installCoverageNotice returns the honest coverage notice printed after

--- a/platform/internal/core/app/app.go
+++ b/platform/internal/core/app/app.go
@@ -233,7 +233,7 @@ func (a *App) BuildScheduler() (*scheduler.Scheduler, int, error) {
 			byID[p.Manifest.ID] = p
 		}
 	}
-	s := scheduler.New(runner.New(a.State), a.State, a.Log, a.Mode)
+	s := scheduler.New(runner.NewWithMode(a.State, a.Mode), a.State, a.Log, a.Mode)
 	n, err := s.Register(a.Config.Jobs, byID)
 	if err != nil {
 		return nil, 0, err

--- a/platform/internal/core/runner/privdrop.go
+++ b/platform/internal/core/runner/privdrop.go
@@ -1,0 +1,139 @@
+// Privilege-drop: when a system-mode (root) platform must run a plugin
+// whose manifest says run_as=current_user, the runner forks and setuids
+// to the logged-in console user BEFORE exec, so the plugin writes the
+// user's files as the user (never as root → /var/root/.claude corruption).
+//
+// Three silent-corruption edges are handled here and unit-tested:
+//
+//   - HOME: root's HOME is /var/root. The dropped child MUST get
+//     HOME=/Users/<console-user> or skill files land in root's home.
+//   - TMPDIR: root's TMPDIR (/var/folders/.../-Tmp-/ owned 0700 by root)
+//     is inaccessible to the dropped uid; CreateTemp would fail. We pin
+//     TMPDIR=/tmp (world-writable, sticky) for the child.
+//   - no console user: at loginwindow / fast-user-switch, `stat -f %u
+//     /dev/console` returns 0 (root). Running the plugin then would write
+//     as root. We SKIP the tick instead (retry next schedule).
+package runner
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+
+	"github.com/eliteGoblin/focusd/platform/internal/core/plugin"
+	"github.com/eliteGoblin/focusd/platform/internal/osadapter"
+)
+
+// dropAction is what runOnce should do about privileges for one exec.
+type dropAction int
+
+const (
+	// dropNone: run the plugin with the platform's own credentials
+	// (system→root for system plugins; user→the logged-in user already).
+	dropNone dropAction = iota
+	// dropToUser: system platform must setuid to the console user before
+	// exec (run_as=current_user under root). plan carries the credentials.
+	dropToUser
+	// dropSkipNoConsoleUser: system platform wants to drop to the console
+	// user but no one is logged in at the screen (console uid 0). Skip the
+	// tick rather than write the user's files as root.
+	dropSkipNoConsoleUser
+)
+
+// dropPlan is the resolved privilege-drop decision for one exec.
+type dropPlan struct {
+	action dropAction
+	// Populated only when action == dropToUser.
+	uid     int
+	gid     int
+	homeEnv string // HOME=/Users/<name>
+	userEnv string // USER=<name>
+	logEnv  string // LOGNAME=<name>
+}
+
+// consoleUserFn discovers the logged-in console user's identity. The
+// real implementation shells out to `stat -f %u /dev/console` (no cgo)
+// and resolves the username/home/gid via os/user. Tests inject a fake
+// to exercise the no-console-user skip and the env-reseed paths without
+// being root or touching /dev/console.
+//
+// Returns (uid, gid, name, home, err). A uid of 0 means "no console
+// user" (loginwindow / fast-user-switch) and MUST trigger the skip.
+type consoleUserFn func() (uid, gid int, name, home string, err error)
+
+// resolvePlan decides what to do for a (mode, run_as) pair. It is the
+// pure can-this-exec-proceed core, unit-tested via a fake consoleUser.
+//
+//   - user platform: current_user runs natively (we ARE the user);
+//     system plugins never reach here (the scheduler gates them).
+//   - system platform: system plugins run natively as root; current_user
+//     plugins drop to the console user, or skip if none is logged in.
+func resolvePlan(mode osadapter.RunMode, runAs string, consoleUser consoleUserFn) (dropPlan, error) {
+	// Only a root/system platform ever needs to step down. In every other
+	// case the platform already holds the right identity for the plugin.
+	if mode != osadapter.ModeSystem {
+		return dropPlan{action: dropNone}, nil
+	}
+	switch runAs {
+	case plugin.RunAsCurrentUser, plugin.RunAsActiveUser:
+		uid, gid, name, home, err := consoleUser()
+		if err != nil {
+			return dropPlan{}, fmt.Errorf("discover console user: %w", err)
+		}
+		if uid == 0 {
+			// No one logged in at the screen (loginwindow / FUS). Running
+			// now would write the user's files as root → corruption. Skip.
+			return dropPlan{action: dropSkipNoConsoleUser}, nil
+		}
+		return dropPlan{
+			action:  dropToUser,
+			uid:     uid,
+			gid:     gid,
+			homeEnv: "HOME=" + home,
+			userEnv: "USER=" + name,
+			logEnv:  "LOGNAME=" + name,
+		}, nil
+	default:
+		// system (or legacy "") plugin under a root platform: run as root.
+		return dropPlan{action: dropNone}, nil
+	}
+}
+
+// dropEnv is the reseeded environment for a privilege-dropped child.
+// Root's environment (HOME=/var/root, TMPDIR=/var/folders/.../root-only)
+// would corrupt or break the child, so we hand it an explicit, sane set
+// rather than inheriting the platform's. PATH is a conventional default;
+// the plugin contract does not depend on the platform's PATH.
+func (p dropPlan) dropEnv() []string {
+	return []string{
+		p.homeEnv,
+		p.userEnv,
+		p.logEnv,
+		"PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+		// Root's TMPDIR is unreadable to the dropped uid → CreateTemp
+		// fails. /tmp is world-writable + sticky, safe for any uid.
+		"TMPDIR=/tmp",
+	}
+}
+
+// realConsoleUser is the production console-user discovery. It shells
+// out to `stat -f %u /dev/console` (darwin) to get the uid, then resolves
+// the rest via os/user. See consoleUserDiscover (platform-specific).
+func realConsoleUser() (uid, gid int, name, home string, err error) {
+	uid, err = consoleUID()
+	if err != nil {
+		return 0, 0, "", "", err
+	}
+	if uid == 0 {
+		return 0, 0, "", "", nil // caller maps uid 0 → skip
+	}
+	u, err := user.LookupId(strconv.Itoa(uid))
+	if err != nil {
+		return 0, 0, "", "", fmt.Errorf("lookup uid %d: %w", uid, err)
+	}
+	gid, err = strconv.Atoi(u.Gid)
+	if err != nil {
+		return 0, 0, "", "", fmt.Errorf("parse gid %q: %w", u.Gid, err)
+	}
+	return uid, gid, u.Username, u.HomeDir, nil
+}

--- a/platform/internal/core/runner/privdrop_darwin.go
+++ b/platform/internal/core/runner/privdrop_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package runner
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// consoleUID returns the uid of the user logged in at the graphical
+// console via `stat -f %u /dev/console`. No cgo — we shell out, as the
+// daemon does elsewhere. A return of 0 means root owns /dev/console,
+// i.e. no one is logged in at the screen (loginwindow / fast-user-switch);
+// the caller maps that to a skip.
+func consoleUID() (int, error) {
+	out, err := exec.Command("stat", "-f", "%u", "/dev/console").Output()
+	if err != nil {
+		return 0, fmt.Errorf("stat /dev/console: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	uid, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("parse console uid %q: %w", s, err)
+	}
+	return uid, nil
+}

--- a/platform/internal/core/runner/privdrop_integration_darwin_test.go
+++ b/platform/internal/core/runner/privdrop_integration_darwin_test.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/platform/internal/core/plugin"
+	"github.com/eliteGoblin/focusd/platform/internal/core/state"
+	"github.com/eliteGoblin/focusd/platform/internal/osadapter"
+	"github.com/eliteGoblin/focusd/platform/internal/testutil"
+)
+
+// TestPrivDropExecAsConsoleUser is the real fork→setuid integration check.
+// It ONLY runs when the test process is actually root on a real Mac with a
+// console user logged in — otherwise the kernel won't honor the Credential.
+// CI (non-root) and root-but-loginwindow both skip cleanly.
+//
+// It runs a stub plugin under a system-mode runner and asserts the child
+// observed: euid == console uid, HOME == the user's home, and a TMPDIR it
+// can actually write to (the three silent-corruption edges, end to end).
+func TestPrivDropExecAsConsoleUser(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("privilege-drop integration test requires root (not root)")
+	}
+	uid, gid, name, home, err := realConsoleUser()
+	if err != nil {
+		t.Skipf("cannot discover console user: %v", err)
+	}
+	if uid == 0 {
+		t.Skip("no console user logged in (loginwindow / fast-user-switch)")
+	}
+	_ = gid
+	_ = name
+
+	db, err := state.Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// The stub writes its observed euid, $HOME, and a temp-file-creation
+	// probe into an output file the test reads back. Make the output dir
+	// world-writable so the dropped uid can write it.
+	outDir := t.TempDir()
+	if err := os.Chmod(outDir, 0o777); err != nil {
+		t.Fatalf("chmod outdir: %v", err)
+	}
+	outFile := filepath.Join(outDir, "observed.txt")
+
+	script := strings.Join([]string{
+		`euid=$(id -u)`,
+		`# Probe TMPDIR writability (root's TMPDIR would be unwritable here).`,
+		`if t=$(mktemp 2>/dev/null); then tmpok=YES; rm -f "$t"; else tmpok=NO; fi`,
+		`printf 'euid=%s\nhome=%s\ntmpok=%s\n' "$euid" "$HOME" "$tmpok" > '` + outFile + `'`,
+		`echo '{"status":"ok"}'`,
+	}, "\n")
+
+	p := testutil.ScriptPlugin(t, "skill-protector", script)
+	p.Manifest.RunAs = plugin.RunAsCurrentUser
+
+	r := NewWithMode(db, osadapter.ModeSystem)
+	out, err := r.Run(context.Background(), Job{ID: "j1"}, p, "scheduler")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Status != state.RunStatusOK {
+		t.Fatalf("status = %q (stderr=%q)", out.Status, out.Stderr)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read observed output: %v", err)
+	}
+	obs := parseKV(string(data))
+
+	if obs["euid"] != strconv.Itoa(uid) {
+		t.Errorf("child euid = %q, want console uid %d", obs["euid"], uid)
+	}
+	if obs["home"] != home {
+		t.Errorf("child HOME = %q, want %q", obs["home"], home)
+	}
+	if obs["tmpok"] != "YES" {
+		t.Errorf("child could not create a temp file (TMPDIR reseed broken): %q", obs["tmpok"])
+	}
+}
+
+func parseKV(s string) map[string]string {
+	m := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		if i := strings.IndexByte(line, '='); i >= 0 {
+			m[line[:i]] = line[i+1:]
+		}
+	}
+	return m
+}

--- a/platform/internal/core/runner/privdrop_other.go
+++ b/platform/internal/core/runner/privdrop_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package runner
+
+import "errors"
+
+// consoleUID is darwin-only (runtime privilege-drop targets macOS's
+// /dev/console + launchd model). On other platforms the system-mode
+// privilege-drop path is never reached in production, but we keep a
+// stub so the package builds everywhere.
+func consoleUID() (int, error) {
+	return 0, errors.New("console-user discovery is darwin-only")
+}

--- a/platform/internal/core/runner/privdrop_test.go
+++ b/platform/internal/core/runner/privdrop_test.go
@@ -1,0 +1,164 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/platform/internal/core/plugin"
+	"github.com/eliteGoblin/focusd/platform/internal/core/state"
+	"github.com/eliteGoblin/focusd/platform/internal/osadapter"
+	"github.com/eliteGoblin/focusd/platform/internal/testutil"
+)
+
+// fakeConsoleUser returns a consoleUserFn yielding the given identity.
+func fakeConsoleUser(uid, gid int, name, home string, err error) consoleUserFn {
+	return func() (int, int, string, string, error) { return uid, gid, name, home, err }
+}
+
+// --- resolvePlan matrix -----------------------------------------------------
+
+func TestResolvePlanMatrix(t *testing.T) {
+	const (
+		uid  = 501
+		gid  = 20
+		name = "frank"
+		home = "/Users/frank"
+	)
+	cu := fakeConsoleUser(uid, gid, name, home, nil)
+
+	cases := []struct {
+		name   string
+		mode   osadapter.RunMode
+		runAs  string
+		want   dropAction
+		wantH  string // expected HOME= when dropToUser
+		wantTM bool   // expect TMPDIR=/tmp in env when dropToUser
+	}{
+		{"user platform current_user runs native", osadapter.ModeUser, plugin.RunAsCurrentUser, dropNone, "", false},
+		{"user platform system runs native", osadapter.ModeUser, plugin.RunAsSystem, dropNone, "", false},
+		{"system platform system runs as root", osadapter.ModeSystem, plugin.RunAsSystem, dropNone, "", false},
+		{"system platform current_user drops", osadapter.ModeSystem, plugin.RunAsCurrentUser, dropToUser, "HOME=/Users/frank", true},
+		{"system platform active_user drops", osadapter.ModeSystem, plugin.RunAsActiveUser, dropToUser, "HOME=/Users/frank", true},
+		{"system platform empty runs as root", osadapter.ModeSystem, "", dropNone, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := resolvePlan(tc.mode, tc.runAs, cu)
+			if err != nil {
+				t.Fatalf("resolvePlan: %v", err)
+			}
+			if plan.action != tc.want {
+				t.Fatalf("action = %d, want %d", plan.action, tc.want)
+			}
+			if tc.want == dropToUser {
+				if plan.uid != uid || plan.gid != gid {
+					t.Errorf("uid/gid = %d/%d, want %d/%d", plan.uid, plan.gid, uid, gid)
+				}
+				if plan.homeEnv != tc.wantH {
+					t.Errorf("homeEnv = %q, want %q", plan.homeEnv, tc.wantH)
+				}
+			}
+		})
+	}
+}
+
+// EDGE 1 (no console user): console uid 0 → skip, never run as root.
+func TestResolvePlanNoConsoleUserSkips(t *testing.T) {
+	cu := fakeConsoleUser(0, 0, "", "", nil) // root owns /dev/console
+	plan, err := resolvePlan(osadapter.ModeSystem, plugin.RunAsCurrentUser, cu)
+	if err != nil {
+		t.Fatalf("resolvePlan: %v", err)
+	}
+	if plan.action != dropSkipNoConsoleUser {
+		t.Fatalf("action = %d, want dropSkipNoConsoleUser (%d)", plan.action, dropSkipNoConsoleUser)
+	}
+}
+
+func TestResolvePlanConsoleUserError(t *testing.T) {
+	cu := fakeConsoleUser(0, 0, "", "", errors.New("stat failed"))
+	if _, err := resolvePlan(osadapter.ModeSystem, plugin.RunAsCurrentUser, cu); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+// EDGE 2 + 3 (HOME + TMPDIR reseed): the dropped child's environment must
+// carry the user's HOME and a writable TMPDIR=/tmp (root's would corrupt /
+// break the child). Verify the exact env the runner hands to the kernel.
+func TestDropEnvReseedsHomeUserLognameTmpdir(t *testing.T) {
+	plan, err := resolvePlan(
+		osadapter.ModeSystem, plugin.RunAsCurrentUser,
+		fakeConsoleUser(501, 20, "frank", "/Users/frank", nil),
+	)
+	if err != nil {
+		t.Fatalf("resolvePlan: %v", err)
+	}
+	env := plan.dropEnv()
+	want := map[string]bool{
+		"HOME=/Users/frank": false,
+		"USER=frank":        false,
+		"LOGNAME=frank":     false,
+		"TMPDIR=/tmp":       false,
+	}
+	for _, e := range env {
+		if _, ok := want[e]; ok {
+			want[e] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("dropEnv missing %q (got %v)", k, env)
+		}
+	}
+	// PATH must be present and non-empty (the child gets a sane default).
+	hasPath := false
+	for _, e := range env {
+		if len(e) > 5 && e[:5] == "PATH=" {
+			hasPath = true
+		}
+	}
+	if !hasPath {
+		t.Errorf("dropEnv missing PATH (got %v)", env)
+	}
+}
+
+// The no-console-user skip path at the runner layer: a system-mode runner
+// dispatching a current_user plugin with no console user records an
+// UNAVAILABLE run (queryable) and never execs the plugin.
+func TestRunOnceNoConsoleUserRecordsUnavailable(t *testing.T) {
+	db, err := state.Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	r := NewWithMode(db, osadapter.ModeSystem)
+	r.consoleUser = fakeConsoleUser(0, 0, "", "", nil) // nobody logged in
+
+	// A plugin that, if it DID run, would create a sentinel file. We assert
+	// it never runs.
+	sentinel := filepath.Join(t.TempDir(), "ran")
+	p := testutil.ScriptPlugin(t, "skill-protector",
+		"touch '"+sentinel+"'\n"+`echo '{"status":"ok"}'`)
+	p.Manifest.RunAs = plugin.RunAsCurrentUser
+
+	out, err := r.Run(context.Background(), Job{ID: "j1"}, p, "scheduler")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.Status != state.RunStatusUnavailable {
+		t.Fatalf("status = %q, want unavailable", out.Status)
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Fatal("plugin executed as root despite no console user — corruption risk")
+	}
+	last, err := db.Runs.LastByStatus("j1", state.RunStatusUnavailable)
+	if err != nil {
+		t.Fatalf("unavailable run not persisted: %v", err)
+	}
+	if last.Status != state.RunStatusUnavailable {
+		t.Errorf("persisted status = %q", last.Status)
+	}
+}

--- a/platform/internal/core/runner/proc_unix.go
+++ b/platform/internal/core/runner/proc_unix.go
@@ -7,13 +7,36 @@ import (
 	"syscall"
 )
 
-// configureProc puts the plugin in its own process group and makes
-// context-cancel kill the whole group. Without this a plugin that
-// spawns children (e.g. a shell running `sleep`) would keep the stdout
-// pipe open after the leader is killed, blocking cmd.Run past the
-// timeout.
-func configureProc(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+// configureProc puts the plugin in its own process group (so context-
+// cancel kills the whole group) and, when plan.action == dropToUser,
+// makes the child fork→setuid to the console user before exec with a
+// reseeded environment.
+//
+// Without the process group a plugin that spawns children (e.g. a shell
+// running `sleep`) would keep the stdout pipe open after the leader is
+// killed, blocking cmd.Run past the timeout.
+//
+// The Credential is applied by the kernel between fork and exec, so this
+// does NOT change the platform's own privileges — only the child's. The
+// AMFI path-rotation (CDHash recomputed at exec from the on-disk inode)
+// is unaffected by the credential.
+func configureProc(cmd *exec.Cmd, plan dropPlan) {
+	attr := &syscall.SysProcAttr{Setpgid: true}
+	if plan.action == dropToUser {
+		attr.Credential = &syscall.Credential{
+			Uid: uint32(plan.uid),
+			Gid: uint32(plan.gid),
+			// Don't try to set supplementary groups: as root we could,
+			// but we deliberately keep it minimal — the plugin only needs
+			// the user's own files. NoSetGroups avoids an EPERM-prone
+			// setgroups call and keeps the drop simple/predictable.
+			NoSetGroups: true,
+		}
+		// Reseed the environment: root's HOME/TMPDIR would corrupt or
+		// break the child (see privdrop.go). Replace it wholesale.
+		cmd.Env = plan.dropEnv()
+	}
+	cmd.SysProcAttr = attr
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil

--- a/platform/internal/core/runner/proc_windows.go
+++ b/platform/internal/core/runner/proc_windows.go
@@ -6,4 +6,5 @@ import "os/exec"
 
 // configureProc is a no-op on Windows; CommandContext's default kill of
 // the process plus WaitDelay is sufficient for the current job model.
-func configureProc(cmd *exec.Cmd) {}
+// Privilege-drop (plan) is darwin-only and never set here.
+func configureProc(cmd *exec.Cmd, _ dropPlan) {}

--- a/platform/internal/core/runner/runner.go
+++ b/platform/internal/core/runner/runner.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/eliteGoblin/focusd/platform/internal/core/plugin"
 	"github.com/eliteGoblin/focusd/platform/internal/core/state"
+	"github.com/eliteGoblin/focusd/platform/internal/osadapter"
 )
 
 // Outcome is the terminal result of a (possibly retried) job execution.
@@ -41,10 +42,37 @@ type Outcome struct {
 // Runner executes plugins and persists run history.
 type Runner struct {
 	DB *state.DB
+	// Mode is the platform's run mode. It gates runtime privilege-drop:
+	// only a system (root) platform steps down to the console user for a
+	// run_as=current_user plugin. Defaults to ModeUser (no drop) so tests
+	// and non-root platforms behave as before.
+	Mode osadapter.RunMode
+	// consoleUser discovers the logged-in console user (uid/gid/name/home)
+	// for the privilege-drop. nil => realConsoleUser. Tests inject a fake
+	// to exercise the no-console-user skip and env-reseed without root.
+	consoleUser consoleUserFn
 }
 
-// New builds a Runner.
-func New(db *state.DB) *Runner { return &Runner{DB: db} }
+// New builds a Runner in user mode (no privilege-drop). System-mode
+// platforms use NewWithMode so the runner can step down for current_user
+// plugins.
+func New(db *state.DB) *Runner { return &Runner{DB: db, Mode: osadapter.ModeUser} }
+
+// NewWithMode builds a Runner for the given platform run mode. A system
+// (root) runner will fork→setuid to the console user for current_user
+// plugins (see privdrop.go).
+func NewWithMode(db *state.DB, mode osadapter.RunMode) *Runner {
+	return &Runner{DB: db, Mode: mode}
+}
+
+// resolveConsoleUser returns the discovery seam, defaulting to the real
+// `stat -f %u /dev/console` implementation when none was injected.
+func (r *Runner) resolveConsoleUser() consoleUserFn {
+	if r.consoleUser != nil {
+		return r.consoleUser
+	}
+	return realConsoleUser
+}
 
 // Job is the minimal job spec the runner needs (decoupled from config).
 type Job struct {
@@ -71,9 +99,13 @@ func (r *Runner) Run(ctx context.Context, job Job, p plugin.Discovered, triggere
 		}
 		out.Attempts = attempt
 		last = out
-		// Terminal: success or a controlled failure (exit 1 is a real
-		// job answer, not a transient error). Only error/timeout retry.
-		if out.Status == state.RunStatusOK || out.Status == state.RunStatusFailed {
+		// Terminal: success, a controlled failure (exit 1 is a real job
+		// answer), or unavailable (no console user — retrying inside this
+		// tick won't help; the next scheduled tick retries). Only
+		// error/timeout retry.
+		if out.Status == state.RunStatusOK ||
+			out.Status == state.RunStatusFailed ||
+			out.Status == state.RunStatusUnavailable {
 			break
 		}
 		if ctx.Err() != nil {
@@ -84,6 +116,22 @@ func (r *Runner) Run(ctx context.Context, job Job, p plugin.Discovered, triggere
 }
 
 func (r *Runner) runOnce(ctx context.Context, job Job, p plugin.Discovered, triggeredBy string) (Outcome, error) {
+	// Resolve the privilege-drop plan BEFORE doing any work. If a root
+	// platform must run a current_user plugin but no console user is
+	// logged in, skip the tick cleanly (retry next schedule) rather than
+	// writing the user's files as root → /var/root corruption.
+	plan, err := resolvePlan(r.Mode, p.Manifest.RunAs, r.resolveConsoleUser())
+	if err != nil {
+		return Outcome{}, err
+	}
+	if plan.action == dropSkipNoConsoleUser {
+		const reason = "no console user logged in; deferring current_user plugin"
+		if rerr := r.DB.Runs.RecordUnavailable(job.ID, p.Manifest.ID, reason); rerr != nil {
+			return Outcome{}, rerr
+		}
+		return Outcome{Status: state.RunStatusUnavailable, Message: reason}, nil
+	}
+
 	cfgPath, cleanup, err := writeJobConfig(job, p.Manifest.ID)
 	if err != nil {
 		return Outcome{}, err
@@ -104,7 +152,7 @@ func (r *Runner) runOnce(ctx context.Context, job Job, p plugin.Discovered, trig
 
 	start := time.Now()
 	cmd := exec.CommandContext(runCtx, p.BinaryPath, "run", "--config", cfgPath)
-	configureProc(cmd)
+	configureProc(cmd, plan)
 	// Backstop: if the killed plugin (or a grandchild) still holds the
 	// output pipes, force Run to return shortly after the kill instead
 	// of hanging until the child exits on its own.

--- a/platform/internal/core/runner/runner.go
+++ b/platform/internal/core/runner/runner.go
@@ -89,6 +89,14 @@ func (r *Runner) Run(ctx context.Context, job Job, p plugin.Discovered, triggere
 	if !p.OK || p.BinaryPath == "" {
 		return Outcome{}, fmt.Errorf("plugin %s is not runnable", p.Dir)
 	}
+	// Production discovery always attaches a non-nil Manifest to an OK
+	// plugin, but Run is a public API any caller (incl. tests) can reach
+	// with a hand-built Discovered. runOnce dereferences p.Manifest.RunAs
+	// first thing — guard it so a nil manifest is a clean error, not a
+	// panic. (go + security review, LOW.)
+	if p.Manifest == nil {
+		return Outcome{}, fmt.Errorf("plugin %s has no manifest", p.Dir)
+	}
 
 	attempts := job.Retry + 1
 	var last Outcome

--- a/platform/internal/core/scheduler/scheduler.go
+++ b/platform/internal/core/scheduler/scheduler.go
@@ -34,9 +34,10 @@ type Scheduler struct {
 }
 
 // New builds a scheduler. The runner and DB must be ready. mode is the
-// platform's run mode; it gates dispatch against each plugin's run_as
-// so a system-mode platform never executes user-domain plugins (which
-// would, e.g., chown ~/.claude/ to root).
+// platform's run mode; it gates dispatch via CanDispatch. A system-mode
+// platform serves current_user plugins through the runner's runtime
+// privilege-drop (it does NOT run them as root); a user-mode platform
+// cannot serve system plugins and marks them unavailable.
 func New(r *runner.Runner, db *state.DB, log *slog.Logger, mode osadapter.RunMode) *Scheduler {
 	return &Scheduler{
 		cron:       cron.New(),
@@ -49,26 +50,37 @@ func New(r *runner.Runner, db *state.DB, log *slog.Logger, mode osadapter.RunMod
 	}
 }
 
-// RunAsMatches reports whether a plugin manifest's run_as is compatible
-// with the platform's current run mode.
+// CanDispatch reports whether the platform's run mode can dispatch a
+// plugin with the given run_as. The semantics are "can this mode serve
+// this plugin", NOT "do they match" — a system platform serves BOTH its
+// own system plugins (native, as root) AND current_user plugins (via the
+// runner's fork→setuid privilege-drop). FEATURE 08:
 //
-//   - "system"       runs only under ModeSystem
-//   - "current_user" / "active_user" run only under ModeUser
-//   - ""             is legacy / unknown: always run (no gate)
+//   - system platform: CAN dispatch system (native) AND current_user
+//     (priv-drop to the console user). The runner handles the drop and,
+//     if no console user is logged in, defers the tick as "unavailable".
+//   - user platform: CAN dispatch current_user (native — it IS the user)
+//     but CANNOT dispatch system (no escalation). System plugins are
+//     reported UNAVAILABLE, not failed: reinstall with admin for them.
+//   - "" (legacy/unknown run_as): always dispatchable (no gate).
 //
-// Mismatched jobs are skipped at dispatch time without recording a
-// failed run — they are a no-op for this platform instance.
-func RunAsMatches(runAs string, mode osadapter.RunMode) bool {
+// A false return is NOT an error — it means "this plugin needs a
+// different install mode"; the caller records an unavailable run.
+func CanDispatch(runAs string, mode osadapter.RunMode) bool {
 	switch runAs {
 	case "":
 		return true // legacy behavior: no gate
 	case plugin.RunAsSystem:
+		// Only a system (root) platform can run a system plugin. A user
+		// platform cannot escalate → unavailable.
 		return mode == osadapter.ModeSystem
 	case plugin.RunAsCurrentUser, plugin.RunAsActiveUser:
-		return mode == osadapter.ModeUser
+		// Both modes can serve a current_user plugin: user natively, system
+		// via runtime privilege-drop in the runner.
+		return mode == osadapter.ModeUser || mode == osadapter.ModeSystem
 	default:
 		// Unknown values shouldn't reach here (manifest validation
-		// rejects them), but be conservative: skip rather than run.
+		// rejects them), but be conservative: do not dispatch.
 		return false
 	}
 }
@@ -117,19 +129,25 @@ func (s *Scheduler) trigger(j config.Job, p plugin.Discovered) {
 	s.triggered[j.ID]++
 	s.mu.Unlock()
 
-	// run_as gate: a plugin whose run_as does not match the platform's
-	// run mode is a no-op for this instance — not a failed run. This
-	// keeps user-domain plugins (skill-protector et al.) from being
-	// executed by a system-mode platform, which would corrupt user
-	// file ownership.
+	// can-dispatch gate: if this platform's mode cannot serve the plugin's
+	// run_as, the job is UNAVAILABLE in this install — not a failed run.
+	// The only such case is a `system` plugin under a user-mode platform
+	// (no escalation). A system platform serves current_user plugins via
+	// the runner's privilege-drop, so they pass this gate.
 	//
-	// At @every 5m a gated plugin fires 288×/day. We DON'T record a DB
-	// event (would fill platform_events) and log at Debug, with one
-	// Info "first-seen" log per (job, lifetime) so an operator looking
-	// at startup can still verify gating was applied. (Go-reviewer HIGH.)
-	if p.Manifest != nil && !RunAsMatches(p.Manifest.RunAs, s.mode) {
-		s.logFirstSkip(j.ID, p.Manifest.RunAs)
-		s.log.Debug("job skipped (run_as mismatch)",
+	// We record ONE "unavailable" run row (queryable by a future `daemon
+	// status` to show "requires system-mode install") then keep quiet: at
+	// @every 5m a gated plugin fires 288×/day, so we do NOT record a DB
+	// event or a fresh row per tick — only the first occurrence per (job,
+	// lifetime) gets an Info log + the unavailable row; subsequent ticks
+	// log at Debug and skip silently. (Go-reviewer HIGH dedup pattern.)
+	if p.Manifest != nil && !CanDispatch(p.Manifest.RunAs, s.mode) {
+		if s.logFirstSkip(j.ID, p.Manifest.RunAs) {
+			reason := fmt.Sprintf("plugin run_as=%q unavailable under %s-mode install (reinstall with admin for full coverage)",
+				p.Manifest.RunAs, string(s.mode))
+			_ = s.db.Runs.RecordUnavailable(j.ID, j.Plugin, reason)
+		}
+		s.log.Debug("job unavailable (run_as not servable in this mode)",
 			"job", j.ID, "run_as", p.Manifest.RunAs, "mode", string(s.mode))
 		return
 	}
@@ -188,19 +206,21 @@ func (s *Scheduler) persistJob(j config.Job, p plugin.Discovered) error {
 	return s.db.Plugins.Upsert(row)
 }
 
-// logFirstSkip emits a single Info-level "skipped: run_as mismatch"
-// the first time a given job is gated this process lifetime, so a
-// startup-log inspector can confirm gating; subsequent skips for the
-// same job log at Debug only.
-func (s *Scheduler) logFirstSkip(jobID, runAs string) {
+// logFirstSkip emits a single Info-level "unavailable in this mode" the
+// first time a given job is gated this process lifetime, so a startup-log
+// inspector can confirm gating; subsequent skips for the same job log at
+// Debug only. Returns true on that first occurrence so the caller records
+// exactly one "unavailable" run row per (job, lifetime) — not 288×/day.
+func (s *Scheduler) logFirstSkip(jobID, runAs string) bool {
 	s.mu.Lock()
 	first := !s.skipLogged[jobID]
 	s.skipLogged[jobID] = true
 	s.mu.Unlock()
 	if first {
-		s.log.Info("job will be skipped (run_as mismatch); silencing further occurrences",
+		s.log.Info("job unavailable in this install mode; silencing further occurrences",
 			"job", jobID, "run_as", runAs, "mode", string(s.mode))
 	}
+	return first
 }
 
 func (s *Scheduler) event(sev, typ, msg, jobID string) {

--- a/platform/internal/core/scheduler/scheduler.go
+++ b/platform/internal/core/scheduler/scheduler.go
@@ -145,7 +145,12 @@ func (s *Scheduler) trigger(j config.Job, p plugin.Discovered) {
 		if s.logFirstSkip(j.ID, p.Manifest.RunAs) {
 			reason := fmt.Sprintf("plugin run_as=%q unavailable under %s-mode install (reinstall with admin for full coverage)",
 				p.Manifest.RunAs, string(s.mode))
-			_ = s.db.Runs.RecordUnavailable(j.ID, j.Plugin, reason)
+			// Surface a failed write — the "unavailable" row is what a
+			// future `daemon status` reads to show the plugin as inactive;
+			// silently losing it would make status lie. (Go-reviewer MEDIUM.)
+			if rerr := s.db.Runs.RecordUnavailable(j.ID, j.Plugin, reason); rerr != nil {
+				s.log.Warn("record unavailable failed", "job", j.ID, "err", rerr)
+			}
 		}
 		s.log.Debug("job unavailable (run_as not servable in this mode)",
 			"job", j.ID, "run_as", p.Manifest.RunAs, "mode", string(s.mode))

--- a/platform/internal/core/scheduler/scheduler_test.go
+++ b/platform/internal/core/scheduler/scheduler_test.go
@@ -161,27 +161,27 @@ func TestTriggerAllowOverlapIgnoresLock(t *testing.T) {
 	}
 }
 
-func TestRunAsMatches(t *testing.T) {
+func TestCanDispatch(t *testing.T) {
 	cases := []struct {
 		name  string
 		runAs string
 		mode  osadapter.RunMode
 		want  bool
 	}{
-		{"empty always runs (user)", "", osadapter.ModeUser, true},
-		{"empty always runs (system)", "", osadapter.ModeSystem, true},
-		{"system on system", plugin.RunAsSystem, osadapter.ModeSystem, true},
-		{"system on user", plugin.RunAsSystem, osadapter.ModeUser, false},
-		{"current_user on user", plugin.RunAsCurrentUser, osadapter.ModeUser, true},
-		{"current_user on system", plugin.RunAsCurrentUser, osadapter.ModeSystem, false},
-		{"active_user on user", plugin.RunAsActiveUser, osadapter.ModeUser, true},
-		{"active_user on system", plugin.RunAsActiveUser, osadapter.ModeSystem, false},
-		{"unknown runs nowhere", "wat", osadapter.ModeUser, false},
+		{"empty always dispatchable (user)", "", osadapter.ModeUser, true},
+		{"empty always dispatchable (system)", "", osadapter.ModeSystem, true},
+		{"system on system runs native", plugin.RunAsSystem, osadapter.ModeSystem, true},
+		{"system on user unavailable (no escalation)", plugin.RunAsSystem, osadapter.ModeUser, false},
+		{"current_user on user runs native", plugin.RunAsCurrentUser, osadapter.ModeUser, true},
+		{"current_user on system runs via priv-drop", plugin.RunAsCurrentUser, osadapter.ModeSystem, true},
+		{"active_user on user runs native", plugin.RunAsActiveUser, osadapter.ModeUser, true},
+		{"active_user on system runs via priv-drop", plugin.RunAsActiveUser, osadapter.ModeSystem, true},
+		{"unknown dispatches nowhere", "wat", osadapter.ModeUser, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := RunAsMatches(tc.runAs, tc.mode); got != tc.want {
-				t.Errorf("RunAsMatches(%q,%q) = %v, want %v",
+			if got := CanDispatch(tc.runAs, tc.mode); got != tc.want {
+				t.Errorf("CanDispatch(%q,%q) = %v, want %v",
 					tc.runAs, tc.mode, got, tc.want)
 			}
 		})
@@ -200,9 +200,9 @@ func TestTriggerRunAsGate(t *testing.T) {
 		wantRun bool
 	}{
 		{"system platform + system job runs", osadapter.ModeSystem, plugin.RunAsSystem, true},
-		{"system platform + user job skipped", osadapter.ModeSystem, plugin.RunAsCurrentUser, false},
+		{"system platform + user job runs (via priv-drop)", osadapter.ModeSystem, plugin.RunAsCurrentUser, true},
 		{"user platform + user job runs", osadapter.ModeUser, plugin.RunAsCurrentUser, true},
-		{"user platform + system job skipped", osadapter.ModeUser, plugin.RunAsSystem, false},
+		{"user platform + system job unavailable", osadapter.ModeUser, plugin.RunAsSystem, false},
 		{"user platform + empty run_as runs", osadapter.ModeUser, "", true},
 		{"system platform + empty run_as runs", osadapter.ModeSystem, "", true},
 	}

--- a/platform/internal/core/state/models.go
+++ b/platform/internal/core/state/models.go
@@ -15,6 +15,14 @@ const (
 	RunStatusError    = "error"    // exit 2+ / spawn error
 	RunStatusTimedOut = "timedout" // killed on timeout
 	RunStatusSkipped  = "skipped"  // no-overlap skip
+	// RunStatusUnavailable marks a job that COULD NOT run in this install
+	// mode, distinct from a failure. Two cases:
+	//   - a system plugin under a user-mode platform (no escalation), and
+	//   - a current_user plugin under a system platform when no console
+	//     user is logged in (would corrupt the user's files as root).
+	// It feeds a future `daemon status` ("requires system-mode install"
+	// / "waiting for console user") without polluting failure metrics.
+	RunStatusUnavailable = "unavailable"
 )
 
 // Event severities.

--- a/platform/internal/core/state/runs.go
+++ b/platform/internal/core/state/runs.go
@@ -43,6 +43,19 @@ VALUES (?,?,?,?,?,?,?)`,
 	return err
 }
 
+// RecordUnavailable inserts a terminal unavailable-run row: the job could
+// not run in this install mode (system plugin under user-mode platform,
+// or current_user plugin under a system platform with no console user).
+// Distinct from skipped/failed so `daemon status` can show "unavailable"
+// rather than an error. reason is a short human string.
+func (r *JobRunRepo) RecordUnavailable(jobID, pluginID, reason string) error {
+	_, err := r.db.Exec(`
+INSERT INTO job_runs (job_id,plugin_id,started_at,ended_at,status,message,triggered_by)
+VALUES (?,?,?,?,?,?,?)`,
+		jobID, pluginID, now(), now(), RunStatusUnavailable, reason, "scheduler")
+	return err
+}
+
 // History returns the most recent runs for a job, newest first.
 func (r *JobRunRepo) History(jobID string, limit int) ([]JobRun, error) {
 	rows, err := r.db.Query(`SELECT id,job_id,plugin_id,plugin_version,started_at,

--- a/requirements/decisions/0009-dual-mesh.md
+++ b/requirements/decisions/0009-dual-mesh.md
@@ -1,0 +1,29 @@
+# ADR-0009 — Dual mesh (two protection engines)
+
+- **Status:** superseded by [ADR-0010](0010-single-mesh-fail-fast.md) on 2026-05-30
+- **Decided by:** implementation choice during FEATURE 1.6
+
+## Context
+
+The behavioural protection (re-injecting the Claude refusal skill into the
+user's home directory) must run as the **user**, because the files it writes
+must be owned by the user. The other protections (blocking sites, killing the
+game, packet filtering) need **admin** rights. A single admin engine refused to
+run the user-level task, so a **second, user-level engine** was installed
+alongside the admin one to host it.
+
+## Decision (at the time)
+
+Run two protection engines simultaneously — one admin, one user — each hosting
+the protections that match its privilege level.
+
+## Why it was superseded
+
+It worked but wasn't KISS: two engines, two state stores (which drift), two
+install footprints, and a doubled identity that a future server would have to
+reconcile for a single person. Replaced by a single engine that temporarily
+steps down to the user's identity for the one user-level task. See ADR-0010.
+
+## Kept for history
+This record stays so the dual-engine approach isn't re-proposed without
+remembering why it was set aside.

--- a/requirements/decisions/0010-single-mesh-fail-fast.md
+++ b/requirements/decisions/0010-single-mesh-fail-fast.md
@@ -1,0 +1,56 @@
+# ADR-0010 — Single mesh, operator-choice install, fail-fast
+
+- **Status:** accepted (2026-05-30)
+- **Supersedes:** ADR-0009 (dual-mesh runtime)
+- **Decided by:** Frank (product owner) + architect review + BA review
+
+## Context
+
+To keep the Claude-side skill re-injected on a schedule, the system briefly
+ran **two protection engines at once** — one with admin power, one as the
+user. It worked, but it doubled the moving parts: two engines, two state
+stores, two install footprints to keep aligned, and (looking ahead) two things
+a future server would have to track for one person. The product owner's
+reaction: *"seems not KISS"* — and the deeper worry from past experience,
+*"avoid confusing like the model was implemented I only caught up later."*
+
+## Decision
+
+**One protection engine per install. Never two at once.** The operator chooses
+the install flavour up front:
+
+- **Admin install** → full power. Runs every protection. The behavioural
+  (user-level) protection is handled by the single engine temporarily stepping
+  down to the user's identity only for that task.
+- **User install** → deliberately limited fallback for machines without admin
+  rights. Runs only the behavioural protection. The admin-level protections
+  are reported as **unavailable**, not broken.
+
+**Fail fast, no surprises.** If the admin install can't get admin rights, it
+**stops and says so** — it does NOT quietly fall back to the limited user
+install. The operator decides to switch, explicitly. (User's words: *"if sudo
+install not success, do not try to auto install as user. fail and let user
+switch to usermode."* and *"KISS fail fast. not trying being too smart. not
+surprise user."*)
+
+## Alternatives considered
+
+- **Keep dual engines (ADR-0009).** Rejected: doubles complexity, two state
+  stores drift over time, harder for a future server to reason about one user.
+- **Single user engine + ask-for-admin-per-action.** Rejected: would need broad
+  standing admin grants — a wider security surface than stepping down per task.
+- **Auto-fall-back to user install when admin fails.** Rejected explicitly:
+  silent downgrade is exactly the "surprise" the owner wants to avoid.
+
+## Consequences
+
+- Simpler to reason about, run, and keep alive; one identity for a future server.
+- **Accepted trade-off:** if the single engine crashes, all protections pause
+  for the few seconds it takes to auto-restart (previously the two engines
+  failed independently). Judged acceptable for the simplicity win.
+- "User mode is a degraded fallback, not a feature to support extra things" is
+  now a standing principle — see philosophy.
+
+## References
+- Feature spec: `../features/08-single-mesh.md`
+- Superseded: `0009-dual-mesh.md`

--- a/requirements/features/08-single-mesh.md
+++ b/requirements/features/08-single-mesh.md
@@ -1,0 +1,61 @@
+# Feature 08 — Single-engine install (admin or user)
+
+- **Status:** in build (2026-05-30) · ships as the next daemon + platform release
+- **Decision:** [ADR-0010](../decisions/0010-single-mesh-fail-fast.md)
+
+## What
+
+focusd runs as **one protection engine**, installed in one of two flavours the
+operator chooses:
+
+| Install | How you install it | What it protects |
+|---|---|---|
+| **Admin (full)** | with admin rights | Everything — site blocking, game-killing, packet filtering, AND the Claude-skill re-injection |
+| **User (limited)** | without admin rights | Only the Claude-skill re-injection. The rest are reported **unavailable** |
+
+Never two engines at once.
+
+## Why
+
+Simpler to run, keep alive, and reason about — one engine, one state, one
+identity. Sets up cleanly for a future server that should see one user, not two.
+The previous approach ran two engines side by side; that was judged not-KISS.
+
+## How it behaves (product rules)
+
+- **Admin install does it all.** For the one task that must act as the user
+  (writing the Claude skill into the user's home), the engine temporarily steps
+  down to the user's identity. The user never sees admin-owned files in their
+  own home folder.
+- **User install is an honest, limited fallback.** It exists for machines where
+  the operator can't get admin rights. It does not pretend to do the admin-level
+  protections — it shows them as unavailable, with a hint to reinstall with
+  admin rights for full coverage.
+- **Fail fast, no surprises.** If an admin install can't get admin rights, it
+  stops and tells the operator. It never silently downgrades to the limited
+  user install — switching is the operator's explicit choice.
+
+## Acceptance criteria (testable behaviour)
+
+1. With an admin install, the Claude-skill re-injection still runs on schedule
+   and re-creates the skill files if deleted (within the normal window).
+2. The skill files written under an admin install are owned by the **user**, and
+   the user can read/edit/delete them normally (no admin needed).
+3. With a user install, the admin-level protections report **unavailable**
+   (not "failed", not silent) — and the skill re-injection still works.
+4. An admin install that cannot obtain admin rights **exits with a clear error**
+   and does NOT fall back to a user install.
+5. During a moment when no one is logged in at the screen, the engine does NOT
+   mis-write the user's files to the wrong place — it waits and tries again.
+
+## Honest limitations
+
+- If the single engine crashes, all protections pause for the few seconds it
+  takes to auto-restart. (Previously the two engines failed independently.)
+  Accepted trade for the simplicity win.
+- Assumes one primary person at the keyboard. A shared/multi-user Mac is out of
+  scope (see philosophy — focusd is a single-user personal commitment device).
+
+## Supersedes
+The dual-engine behaviour from FEATURE 1.6 (#37). That fix is replaced, not
+removed from history — see ADR-0009.


### PR DESCRIPTION
## Summary
Consolidates to **one protection engine per install** (was two running simultaneously). The operator chooses the flavour: admin install = full coverage (the engine steps down to the user's identity for the one user-level task); user install = limited fallback (only the behavioural protection; the rest report **unavailable**, not failed). Fail-fast: an admin install that can't get admin rights stops with a clear message — never silently downgrades.

First feature shipped through the new **`/product-cycle`** process. Product spec + decision captured at product altitude:
- `requirements/decisions/0010-single-mesh-fail-fast.md` (supersedes 0009)
- `requirements/features/08-single-mesh.md` (the contract the e2e stage verified against)

## Reviewed (Stage 4)
- **go-reviewer: APPROVE** — the 3 silent-corruption edges (HOME, TMPDIR, no-console-user) all solid + tested; 1 MEDIUM (swallowed DB write) fixed.
- **security-reviewer: PASS** — privilege-drop structurally sound. No exec-as-root path when no console user; env fully replaced (no DYLD/SUDO/SSH leak into the dropped child); discovery injection-safe. 1 LOW (nil-manifest guard) fixed.

## Verified (Stage 5) — every acceptance criterion has a passing test
- AC#2/#5 (user-owned files / no-console-user defers) → priv-drop unit + integration tests
- AC#3 (system plugins UNAVAILABLE-not-failed under user install) → `TestCanDispatch` 9-cell matrix
- AC#4 (sudo-install fail-fast, no fallback) → `TestInstallFailureHint`/`TestInstallCoverageNotice`

## How (kept out of the product docs, here for engineers)
Runner detects a root platform dispatching a `run_as: current_user` plugin → resolves console user via `stat /dev/console` → if UID 0 (no one logged in) skips + records `unavailable` (never writes as root) → else sets `syscall.Credential{uid,gid,NoSetGroups}` + **fully reseeds env** (HOME/USER/LOGNAME/PATH/TMPDIR=/tmp) → exec. Scheduler gate changed from "skip if mismatch" to `CanDispatch` (system serves user plugins via drop; user can't escalate to system). AMFI path-rotation unaffected (exec-time, credential-agnostic).

## Honest limitations
- Single engine crash pauses all protections for the ~10s mesh-respawn window (was independent before). Accepted for simplicity (ADR-0010).
- Assumes one primary console user; multi-user Macs out of scope.
- Integration test (`privdrop_integration_darwin_test.go`) only runs as root on a real Mac; skips cleanly otherwise.

## Test plan
- [x] `go test ./daemon/... ./platform/...` green (28 packages); `gofmt`/`vet` clean
- [x] 3 corruption edges each unit-tested; integration test guards on root+console-user
- [ ] CI green
- [ ] Copilot review addressed
- [ ] Ship daemon-v0.4.0 + platform v0.13.0; deploy (switch laptop to single system-mode engine; uninstall the old user mesh)