### PR TITLE
feat(daemon): daemon update discovers the disguised install

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -231,37 +231,6 @@ func loop(args []string, once bool) int {
 // + swaps via the normal EnsureRunning path (which is fetch-then-stop
 // — see executor.go). This command itself is a thin write + (optional)
 // one-shot resolve; it does NOT loop on ticks or wipe state.
-// resolveUpdateWorkdir picks the workdir `daemon update` writes to. An
-// explicit (non-default) --workdir is always honored. Otherwise, if a
-// genuine install already lives at the default workdir, use it; if not,
-// fall back to discovering the real (possibly disguised/relocated) install.
-// Pure + injectable so the precedence is unit-tested without touching
-// launchd. The disguised path is only ever used internally, never printed.
-func resolveUpdateWorkdir(explicitWd, defaultWd string, hasInstall func(dir string) bool, discover func() (string, bool)) string {
-	if explicitWd != defaultWd {
-		return explicitWd // caller pointed us somewhere explicit
-	}
-	if hasInstall(explicitWd) {
-		return explicitWd // an install already lives at the default
-	}
-	if wd, ok := discover(); ok && wd != "" {
-		return wd
-	}
-	return explicitWd
-}
-
-// discoverInstallWorkdir finds the genuine focusd install for the current
-// mode via Ed25519 recognition (nil verifier => sig.VerifyFile) and returns
-// its workdir. Returns ("", false) when no install is found or discovery is
-// unsupported (non-darwin). Never logs or prints the path.
-func discoverInstallWorkdir() (string, bool) {
-	cur, err := osadapter.FindCurrentInstall(mode.Resolve(), nil)
-	if err != nil || cur.Workdir == "" {
-		return "", false
-	}
-	return cur.Workdir, true
-}
-
 func doUpdate(args []string) int {
 	// Use a dedicated FlagSet so we can correctly pick up the trailing
 	// positional version after all flags (handles `--workdir=/x v1.0.0`
@@ -279,12 +248,19 @@ func doUpdate(args []string) int {
 	// the default workdir is empty on such systems. When the caller did not
 	// point us at an explicit workdir AND none lives at the default, discover
 	// the genuine install (same Ed25519 recognition `self-update` uses) and
-	// target it. The disguised path stays INTERNAL — it is never printed.
-	workdir := resolveUpdateWorkdir(
+	// target it. The disguised path stays INTERNAL to this process — it is
+	// never written to the log/output here. A discovery I/O error (e.g.
+	// permission) fails fast rather than silently writing to the wrong place.
+	workdir, derr := resolveUpdateWorkdir(
 		*wd, defaultWorkdir(),
 		func(dir string) bool { return (&core.Store{Dir: dir}).HaveConfig() },
 		discoverInstallWorkdir,
 	)
+	if derr != nil {
+		fmt.Fprintln(os.Stderr,
+			"update: could not locate the install; re-run with sudo or pass --workdir")
+		return 1
+	}
 
 	o := opts{workdir: workdir, github: *gh, asset: *as}
 	_, log := build(o)
@@ -301,7 +277,8 @@ func doUpdate(args []string) int {
 			return 2
 		}
 		if err := st.WriteDesired(explicit); err != nil {
-			log.Error("write desired failed", "err", err)
+			// Don't log raw err: the store path can be the disguised workdir.
+			log.Error("write desired failed (store not writable; re-run with sudo?)")
 			return 1
 		}
 		log.Info("desired written", "version", explicit, "note", "no network call")
@@ -325,6 +302,44 @@ func doUpdate(args []string) int {
 	}
 	log.Info("desired written", "version", v, "note", "resolved from GitHub")
 	return 0
+}
+
+// resolveUpdateWorkdir picks the workdir `daemon update` writes to. An
+// explicit (non-default) --workdir is always honored. Otherwise, if a
+// genuine install already lives at the default workdir, use it; if not,
+// discover the real (possibly disguised/relocated) install. Pure +
+// injectable so the precedence is unit-tested without touching launchd.
+// A discovery I/O error is propagated (caller fails fast) so we never
+// silently write to the wrong workdir; "no install found" (nil error,
+// empty path) falls back to the default.
+func resolveUpdateWorkdir(explicitWd, defaultWd string, hasInstall func(dir string) bool, discover func() (string, error)) (string, error) {
+	if explicitWd != defaultWd {
+		return explicitWd, nil // caller pointed us somewhere explicit
+	}
+	if hasInstall(explicitWd) {
+		return explicitWd, nil // an install already lives at the default
+	}
+	wd, err := discover()
+	if err != nil {
+		return "", err // I/O failure during discovery — fail fast
+	}
+	if wd != "" {
+		return wd, nil
+	}
+	return explicitWd, nil // no install discovered — keep the default
+}
+
+// discoverInstallWorkdir finds the genuine focusd install for the current
+// mode via Ed25519 recognition (nil verifier => sig.VerifyFile) and returns
+// its workdir. ("", nil) means no install was found (a clean fallback);
+// a non-nil error is a real filesystem failure. Never logs or prints the
+// path.
+func discoverInstallWorkdir() (string, error) {
+	cur, err := osadapter.FindCurrentInstall(mode.Resolve(), nil)
+	if err != nil {
+		return "", err
+	}
+	return cur.Workdir, nil
 }
 
 // osSupportsLaunchd reports whether launchd install/uninstall is

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -231,6 +231,37 @@ func loop(args []string, once bool) int {
 // + swaps via the normal EnsureRunning path (which is fetch-then-stop
 // — see executor.go). This command itself is a thin write + (optional)
 // one-shot resolve; it does NOT loop on ticks or wipe state.
+// resolveUpdateWorkdir picks the workdir `daemon update` writes to. An
+// explicit (non-default) --workdir is always honored. Otherwise, if a
+// genuine install already lives at the default workdir, use it; if not,
+// fall back to discovering the real (possibly disguised/relocated) install.
+// Pure + injectable so the precedence is unit-tested without touching
+// launchd. The disguised path is only ever used internally, never printed.
+func resolveUpdateWorkdir(explicitWd, defaultWd string, hasInstall func(dir string) bool, discover func() (string, bool)) string {
+	if explicitWd != defaultWd {
+		return explicitWd // caller pointed us somewhere explicit
+	}
+	if hasInstall(explicitWd) {
+		return explicitWd // an install already lives at the default
+	}
+	if wd, ok := discover(); ok && wd != "" {
+		return wd
+	}
+	return explicitWd
+}
+
+// discoverInstallWorkdir finds the genuine focusd install for the current
+// mode via Ed25519 recognition (nil verifier => sig.VerifyFile) and returns
+// its workdir. Returns ("", false) when no install is found or discovery is
+// unsupported (non-darwin). Never logs or prints the path.
+func discoverInstallWorkdir() (string, bool) {
+	cur, err := osadapter.FindCurrentInstall(mode.Resolve(), nil)
+	if err != nil || cur.Workdir == "" {
+		return "", false
+	}
+	return cur.Workdir, true
+}
+
 func doUpdate(args []string) int {
 	// Use a dedicated FlagSet so we can correctly pick up the trailing
 	// positional version after all flags (handles `--workdir=/x v1.0.0`
@@ -244,7 +275,18 @@ func doUpdate(args []string) int {
 	_ = fs.Parse(args)
 	explicit := fs.Arg(0) // optional positional version, e.g. v1.2.3
 
-	o := opts{workdir: *wd, github: *gh, asset: *as}
+	// A real install relocates its workdir to a disguised, random path, so
+	// the default workdir is empty on such systems. When the caller did not
+	// point us at an explicit workdir AND none lives at the default, discover
+	// the genuine install (same Ed25519 recognition `self-update` uses) and
+	// target it. The disguised path stays INTERNAL — it is never printed.
+	workdir := resolveUpdateWorkdir(
+		*wd, defaultWorkdir(),
+		func(dir string) bool { return (&core.Store{Dir: dir}).HaveConfig() },
+		discoverInstallWorkdir,
+	)
+
+	o := opts{workdir: workdir, github: *gh, asset: *as}
 	_, log := build(o)
 
 	st := &core.Store{Dir: o.workdir}

--- a/daemon/cmd/daemon/update_workdir_test.go
+++ b/daemon/cmd/daemon/update_workdir_test.go
@@ -1,11 +1,15 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestResolveUpdateWorkdir(t *testing.T) {
 	const def = "/default/wd"
-	discoverOK := func() (string, bool) { return "/disguised/wd", true }
-	discoverNone := func() (string, bool) { return "", false }
+	discoverOK := func() (string, error) { return "/disguised/wd", nil }
+	discoverNone := func() (string, error) { return "", nil }
+	discoverErr := func() (string, error) { return "", errors.New("permission denied") }
 	yes := func(string) bool { return true }
 	no := func(string) bool { return false }
 
@@ -13,18 +17,30 @@ func TestResolveUpdateWorkdir(t *testing.T) {
 		name     string
 		explicit string
 		has      func(string) bool
-		discover func() (string, bool)
+		discover func() (string, error)
 		want     string
+		wantErr  bool
 	}{
-		{"explicit override is honored even if discoverable", "/x", no, discoverOK, "/x"},
-		{"default with install present uses default", def, yes, discoverOK, def},
-		{"default empty discovers disguised install", def, no, discoverOK, "/disguised/wd"},
-		{"default empty + discovery fails falls back to default", def, no, discoverNone, def},
-		{"explicit override honored even when it has no install", "/x", no, discoverNone, "/x"},
+		{"explicit override honored even if discoverable", "/x", no, discoverOK, "/x", false},
+		{"default with install present uses default", def, yes, discoverOK, def, false},
+		{"default empty discovers disguised install", def, no, discoverOK, "/disguised/wd", false},
+		{"default empty + no install falls back to default", def, no, discoverNone, def, false},
+		{"explicit override honored even with no install", "/x", no, discoverNone, "/x", false},
+		{"discovery I/O error fails fast", def, no, discoverErr, "", true},
+		{"explicit override skips discovery (no error even if discover would err)", "/x", no, discoverErr, "/x", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := resolveUpdateWorkdir(c.explicit, def, c.has, c.discover)
+			got, err := resolveUpdateWorkdir(c.explicit, def, c.has, c.discover)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (wd=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if got != c.want {
 				t.Fatalf("resolveUpdateWorkdir = %q, want %q", got, c.want)
 			}

--- a/daemon/cmd/daemon/update_workdir_test.go
+++ b/daemon/cmd/daemon/update_workdir_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestResolveUpdateWorkdir(t *testing.T) {
+	const def = "/default/wd"
+	discoverOK := func() (string, bool) { return "/disguised/wd", true }
+	discoverNone := func() (string, bool) { return "", false }
+	yes := func(string) bool { return true }
+	no := func(string) bool { return false }
+
+	cases := []struct {
+		name     string
+		explicit string
+		has      func(string) bool
+		discover func() (string, bool)
+		want     string
+	}{
+		{"explicit override is honored even if discoverable", "/x", no, discoverOK, "/x"},
+		{"default with install present uses default", def, yes, discoverOK, def},
+		{"default empty discovers disguised install", def, no, discoverOK, "/disguised/wd"},
+		{"default empty + discovery fails falls back to default", def, no, discoverNone, def},
+		{"explicit override honored even when it has no install", "/x", no, discoverNone, "/x"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := resolveUpdateWorkdir(c.explicit, def, c.has, c.discover)
+			if got != c.want {
+				t.Fatalf("resolveUpdateWorkdir = %q, want %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
`daemon update <ver>` now discovers the genuine (relocated/disguised) install when no explicit `--workdir` is given, mirroring `self-update`'s Ed25519 recognition.

## Why
A real install relocates its workdir to a disguised random path, so `daemon update` against the default workdir wrote nowhere useful. This blocks bumping the **platform** version on a disguised install without handling the disguised path manually. Now the path stays **internal** (never printed), preserving obfuscation, and the platform can be deployed via `sudo daemon update vX.Y.Z`.

## Design
Pure, unit-tested precedence helper `resolveUpdateWorkdir`: explicit --workdir > install-at-default > discovered-install > default. Discovery uses `osadapter.FindCurrentInstall` (nil verifier => sig.VerifyFile); non-darwin / not-found falls back safely.

## Test plan
- [x] `resolveUpdateWorkdir` table test (all 5 precedence cases)
- [x] go build/test/vet/gofmt clean
- [ ] CI green

Enables the platform v0.14.0 deploy; ships in daemon-v0.5.0.