### PR TITLE
chore(build): rebundle plugins before platform build (#38)

### DIFF
--- a/plugins/kill-steam/Makefile
+++ b/plugins/kill-steam/Makefile
@@ -1,0 +1,40 @@
+# Makefile for plugins/kill-steam
+#
+# Targets:
+#   build   compile the plugin binary into ./build/
+#   test    run unit tests with -race
+#   bundle  build + copy binary + plugin.json into the platform bundle
+#           dir (platform/internal/bundle/data/kill-steam/) so the
+#           platform's release pipeline ships the plugin embedded.
+#
+# Mirrors plugins/skill-protector/Makefile + plugins/network-block/Makefile.
+
+PLUGIN_NAME := kill-steam
+BUILD_DIR   := build
+OUT_BIN     := $(BUILD_DIR)/$(PLUGIN_NAME)
+
+REPO_ROOT   := $(shell git rev-parse --show-toplevel 2>/dev/null || (cd $(CURDIR)/../.. && pwd))
+BUNDLE_DIR  := $(REPO_ROOT)/platform/internal/bundle/data/$(PLUGIN_NAME)
+
+GO ?= go
+LDFLAGS ?= -s -w
+
+.PHONY: all build test bundle clean
+
+all: build
+
+build:
+	mkdir -p $(BUILD_DIR)
+	CGO_ENABLED=0 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT_BIN) ./cmd
+
+test:
+	$(GO) test ./... -race -count=1
+
+bundle: build
+	mkdir -p $(BUNDLE_DIR)
+	cp plugin.json $(BUNDLE_DIR)/plugin.json
+	cp $(OUT_BIN)  $(BUNDLE_DIR)/$(PLUGIN_NAME)
+	@echo "bundled $(PLUGIN_NAME) into $(BUNDLE_DIR)"
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/scripts/build-platform.sh
+++ b/scripts/build-platform.sh
@@ -10,6 +10,24 @@ mkdir -p "${OUT}"
 VERSION="${VERSION:-$(git -C "${ROOT}" describe --tags --always --dirty 2>/dev/null || echo dev)}"
 LDFLAGS="-s -w -X main.version=${VERSION}"
 
+# Rebundle every plugin BEFORE building the platform. The platform embeds
+# each plugin's binary from platform/internal/bundle/data/<id>/ via
+# //go:embed; if a plugin's source changed but its bundled binary wasn't
+# refreshed, the platform ships a STALE plugin (this is exactly what caused
+# the v0.12.0 -> v0.12.1 hotfix). Running each plugin's `make bundle` here
+# keeps the embedded copies in lockstep with source on every build.
+echo "rebundling plugins…"
+for pdir in "${ROOT}"/plugins/*/; do
+  name="$(basename "${pdir}")"
+  [ "${name}" = "_fakes" ] && continue
+  if [ -f "${pdir}Makefile" ] && grep -qE '^bundle:' "${pdir}Makefile"; then
+    echo "  bundle ${name}"
+    make -C "${pdir}" bundle >/dev/null
+  else
+    echo "  skip ${name} (no bundle target)"
+  fi
+done
+
 matrix=(
   "darwin arm64"
   "darwin amd64"

--- a/scripts/build-platform.sh
+++ b/scripts/build-platform.sh
@@ -16,13 +16,25 @@ LDFLAGS="-s -w -X main.version=${VERSION}"
 # refreshed, the platform ships a STALE plugin (this is exactly what caused
 # the v0.12.0 -> v0.12.1 hotfix). Running each plugin's `make bundle` here
 # keeps the embedded copies in lockstep with source on every build.
-echo "rebundling plugins…"
+#
+# CRITICAL: pin the bundle build to the real deploy target (darwin/arm64),
+# NOT the host. This script's `build` job runs on ubuntu-latest in CI
+# (.github/workflows/platform.yml); a host-arch `make bundle` there would
+# overwrite the committed darwin/arm64 plugin binaries with LINUX ones and
+# embed them into the darwin platform release — a broken release (Copilot
+# review, PR #44). The platform embeds a single plugin binary into every
+# matrix variant; only Apple Silicon macOS is a real deployment, so the
+# embedded plugins target darwin/arm64 (matching the previously-committed
+# binaries). Plugins are CGO-free, so this cross-compiles from any host.
+export BUNDLE_GOOS="${BUNDLE_GOOS:-darwin}"
+export BUNDLE_GOARCH="${BUNDLE_GOARCH:-arm64}"
+echo "rebundling plugins (target ${BUNDLE_GOOS}/${BUNDLE_GOARCH})…"
 for pdir in "${ROOT}"/plugins/*/; do
   name="$(basename "${pdir}")"
   [ "${name}" = "_fakes" ] && continue
   if [ -f "${pdir}Makefile" ] && grep -qE '^bundle:' "${pdir}Makefile"; then
     echo "  bundle ${name}"
-    make -C "${pdir}" bundle >/dev/null
+    make -C "${pdir}" bundle GOOS="${BUNDLE_GOOS}" GOARCH="${BUNDLE_GOARCH}" >/dev/null
   else
     echo "  skip ${name} (no bundle target)"
   fi


### PR DESCRIPTION
## What

`scripts/build-platform.sh` now rebundles every plugin (`make bundle`) before compiling the platform, so the `//go:embed`-ed plugin binaries are always in lockstep with source.

Also adds `plugins/kill-steam/Makefile` (it had none) with a `bundle` target mirroring skill-protector/network-block — without it, kill-steam was silently skipped by the rebundle loop.

## Why

The platform embeds each plugin binary from `platform/internal/bundle/data/<id>/`. A plugin whose source changed but whose bundled binary wasn't refreshed ships **stale** — this is exactly what forced the v0.12.0 → v0.12.1 hotfix (register §7 hygiene gap #38).

## Test plan

- [x] `build-platform.sh` rebundle loop detects `bundle` targets: dns-block, kill-steam, network-block, skill-protector → bundled; browser-monitor (no bundle target) → skipped, as intended
- [x] `make -C plugins/kill-steam bundle` produces binary + plugin.json in the bundle dir
- [ ] CI green

Closes #38.