### PR TITLE
fix(privdrop): make plugin binary + config reachable by dropped user (v0.13.1)

### DIFF
--- a/platform/internal/core/runner/privdrop.go
+++ b/platform/internal/core/runner/privdrop.go
@@ -17,7 +17,9 @@ package runner
 
 import (
 	"fmt"
+	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 
 	"github.com/eliteGoblin/focusd/platform/internal/core/plugin"
@@ -114,6 +116,66 @@ func (p dropPlan) dropEnv() []string {
 		// fails. /tmp is world-writable + sticky, safe for any uid.
 		"TMPDIR=/tmp",
 	}
+}
+
+// prepareDropPaths makes a privilege-dropped child able to exec the
+// plugin binary. The disguised workdir is root-owned 0700 (hidden from
+// casual `ls`), so a child dropped to the console user cannot, by
+// default, traverse down to the binary or read it — exec fails with
+// "permission denied" (the real-hardware gap the 0777-tmpdir integration
+// test originally masked).
+//
+// We widen the MINIMUM: read+execute on the binary itself, and traverse
+// (execute, NOT read) on each ancestor directory that lacks it, up to a
+// directory that is already world-traversable (system dirs like
+// /Library/Application Support are 0755 and are left untouched). Adding
+// only the execute bit to directories means their contents stay
+// un-listable — disguise-by-enumeration is preserved; a dropped user can
+// reach a binary whose exact path it already knows but cannot discover
+// the tree. The binary stays root-OWNED (we only widen its mode), so the
+// user can run it but cannot modify or neuter it.
+func prepareDropPaths(binPath string) error {
+	// Binary: the kernel must read the Mach-O to map it, and the exec bit
+	// must be set for a non-owner. Add r-x for "other".
+	if err := addPerm(binPath, 0o005); err != nil {
+		return fmt.Errorf("make plugin binary user-executable: %w", err)
+	}
+	// Ancestors: add traverse (execute only) wherever missing. Walk all
+	// the way up — a mid-chain dir may already be 0755 while a higher one
+	// is still 0700, so we must not stop at the first traversable dir. We
+	// only chmod dirs that lack o+x, so already-traversable system dirs are
+	// left exactly as they are. Never touch "/".
+	dir := filepath.Dir(binPath)
+	for dir != "/" && dir != "." {
+		if err := addPermIfMissing(dir, 0o001); err != nil {
+			return fmt.Errorf("make %s traversable: %w", dir, err)
+		}
+		dir = filepath.Dir(dir)
+	}
+	return nil
+}
+
+// addPerm ORs the given permission bits into path's mode.
+func addPerm(path string, bits os.FileMode) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(path, fi.Mode().Perm()|bits)
+}
+
+// addPermIfMissing ORs bits into path's mode only when they're not
+// already set — avoids needless chmod (and mtime churn) on system dirs
+// that are already traversable.
+func addPermIfMissing(path string, bits os.FileMode) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode().Perm()&bits == bits {
+		return nil
+	}
+	return os.Chmod(path, fi.Mode().Perm()|bits)
 }
 
 // realConsoleUser is the production console-user discovery. It shells

--- a/platform/internal/core/runner/privdrop_integration_darwin_test.go
+++ b/platform/internal/core/runner/privdrop_integration_darwin_test.go
@@ -53,6 +53,21 @@ func TestPrivDropExecAsConsoleUser(t *testing.T) {
 	}
 	outFile := filepath.Join(outDir, "observed.txt")
 
+	// Regression guard for the real-hardware permission gap: the stub
+	// plugin binary lives under a root-owned 0700 directory tree, exactly
+	// like the disguised workdir on a real install. Without prepareDropPaths
+	// the dropped user cannot traverse to or exec the binary
+	// ("permission denied"). testutil.ScriptPlugin writes into t.TempDir()
+	// (0700); we additionally lock the plugin's parent chain to 0700 root
+	// so the test would fail if prepareDropPaths were removed.
+	lockChain := func(start string) {
+		d := start
+		for i := 0; i < 4 && d != "/" && d != "."; i++ {
+			_ = os.Chmod(d, 0o700)
+			d = filepath.Dir(d)
+		}
+	}
+
 	script := strings.Join([]string{
 		`euid=$(id -u)`,
 		`# Probe TMPDIR writability (root's TMPDIR would be unwritable here).`,
@@ -63,6 +78,12 @@ func TestPrivDropExecAsConsoleUser(t *testing.T) {
 
 	p := testutil.ScriptPlugin(t, "skill-protector", script)
 	p.Manifest.RunAs = plugin.RunAsCurrentUser
+
+	// Lock the plugin binary's directory chain to root-owned 0700 — the
+	// real disguised-workdir condition. prepareDropPaths must re-open the
+	// traverse path for the dropped user; without it this test fails with
+	// "permission denied" on exec.
+	lockChain(filepath.Dir(p.BinaryPath))
 
 	r := NewWithMode(db, osadapter.ModeSystem)
 	out, err := r.Run(context.Background(), Job{ID: "j1"}, p, "scheduler")

--- a/platform/internal/core/runner/privdrop_test.go
+++ b/platform/internal/core/runner/privdrop_test.go
@@ -162,3 +162,54 @@ func TestRunOnceNoConsoleUserRecordsUnavailable(t *testing.T) {
 		t.Errorf("persisted status = %q", last.Status)
 	}
 }
+
+// TestPrepareDropPathsMakesBinaryUserReachable verifies the real-hardware
+// fix: under a root-owned-style 0700 directory tree (the disguised
+// workdir), prepareDropPaths must add traverse (o+x) to the ancestor
+// dirs and read+exec (o+rx) to the binary, WITHOUT adding read (o+r) to
+// the directories (disguise: contents stay un-listable). Runs without
+// root - it only checks the resulting permission bits.
+func TestPrepareDropPathsMakesBinaryUserReachable(t *testing.T) {
+	root := t.TempDir()
+	// Build workdir-like chain: <root>/bin/v1/plugins/sp/, all 0700.
+	deep := filepath.Join(root, "bin", "v1", "plugins", "sp")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(deep, "sp")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Lock the whole chain to 0700 (root-owned-style; t.TempDir parents
+	// already are, but be explicit on our created dirs).
+	for _, d := range []string{root, filepath.Join(root, "bin"),
+		filepath.Join(root, "bin", "v1"),
+		filepath.Join(root, "bin", "v1", "plugins"), deep} {
+		if err := os.Chmod(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := prepareDropPaths(bin); err != nil {
+		t.Fatalf("prepareDropPaths: %v", err)
+	}
+
+	// Binary must now be read+exec for other.
+	bfi, _ := os.Stat(bin)
+	if bfi.Mode().Perm()&0o005 != 0o005 {
+		t.Errorf("binary perm = %o, want o+rx set", bfi.Mode().Perm())
+	}
+	// Each ancestor dir must be traversable (o+x) but NOT listable (no o+r).
+	for _, d := range []string{deep,
+		filepath.Join(root, "bin", "v1", "plugins"),
+		filepath.Join(root, "bin", "v1"),
+		filepath.Join(root, "bin"), root} {
+		fi, _ := os.Stat(d)
+		if fi.Mode().Perm()&0o001 == 0 {
+			t.Errorf("dir %s not traversable: perm = %o", d, fi.Mode().Perm())
+		}
+		if fi.Mode().Perm()&0o004 != 0 {
+			t.Errorf("dir %s became world-readable (disguise leak): perm = %o", d, fi.Mode().Perm())
+		}
+	}
+}

--- a/platform/internal/core/runner/runner.go
+++ b/platform/internal/core/runner/runner.go
@@ -140,7 +140,15 @@ func (r *Runner) runOnce(ctx context.Context, job Job, p plugin.Discovered, trig
 		return Outcome{Status: state.RunStatusUnavailable, Message: reason}, nil
 	}
 
-	cfgPath, cleanup, err := writeJobConfig(job, p.Manifest.ID)
+	// When dropping to the console user, the plugin binary + the path to
+	// it must be reachable by that user (the workdir is root-owned 0700).
+	if plan.action == dropToUser {
+		if err := prepareDropPaths(p.BinaryPath); err != nil {
+			return Outcome{}, err
+		}
+	}
+
+	cfgPath, cleanup, err := writeJobConfig(job, p.Manifest.ID, plan)
 	if err != nil {
 		return Outcome{}, err
 	}
@@ -244,13 +252,22 @@ func classify(out *Outcome, ctx context.Context, runErr error) {
 	out.Err = runErr.Error()
 }
 
-func writeJobConfig(job Job, pluginID string) (string, func(), error) {
+func writeJobConfig(job Job, pluginID string, plan dropPlan) (string, func(), error) {
 	in := plugin.JobInput{JobID: job.ID, PluginID: pluginID, Config: job.Config}
 	data, err := json.Marshal(in)
 	if err != nil {
 		return "", func() {}, fmt.Errorf("marshal job config: %w", err)
 	}
-	f, err := os.CreateTemp("", "focusd-job-"+job.ID+"-*.json")
+	// When dropping to the console user, the default temp dir is root's
+	// TMPDIR (/var/folders/.../-Tmp-, mode 0700 root) which the dropped
+	// uid cannot traverse to read the config. Write to /tmp (world-
+	// traversable, sticky) and chown the file to the target uid so only
+	// that user can read it. The config is non-sensitive job input.
+	tmpDir := ""
+	if plan.action == dropToUser {
+		tmpDir = "/tmp"
+	}
+	f, err := os.CreateTemp(tmpDir, "focusd-job-"+job.ID+"-*.json")
 	if err != nil {
 		return "", func() {}, fmt.Errorf("create temp job config: %w", err)
 	}
@@ -264,6 +281,12 @@ func writeJobConfig(job Job, pluginID string) (string, func(), error) {
 	if err := f.Close(); err != nil {
 		cleanup()
 		return "", func() {}, err
+	}
+	if plan.action == dropToUser {
+		if err := os.Chown(path, plan.uid, plan.gid); err != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("chown job config to dropped uid: %w", err)
+		}
 	}
 	return path, cleanup, nil
 }


### PR DESCRIPTION
Hotfix for FEATURE 8. Stage-5 VERIFY on real hardware caught what the integration test masked (0777 tmpdir): the privilege-drop exec failed with 'permission denied' because the dropped user can't traverse the root-0700 disguised workdir to the plugin binary, nor read the job config in root's TMPDIR.

**Option A fix (chosen with the user):** add traverse (o+x, not o+r) to the dir chain + read+exec to the binary (which stays root-owned = user can run but not neuter it); write the drop-case config to /tmp chowned to the target uid. Disguise-by-enumeration preserved (dirs stay un-listable).

Integration test now locks the plugin dir chain to 0700 (the real condition) so this can't regress. New unit test asserts dirs get o+x but NOT o+r.

- [x] daemon + platform packages green; gofmt/vet clean
- [ ] CI green
- [ ] ship v0.13.1 + daemon-v0.4.1, redeploy, verify priv-drop run goes OK