### PR TITLE
fix(daemon): daemon update prefers discovered install over stale default

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -251,11 +251,7 @@ func doUpdate(args []string) int {
 	// target it. The disguised path stays INTERNAL to this process — it is
 	// never written to the log/output here. A discovery I/O error (e.g.
 	// permission) fails fast rather than silently writing to the wrong place.
-	workdir, derr := resolveUpdateWorkdir(
-		*wd, defaultWorkdir(),
-		func(dir string) bool { return (&core.Store{Dir: dir}).HaveConfig() },
-		discoverInstallWorkdir,
-	)
+	workdir, derr := resolveUpdateWorkdir(*wd, defaultWorkdir(), discoverInstallWorkdir)
 	if derr != nil {
 		fmt.Fprintln(os.Stderr,
 			"update: could not locate the install; re-run with sudo or pass --workdir")
@@ -312,21 +308,23 @@ func doUpdate(args []string) int {
 // A discovery I/O error is propagated (caller fails fast) so we never
 // silently write to the wrong workdir; "no install found" (nil error,
 // empty path) falls back to the default.
-func resolveUpdateWorkdir(explicitWd, defaultWd string, hasInstall func(dir string) bool, discover func() (string, error)) (string, error) {
+func resolveUpdateWorkdir(explicitWd, defaultWd string, discover func() (string, error)) (string, error) {
 	if explicitWd != defaultWd {
 		return explicitWd, nil // caller pointed us somewhere explicit
 	}
-	if hasInstall(explicitWd) {
-		return explicitWd, nil // an install already lives at the default
-	}
+	// Discovery WINS over the default. A real install relocates to a
+	// disguised path, so the running mesh's workdir is the authoritative
+	// target; a stale install left at the default location must NOT shadow
+	// it (that bug wrote `desired` to the wrong place and the platform never
+	// upgraded). A genuine I/O error during discovery is fatal — fail fast.
 	wd, err := discover()
 	if err != nil {
-		return "", err // I/O failure during discovery — fail fast
+		return "", err
 	}
 	if wd != "" {
-		return wd, nil
+		return wd, nil // the real, running, discovered install wins
 	}
-	return explicitWd, nil // no install discovered — keep the default
+	return defaultWd, nil // nothing discovered — use the default
 }
 
 // discoverInstallWorkdir finds the genuine focusd install for the current

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -238,19 +238,23 @@ func doUpdate(args []string) int {
 	// arg without a `-` prefix" scan was wrong for `--flag value` form,
 	// where `value` is non-flag but not the version. Go-review HIGH #2.
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	wd := fs.String("workdir", defaultWorkdir(), "daemon work directory")
+	// --workdir defaults to "" (NOT the default path) so an explicit
+	// override is detectable, matching `self-update`/`status`. Empty means
+	// "discover the running install"; a non-empty value is an explicit
+	// target the operator chose.
+	wd := fs.String("workdir", "", "explicit daemon work directory (default: discover the running install)")
 	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo (for `update` with no version arg)")
 	as := fs.String("asset", "", "release asset filename")
 	_ = fs.Parse(args)
 	explicit := fs.Arg(0) // optional positional version, e.g. v1.2.3
 
-	// A real install relocates its workdir to a disguised, random path, so
-	// the default workdir is empty on such systems. When the caller did not
-	// point us at an explicit workdir AND none lives at the default, discover
-	// the genuine install (same Ed25519 recognition `self-update` uses) and
-	// target it. The disguised path stays INTERNAL to this process — it is
-	// never written to the log/output here. A discovery I/O error (e.g.
-	// permission) fails fast rather than silently writing to the wrong place.
+	// Resolve the target workdir. A real install relocates to a disguised,
+	// random path, so by default we DISCOVER the running mesh's workdir
+	// (same Ed25519 recognition `self-update` uses) — discovery WINS over
+	// any stale install at the default location. An explicit --workdir is
+	// always honored. The disguised path stays INTERNAL to this process; it
+	// is never logged/printed. A discovery I/O error fails fast rather than
+	// silently writing to the wrong place.
 	workdir, derr := resolveUpdateWorkdir(*wd, defaultWorkdir(), discoverInstallWorkdir)
 	if derr != nil {
 		fmt.Fprintln(os.Stderr,
@@ -302,24 +306,21 @@ func doUpdate(args []string) int {
 
 // resolveUpdateWorkdir picks the workdir `daemon update` writes to. An
 // explicit (non-default) --workdir is always honored. Otherwise, if a
-// genuine install already lives at the default workdir, use it; if not,
-// discover the real (possibly disguised/relocated) install. Pure +
-// injectable so the precedence is unit-tested without touching launchd.
-// A discovery I/O error is propagated (caller fails fast) so we never
-// silently write to the wrong workdir; "no install found" (nil error,
-// empty path) falls back to the default.
+// install. Precedence: an explicit (non-empty) --workdir is always
+// honored; otherwise DISCOVERY of the real (possibly disguised/relocated)
+// install WINS over the default location — a stale install left at the
+// default must NOT shadow the running mesh (that bug wrote `desired` to the
+// wrong place and the platform never upgraded). Only when discovery finds
+// nothing do we fall back to defaultWd. A discovery I/O error is propagated
+// so the caller fails fast instead of silently writing to the wrong place.
+// Pure + injectable so the precedence is unit-tested without touching launchd.
 func resolveUpdateWorkdir(explicitWd, defaultWd string, discover func() (string, error)) (string, error) {
-	if explicitWd != defaultWd {
-		return explicitWd, nil // caller pointed us somewhere explicit
+	if explicitWd != "" {
+		return explicitWd, nil // operator chose an explicit target
 	}
-	// Discovery WINS over the default. A real install relocates to a
-	// disguised path, so the running mesh's workdir is the authoritative
-	// target; a stale install left at the default location must NOT shadow
-	// it (that bug wrote `desired` to the wrong place and the platform never
-	// upgraded). A genuine I/O error during discovery is fatal — fail fast.
 	wd, err := discover()
 	if err != nil {
-		return "", err
+		return "", err // I/O failure during discovery — fail fast
 	}
 	if wd != "" {
 		return wd, nil // the real, running, discovered install wins

--- a/daemon/cmd/daemon/update_workdir_test.go
+++ b/daemon/cmd/daemon/update_workdir_test.go
@@ -10,28 +10,23 @@ func TestResolveUpdateWorkdir(t *testing.T) {
 	discoverOK := func() (string, error) { return "/disguised/wd", nil }
 	discoverNone := func() (string, error) { return "", nil }
 	discoverErr := func() (string, error) { return "", errors.New("permission denied") }
-	yes := func(string) bool { return true }
-	no := func(string) bool { return false }
 
 	cases := []struct {
 		name     string
 		explicit string
-		has      func(string) bool
 		discover func() (string, error)
 		want     string
 		wantErr  bool
 	}{
-		{"explicit override honored even if discoverable", "/x", no, discoverOK, "/x", false},
-		{"default with install present uses default", def, yes, discoverOK, def, false},
-		{"default empty discovers disguised install", def, no, discoverOK, "/disguised/wd", false},
-		{"default empty + no install falls back to default", def, no, discoverNone, def, false},
-		{"explicit override honored even with no install", "/x", no, discoverNone, "/x", false},
-		{"discovery I/O error fails fast", def, no, discoverErr, "", true},
-		{"explicit override skips discovery (no error even if discover would err)", "/x", no, discoverErr, "/x", false},
+		{"explicit override honored, skips discovery", "/x", discoverOK, "/x", false},
+		{"discovered real install shadows the stale default", def, discoverOK, "/disguised/wd", false},
+		{"default + discovery finds nothing falls back to default", def, discoverNone, def, false},
+		{"discovery I/O error fails fast", def, discoverErr, "", true},
+		{"explicit override skips discovery even when discovery would error", "/x", discoverErr, "/x", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := resolveUpdateWorkdir(c.explicit, def, c.has, c.discover)
+			got, err := resolveUpdateWorkdir(c.explicit, def, c.discover)
 			if c.wantErr {
 				if err == nil {
 					t.Fatalf("expected an error, got nil (wd=%q)", got)

--- a/daemon/cmd/daemon/update_workdir_test.go
+++ b/daemon/cmd/daemon/update_workdir_test.go
@@ -10,6 +10,9 @@ func TestResolveUpdateWorkdir(t *testing.T) {
 	discoverOK := func() (string, error) { return "/disguised/wd", nil }
 	discoverNone := func() (string, error) { return "", nil }
 	discoverErr := func() (string, error) { return "", errors.New("permission denied") }
+	// discoverPanic enforces that discovery is NOT called when an explicit
+	// --workdir override is given (it would panic the test if reached).
+	discoverPanic := func() (string, error) { panic("discover must not be called for an explicit override") }
 
 	cases := []struct {
 		name     string
@@ -18,11 +21,10 @@ func TestResolveUpdateWorkdir(t *testing.T) {
 		want     string
 		wantErr  bool
 	}{
-		{"explicit override honored, skips discovery", "/x", discoverOK, "/x", false},
-		{"discovered real install shadows the stale default", def, discoverOK, "/disguised/wd", false},
-		{"default + discovery finds nothing falls back to default", def, discoverNone, def, false},
-		{"discovery I/O error fails fast", def, discoverErr, "", true},
-		{"explicit override skips discovery even when discovery would error", "/x", discoverErr, "/x", false},
+		{"explicit override honored, discovery NOT called", "/x", discoverPanic, "/x", false},
+		{"no override: discovered install wins over default", "", discoverOK, "/disguised/wd", false},
+		{"no override: discovery finds nothing falls back to default", "", discoverNone, def, false},
+		{"no override: discovery I/O error fails fast", "", discoverErr, "", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Bug (found by live deploy)
A stale root-owned install at the **default** workdir (`~/Library/Application Support/focusd-daemon`, just a `version.json`) shadowed the real relocated/disguised mesh. `resolveUpdateWorkdir` checked the default *before* discovery, so `sudo daemon update v0.14.0` wrote `desired` to the stale default and the live platform never upgraded (status kept reading v0.13.1).

## Fix
Discovery **wins** over the default. Precedence: explicit `--workdir` > discovered (running) install > default. Dropped the now-unused `hasInstall` param.

## Test plan
- [x] table test incl. "discovered real install shadows the stale default" + fail-fast on discovery I/O error
- [x] go build/test/vet/gofmt clean
- [ ] CI green

Ships in daemon-v0.5.1. Found via multi-agent diagnostic workflow during the FEATURE 09 live deploy.