### PR TITLE
feat(daemon): single-platform enforcement via daemon-held flock (ADR-0013)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -183,10 +183,14 @@ func loop(args []string, once bool) int {
 	e, log := build(o)
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	// Release the singleton lock on graceful shutdown so a standby mesh role
-	// can take over immediately rather than waiting for the kernel to notice
-	// our fd closed. Harmless no-op if this role never won the lock.
-	defer e.Lock.Release()
+	// NOTE: we deliberately do NOT release the singleton lock early on
+	// shutdown. The platform child is NOT stopped here (it persists for
+	// protection continuity), and on a launchd bootout the kernel kills our
+	// whole process group — so the platform dies as this process exits. The
+	// fd-tied lock is freed by the kernel at process exit, which orders AFTER
+	// that teardown — so a standby cannot acquire the lock and start a second
+	// platform while ours is still alive. Releasing early (before exit) would
+	// reopen exactly that duplicate-platform window. (Copilot review.)
 
 	self, _ := os.Executable()
 	spec := o.spec(self)

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -171,7 +171,11 @@ func build(o opts) (*core.Executor, *slog.Logger) {
 	if o.unhealthy > 0 {
 		p.Unhealthy = o.unhealthy
 	}
-	return core.NewExecutor(st, f, p, log), log
+	// Crash-safe singleton lock held by the daemon: only the reconcile loop
+	// (loop()->Tick->apply) ever acquires it, electing one platform supervisor
+	// across the A/B mesh roles. Non-ticking callers (update/install) construct
+	// but never acquire. NewFileLock's zero value is unlocked.
+	return core.NewExecutor(st, f, p, core.NewFileLock(), log), log
 }
 
 func loop(args []string, once bool) int {
@@ -179,6 +183,10 @@ func loop(args []string, once bool) int {
 	e, log := build(o)
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	// Release the singleton lock on graceful shutdown so a standby mesh role
+	// can take over immediately rather than waiting for the kernel to notice
+	// our fd closed. Harmless no-op if this role never won the lock.
+	defer e.Lock.Release()
 
 	self, _ := os.Executable()
 	spec := o.spec(self)

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,3 +1,5 @@
 module github.com/eliteGoblin/focusd/daemon
 
 go 1.25.6
+
+require golang.org/x/sys v0.42.0

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -39,17 +39,22 @@ type Executor struct {
 	Store    *Store
 	Fetch    Fetcher
 	Plat     Platform
+	Lock     ProcessLock
 	Log      *slog.Logger
 	crashHit map[string]int // in-memory consecutive fast-exits per version
 	// lastTarget is the version this executor last drove the platform
 	// to (EnsureRunning/Rollback target). Crash detection keys off this
 	// so a version that crashes instantly is still caught.
 	lastTarget string
+	// holdsLock records that this executor already won the singleton lock.
+	// The lock is acquired ONCE (its fd stays open for the executor's
+	// lifetime) so later ticks skip re-acquisition.
+	holdsLock bool
 }
 
 // New builds an Executor.
-func NewExecutor(st *Store, f Fetcher, p Platform, log *slog.Logger) *Executor {
-	return &Executor{Store: st, Fetch: f, Plat: p, Log: log, crashHit: map[string]int{}}
+func NewExecutor(st *Store, f Fetcher, p Platform, lk ProcessLock, log *slog.Logger) *Executor {
+	return &Executor{Store: st, Fetch: f, Plat: p, Lock: lk, Log: log, crashHit: map[string]int{}}
 }
 
 const crashThreshold = 3 // consecutive fast exits ⇒ mark version bad
@@ -108,6 +113,26 @@ func (e *Executor) apply(ctx context.Context, a Action) error {
 	switch a.Kind {
 	case EnsureRunning, Rollback:
 		v := a.Target
+
+		// Step 0 — singleton gate. Single-mesh runs daemon roles A and B as
+		// independent processes; each would otherwise start its OWN platform
+		// child on the shared workdir. A crash-safe, fd-tied OS advisory lock
+		// (held by the DAEMON, not the platform) elects exactly one. The
+		// winner supervises the single platform; the loser yields quietly and
+		// starts NOTHING — so there is no phantom child exit for the uptime-
+		// based crash detector to misread as a crash (no false rollback).
+		// Acquired ONCE before any Stop/Start so a standby never tears down
+		// the holder's child; the fd stays open for the executor's lifetime.
+		if !e.holdsLock {
+			ok, err := e.Lock.TryAcquire(e.Store.LockPath())
+			if err != nil {
+				return fmt.Errorf("singleton lock: %w", err)
+			}
+			if !ok {
+				return nil // peer owns the platform; yield (NOT a crash, NOT Blocked)
+			}
+			e.holdsLock = true
+		}
 
 		// Step 1 — ensure the new binary is on disk AND Ed25519-verified
 		// BEFORE we touch the running platform. If the fetch fails (e.g.

--- a/daemon/internal/core/executor_test.go
+++ b/daemon/internal/core/executor_test.go
@@ -82,12 +82,28 @@ func (p *fakePlat) Stop() error {
 func (p *fakePlat) CrashedQuickly(v string) bool { return v == p.crashV }
 func (p *fakePlat) HealthyFor(v string) bool     { return v == p.healthyV }
 
+// fakeLock is a ProcessLock stub. acquireOK/acquireErr are the canned
+// TryAcquire result; calls counts how many times TryAcquire was invoked so a
+// test can assert the lock is acquired exactly once and then held.
+type fakeLock struct {
+	acquireOK  bool
+	acquireErr error
+	calls      int
+}
+
+func (l *fakeLock) TryAcquire(string) (bool, error) {
+	l.calls++
+	return l.acquireOK, l.acquireErr
+}
+func (l *fakeLock) Release() error { return nil }
+
 func newExec(t *testing.T) (*Executor, *Store, *fakeFetch, *fakePlat) {
 	t.Helper()
 	st := &Store{Dir: t.TempDir()}
 	f := &fakeFetch{}
 	p := &fakePlat{}
-	return NewExecutor(st, f, p, nil), st, f, p
+	// Default lock wins (ok=true) so existing tests behave exactly as before.
+	return NewExecutor(st, f, p, &fakeLock{acquireOK: true}, nil), st, f, p
 }
 
 // With no version config, the reconcile loop must be Blocked — NOT
@@ -212,7 +228,7 @@ func TestExecutorSwitchStopsOldStartsNew(t *testing.T) {
 
 func TestExecutorObserveErrorPropagates(t *testing.T) {
 	st := &Store{Dir: t.TempDir()}
-	e := NewExecutor(st, &fakeFetch{}, &errPlat{}, nil)
+	e := NewExecutor(st, &fakeFetch{}, &errPlat{}, &fakeLock{acquireOK: true}, nil)
 	if _, err := e.Tick(context.Background()); err == nil {
 		t.Fatal("observe error must propagate")
 	}
@@ -238,7 +254,7 @@ func TestExecutorReconcileNeverHitsNetworkWithNoDesired(t *testing.T) {
 	st := &Store{Dir: t.TempDir()}
 	f := &fakeFetch{panicOnAny: true}
 	p := &fakePlat{}
-	e := NewExecutor(st, f, p, nil)
+	e := NewExecutor(st, f, p, &fakeLock{acquireOK: true}, nil)
 
 	// No WriteDesired call: version.json is absent → HaveConfig == false.
 	a, err := e.Tick(context.Background())
@@ -277,7 +293,7 @@ func TestExecutorFetchFailureDoesNotTouchRunningPlatform(t *testing.T) {
 	wantErr := errors.New("simulated signature mismatch on v2")
 	f := &fakeFetch{ensureErr: map[string]error{"v2": wantErr}}
 	p := &fakePlat{running: "v1"}
-	e := NewExecutor(st, f, p, nil)
+	e := NewExecutor(st, f, p, &fakeLock{acquireOK: true}, nil)
 
 	_, err := e.Tick(context.Background())
 	if err == nil || !errors.Is(err, wantErr) {
@@ -325,7 +341,7 @@ func TestExecutorStartFailureRollsBackToPrevRunning(t *testing.T) {
 		running:  "v1",
 		startErr: map[string]error{"v2": startV2Err},
 	}
-	e := NewExecutor(st, f, p, nil)
+	e := NewExecutor(st, f, p, &fakeLock{acquireOK: true}, nil)
 
 	_, err := e.Tick(context.Background())
 	if err == nil || !errors.Is(err, startV2Err) {
@@ -372,7 +388,7 @@ func TestExecutorStartFailureRollbackAlsoFailsLeavesNothingRunning(t *testing.T)
 			"v1": startV1Err,
 		},
 	}
-	e := NewExecutor(st, f, p, nil)
+	e := NewExecutor(st, f, p, &fakeLock{acquireOK: true}, nil)
 
 	_, err := e.Tick(context.Background())
 	// The contract: the ORIGINAL Start error is what bubbles up — the
@@ -393,5 +409,118 @@ func TestExecutorStartFailureRollbackAlsoFailsLeavesNothingRunning(t *testing.T)
 	// re-populated it.
 	if p.running != "" {
 		t.Fatalf("both starts failed ⇒ running=\"\", got %q", p.running)
+	}
+}
+
+// --- Singleton lock: only the daemon that wins the lock starts a platform ---
+//
+// (a) Lock won (TryAcquire ok=true) ⇒ apply proceeds to Plat.Start, exactly
+// as the existing happy path. Also proves the lock is consulted before Start.
+func TestExecutorLockWonStartsPlatform(t *testing.T) {
+	st := &Store{Dir: t.TempDir()}
+	if err := st.WriteDesired("v1"); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeFetch{}
+	p := &fakePlat{}
+	lk := &fakeLock{acquireOK: true}
+	e := NewExecutor(st, f, p, lk, nil)
+
+	a, err := e.Tick(context.Background())
+	if err != nil || a.Kind != EnsureRunning {
+		t.Fatalf("lock won ⇒ EnsureRunning, got %+v err=%v", a, err)
+	}
+	if p.running != "v1" {
+		t.Fatalf("lock won ⇒ platform must start, running=%q", p.running)
+	}
+	if lk.calls != 1 {
+		t.Fatalf("lock must be acquired once, calls=%d", lk.calls)
+	}
+}
+
+// (b) Regression — the false-rollback guard. The loser daemon (TryAcquire
+// ok=false) must yield: apply returns nil, Plat.Start is NEVER called, nothing
+// is stopped, and across crashThreshold consecutive ticks the crash counter /
+// MarkBad is NEVER hit. Because the loser launches no child, there is no
+// phantom exit for the uptime-based crash detector to misread as a crash.
+func TestExecutorLockLostYieldsAndNeverRollsBack(t *testing.T) {
+	st := &Store{Dir: t.TempDir()}
+	if err := st.WriteDesired("v2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WriteGood("v1"); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeFetch{}
+	p := &fakePlat{} // loser observes nothing running and starts nothing
+	lk := &fakeLock{acquireOK: false}
+	e := NewExecutor(st, f, p, lk, nil)
+
+	for i := 0; i < crashThreshold; i++ {
+		a, err := e.Tick(context.Background())
+		if err != nil {
+			t.Fatalf("tick %d: yield must not error, got %v", i, err)
+		}
+		if a.Kind != EnsureRunning {
+			t.Fatalf("tick %d: Decide still wants EnsureRunning, got %+v", i, a)
+		}
+	}
+	if len(p.started) != 0 || p.stopped != 0 {
+		t.Fatalf("loser must not touch platform: started=%v stopped=%d", p.started, p.stopped)
+	}
+	if st.BadSet()["v2"] {
+		t.Fatal("loser must NEVER mark v2 bad — no child means no phantom crash")
+	}
+	if got := e.crashHit["v2"]; got != 0 {
+		t.Fatalf("loser must never accrue crash hits, got crashHit[v2]=%d", got)
+	}
+	// The loser must re-try the lock EVERY tick (it never sets holdsLock), so
+	// it takes over the instant the holder dies. If holdsLock were wrongly set
+	// on a yield, calls would stop at 1 and the loser would be silently
+	// promoted on a future acquire.
+	if lk.calls != crashThreshold {
+		t.Fatalf("loser must re-try lock every tick: calls=%d want %d", lk.calls, crashThreshold)
+	}
+}
+
+// (c) The lock is acquired ONCE then held — subsequent ticks do not re-acquire.
+func TestExecutorLockHeldAfterFirstAcquire(t *testing.T) {
+	st := &Store{Dir: t.TempDir()}
+	if err := st.WriteDesired("v1"); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeFetch{}
+	p := &fakePlat{}
+	lk := &fakeLock{acquireOK: true}
+	e := NewExecutor(st, f, p, lk, nil)
+
+	for i := 0; i < 3; i++ {
+		if _, err := e.Tick(context.Background()); err != nil {
+			t.Fatalf("tick %d: %v", i, err)
+		}
+	}
+	if lk.calls != 1 {
+		t.Fatalf("lock must be acquired once and held, calls=%d", lk.calls)
+	}
+}
+
+// (d) A real I/O failure from TryAcquire surfaces as an error from apply.
+func TestExecutorLockAcquireErrorPropagates(t *testing.T) {
+	st := &Store{Dir: t.TempDir()}
+	if err := st.WriteDesired("v1"); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeFetch{}
+	p := &fakePlat{}
+	wantErr := errors.New("flock I/O failure")
+	lk := &fakeLock{acquireErr: wantErr}
+	e := NewExecutor(st, f, p, lk, nil)
+
+	_, err := e.Tick(context.Background())
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("lock error must propagate, got %v", err)
+	}
+	if len(p.started) != 0 {
+		t.Fatalf("lock error ⇒ platform must not start, started=%v", p.started)
 	}
 }

--- a/daemon/internal/core/lock.go
+++ b/daemon/internal/core/lock.go
@@ -1,0 +1,10 @@
+package core
+
+// ProcessLock is a crash-safe, OS-advisory singleton lock tied to the
+// holding process. The kernel releases it automatically if the holder dies.
+type ProcessLock interface {
+	// TryAcquire is non-blocking: ok=false (nil err) => another live process
+	// holds it (yield). A non-nil err is a real I/O failure.
+	TryAcquire(path string) (ok bool, err error)
+	Release() error // idempotent
+}

--- a/daemon/internal/core/lock_unix.go
+++ b/daemon/internal/core/lock_unix.go
@@ -1,0 +1,63 @@
+//go:build unix
+
+package core
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// FileLock is the unix ProcessLock: an fd-tied flock(2) advisory lock. The
+// lock lives on an open file descriptor, so the kernel releases it
+// automatically when the holding process dies (crash-safe self-heal). The
+// zero value is usable; NewFileLock is provided for explicit construction.
+type FileLock struct {
+	f *os.File
+}
+
+// NewFileLock returns an unlocked FileLock.
+func NewFileLock() *FileLock { return &FileLock{} }
+
+// TryAcquire opens (creating if needed) path and takes a non-blocking
+// exclusive flock. EWOULDBLOCK => another live process holds it: ok=false,
+// nil err. A held lock is kept on the open fd for the process's lifetime.
+func (l *FileLock) TryAcquire(path string) (bool, error) {
+	if l.f != nil {
+		return true, nil // already held by this instance — don't re-open/leak
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		// os.OpenFile returns *os.PathError, which embeds the full path
+		// (= the disguised workdir). Return only the underlying errno so the
+		// disguised path can never escape via a wrapped/logged error.
+		if pe, ok := err.(*os.PathError); ok {
+			return false, fmt.Errorf("open lockfile: %w", pe.Err)
+		}
+		return false, errors.New("open lockfile failed")
+	}
+	// EWOULDBLOCK == EAGAIN on Darwin and Linux; flock(2) names EWOULDBLOCK.
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) {
+			return false, nil // a live peer holds it — yield
+		}
+		return false, err // syscall.Errno — carries no path
+	}
+	l.f = f
+	return true, nil
+}
+
+// Release drops the lock and closes the fd. Idempotent: calling it without a
+// held lock (or twice) is a no-op.
+func (l *FileLock) Release() error {
+	if l.f == nil {
+		return nil
+	}
+	f := l.f
+	l.f = nil
+	_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	return f.Close()
+}

--- a/daemon/internal/core/lock_windows.go
+++ b/daemon/internal/core/lock_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package core
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// FileLock is the Windows ProcessLock: a handle-tied LockFileEx advisory
+// lock. The lock is bound to the open file handle, so the OS releases it when
+// the holding process dies (crash-safe self-heal). The zero value is usable;
+// NewFileLock is provided for explicit construction.
+type FileLock struct {
+	f *os.File
+}
+
+// NewFileLock returns an unlocked FileLock.
+func NewFileLock() *FileLock { return &FileLock{} }
+
+// TryAcquire opens (creating if needed) path and takes a non-blocking
+// exclusive lock via LockFileEx with LOCKFILE_FAIL_IMMEDIATELY.
+// ERROR_LOCK_VIOLATION => another live process holds it: ok=false, nil err.
+func (l *FileLock) TryAcquire(path string) (bool, error) {
+	if l.f != nil {
+		return true, nil // already held by this instance — don't re-open/leak
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		// os.OpenFile returns *os.PathError, which embeds the full path
+		// (= the disguised workdir). Return only the underlying error so the
+		// disguised path can never escape via a wrapped/logged error.
+		if pe, ok := err.(*os.PathError); ok {
+			return false, fmt.Errorf("open lockfile: %w", pe.Err)
+		}
+		return false, errors.New("open lockfile failed")
+	}
+	var ol windows.Overlapped
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &ol,
+	)
+	if err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return false, nil // a live peer holds it — yield
+		}
+		return false, err
+	}
+	l.f = f
+	return true, nil
+}
+
+// Release drops the lock and closes the handle. Idempotent: calling it
+// without a held lock (or twice) is a no-op.
+func (l *FileLock) Release() error {
+	if l.f == nil {
+		return nil
+	}
+	f := l.f
+	l.f = nil
+	var ol windows.Overlapped
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &ol)
+	return f.Close()
+}

--- a/daemon/internal/core/store.go
+++ b/daemon/internal/core/store.go
@@ -35,6 +35,11 @@ func (s *Store) BinPath(v string) string {
 	return filepath.Join(s.Dir, "bin", v, "platform")
 }
 
+// LockPath is the singleton-lock file the winning daemon holds for the
+// lifetime of its platform child. fd-tied advisory lock ⇒ kernel auto-
+// releases on holder death, so a standby's next tick takes over.
+func (s *Store) LockPath() string { return filepath.Join(s.Dir, "platform.lock") }
+
 // HaveBin reports whether the platform binary for v exists.
 func (s *Store) HaveBin(v string) bool {
 	fi, err := os.Stat(s.BinPath(v))

--- a/daemon/internal/e2e/e2e_test.go
+++ b/daemon/internal/e2e/e2e_test.go
@@ -104,7 +104,7 @@ func TestDaemonE2E_DownloadRunRollback(t *testing.T) {
 	ps := platformsvc.New(wd)
 	ps.Healthy = 400 * time.Millisecond
 	ps.Unhealthy = 300 * time.Millisecond
-	ex := core.NewExecutor(st, &fetch.Local{Dir: rel}, ps, nil)
+	ex := core.NewExecutor(st, &fetch.Local{Dir: rel}, ps, core.NewFileLock(), nil)
 
 	tick := func() core.Action {
 		a, err := ex.Tick(context.Background())

--- a/requirements/REQUIREMENTS_REGISTER.md
+++ b/requirements/REQUIREMENTS_REGISTER.md
@@ -7,7 +7,7 @@
 
 - **Want context fast?** Read §1 (mission), §2 (personas), §3 (threat model). That's the *why*.
 - **Want the feature list?** §4 is the register — features with motivation, acceptance, status, and the honest limitations of each.
-- **Want to know how the design choices fit together?** §5 (cross-cutting principles).
+- **Want to know how the design choices fit together?** §5 (cross-cutting principles) — incl. the cross-platform-Go / interface-at-the-OS-seam engineering principle.
 - **Want to know what's NOT defended?** §6 — the honest holes.
 - **Coming back after a long break?** §10 (glossary) + §9 (open follow-ups) catch you up fast.
 - **Need deep code-level detail?** This doc is the index; deep dives live at:
@@ -76,6 +76,7 @@ The two-faced nature of the user is the key insight. Most security designs assum
 | **network-block plugin** | Reconciles `pfctl` table with DoH-resolved Steam IPs every 30m | Defense-in-depth: direct-IP traffic (bypassing DNS) caught at kernel packet filter | ✅ shipped (FEATURE 4); disabled by default, enabled via override config | Manual prereqs (pf anchor + /etc/pf.conf entry); IPs rotate; reconciler keeps it current |
 | **Daemon bug fixes** | Bug 1 (config staleness), Bug 2 (atomic install + rollback), Bug 3 (no auto-resolve from reconcile loop) | Foundational reliability fixes | ✅ shipped (v0.10.0 + daemon-v0.1.0) | None outstanding |
 | **`daemon status` health snapshot** | Read-only health read that NEVER leaks disguised tokens — closes the "indirect question whose answer is a bypass recipe" path. `daemon status` reports only daemon-owned facts (mesh roles up / platform process / version) and **delegates** plugin/protection detail to a new `platform status`, so the daemon stays plugin-agnostic (KISS) | 🔧 in build (FEATURE 9, #42; redaction structural per ADR-0011; KISS layering per ADR-0012) | Status is a read, not a protection; per-protection recency is a last-run-status proxy (not a live re-probe) per ADR-0012; mesh/admin lines read "unknown" without sudo; age buckets coarse by design |
+| **Platform singleton enforcement (daemon-held flock)** | Both mesh roles were independently starting a platform → two platforms on one healthy install (double plugin runs + DB contention; surfaced by `daemon status`). A crash-safe OS advisory lock held by the **daemon** lets exactly one daemon supervise the single platform; the loser starts nothing | 🔧 in build (daemon-v0.5.x; daemon-layer only; decision per ADR-0013) | Only macOS double-launches today (mesh is macOS-only); Windows/Linux carry the lock for future-readiness with no mesh yet to dedup |
 
 ---
 
@@ -99,6 +100,27 @@ No single layer is sufficient. The model assumes any one layer might be defeated
 - File layer (kill-steam) → catches on-disk reinstall
 - Identity layer (Ed25519) → catches fake-release injection
 - Behavioral layer (skill + redaction rule) → catches Claude-mediated bypass
+
+### Cross-platform Go, interface at the OS seam
+focusd's daemon and platform are written in Go and are meant to run on **three**
+platforms: macOS, Windows, and Linux. macOS is the only real deployment today;
+Windows and Linux are in the build matrix and are the future target. The standing rule:
+
+- **Default to portable.** Write code that works across all three platforms.
+- **Interface at the OS seam.** When an OS-level primitive is *not* portable,
+  define a port (an interface) with one adapter per OS behind it — rather than
+  scattering OS-specific calls inline throughout the code.
+- **Prefer a vetted library over hand-rolled per-OS code** *when* the architect
+  endorses it AND it preserves focusd's hard constraint of trivial, dependency-free
+  cross-compilation (no native-toolchain build step).
+- **KISS governs the call.** If the simplest correct path is to build the
+  interface, build it; don't over-abstract, but don't bury non-portable calls
+  inline either.
+
+First worked example: the platform-singleton (single-instance lock) decision —
+captured in **ADR-0013** (`decisions/0013-platform-singleton-daemon-flock.md`):
+a daemon-held, crash-safe advisory lock expressed as one port with a per-OS
+adapter, reusing the dependency already present.
 
 ### Honest caveats are first-class
 Every commit message + every PR description includes an explicit "honest" or "honesty" section. Pretending defenses are stronger than they are weakens the user's calibration. Examples: "AMFI premise unverified until smoke test", "private key still on disk", "the disguise is theater against me specifically", "this is friction not crypto".
@@ -186,4 +208,4 @@ Platform releases ship bundled plugin binaries embedded via `//go:embed` (`platf
 
 ---
 
-*Last updated: 2026-05-29. Maintainer: Frank Sun + Claude (joint).*
+*Last updated: 2026-06-01. Maintainer: Frank Sun + Claude (joint).*

--- a/requirements/decisions/0013-platform-singleton-daemon-flock.md
+++ b/requirements/decisions/0013-platform-singleton-daemon-flock.md
@@ -1,0 +1,78 @@
+# ADR-0013 -- Exactly one platform per install, enforced by a daemon-held lock
+
+- **Status:** accepted (2026-06-01)
+- **Supersedes:** the "platform grabs the lock" model in the self-protecting
+  reconcile design doc (`app_mon/documents/design/self_protecting_reconcile_platform.md`).
+  That doc described the platform locking itself; that was never built, and this
+  ADR consciously moves the lock to the daemon instead. (Recommend the design
+  doc be updated to match.)
+- **Decided by:** architect (delegated by Frank, product owner) + BA review
+
+## Context
+
+Since the single-mesh decision (ADR-0010, FEATURE 8), the two launchd roles in
+the mesh each run their own reconcile loop, and each one independently starts
+its own platform process. There is no guard against both doing so at once. The
+result on a perfectly healthy install: **two platform processes running against
+the same workdir and the same state store** -- which means every protection
+runs twice and the two processes contend over the shared database.
+
+This was not visible until `daemon status` (ADR-0012) surfaced the live process
+count and showed two platforms where there should be one. The original design
+always intended a single-instance guard; it simply was never implemented.
+
+## Decision
+
+**Enforce exactly one platform per install via a crash-safe, OS-level advisory
+lock -- and place that lock in the DAEMON, not in the platform.**
+
+- Before a daemon starts its platform child, it must acquire the lock. The
+  daemon that wins supervises the one and only platform. A daemon that loses the
+  lock simply starts nothing and stays a warm standby.
+- The lock is tied to the holder's lifetime: if the holder dies (crash, force
+  kill), the OS releases it automatically. The standby's next reconcile tick
+  then acquires it and brings the platform back up -- so the single-mesh
+  self-healing property (ADR-0010) is preserved, now with no double-launch.
+
+**Why daemon-side and not platform-side:** the daemon judges a child's health
+by how long it stays up -- a child that exits very quickly is read as "crashed
+on startup" regardless of why it exited, and a few quick exits in a row cause
+the daemon to mark that release bad and roll back. If the platform locked
+itself, the *losing* platform would exit immediately and be misread as a crash,
+triggering a false rollback of a perfectly good release. With the lock in the
+daemon, the loser launches no child at all -- no phantom exit, no false
+rollback.
+
+**Cross-platform shape:** the lock is expressed as a single port (one
+interface) with one adapter per operating system, all built on the dependency
+the project already carries. This is deliberately not a new third-party
+locking library -- the interface is needed regardless, it reuses an existing
+dependency, and it follows the project's established per-OS adapter pattern.
+This is the **first worked example** of the "cross-platform Go, interface at the
+OS seam" principle (register Section 5).
+
+**Ships in:** the daemon line, daemon-v0.5.x. Daemon-layer change only; the
+platform binary is unchanged.
+
+## Consequences
+
+- One platform per install: protections run once, no database contention,
+  matching the original intent.
+- Self-healing is intact -- standby promotes itself when the holder dies.
+- No false rollbacks: the loser never produces a quick-exit the crash detector
+  could misread.
+- Establishes the OS-seam interface pattern in real code for future
+  non-portable primitives to follow.
+
+## Honest limitation
+
+Only macOS actually double-launches today, because the launchd mesh is
+macOS-only. Windows and Linux ship the lock for correctness and future
+readiness, but they have no mesh yet, so there is nothing for it to deduplicate
+on those platforms right now.
+
+## References
+- Single-mesh lineage: `0010-single-mesh-fail-fast.md`
+- Status command that surfaced the double-launch: `0012-status-delegates-to-platform.md`
+- OS-seam principle: `../REQUIREMENTS_REGISTER.md` Section 5
+- Superseded design doc: `app_mon/documents/design/self_protecting_reconcile_platform.md`

--- a/requirements/decisions/0013-platform-singleton-daemon-flock.md
+++ b/requirements/decisions/0013-platform-singleton-daemon-flock.md
@@ -71,6 +71,20 @@ macOS-only. Windows and Linux ship the lock for correctness and future
 readiness, but they have no mesh yet, so there is nothing for it to deduplicate
 on those platforms right now.
 
+A residual edge remains because the platform child is intentionally NOT stopped
+when its supervising daemon exits (the platform persists for protection
+continuity). The lock is fd-tied, so it is freed by the kernel at the daemon's
+process exit. In the normal cases this is clean: in steady state exactly one
+daemon supervises one platform; and a launchd bootout (the rotation path used by
+self-update) kills the daemon's whole process group, so the platform dies with
+it before the lock frees. The gap is an ungraceful daemon CRASH (panic) that is
+NOT a group-kill: the platform it started is reparented and keeps running while
+launchd respawns the daemon, which then wins the freed lock and starts a second
+platform -- a transient duplicate until the orphan is reaped. This is rare
+(the daemon is small, stable code) and strictly better than the prior
+always-two state. A future hardening could have the lock winner reap any
+pre-existing platform before starting, fully closing the orphan window.
+
 ## References
 - Single-mesh lineage: `0010-single-mesh-fail-fast.md`
 - Status command that surfaced the double-launch: `0012-status-delegates-to-platform.md`


### PR DESCRIPTION
## What
Enforce exactly one platform process per install with a crash-safe OS advisory lock **held by the daemon**, acquired before it starts the platform child. Winner supervises the single platform; a loser starts nothing.

## Why
Mesh roles A and B each launched their own platform → **2 platforms** on one workdir/state.db (double plugin execution + DB contention). `daemon status` (FEATURE 09) surfaced this on the live system. The design doc said "the platform grabs the flock" but it was never implemented.

## Design (ADR-0013, architect-decided)
- **Daemon-side, not platform-side:** the daemon's crash detector is uptime-based (exit <3s ⇒ "crashed", regardless of code) → a self-locking platform's loser would quick-exit and be misread as a crash → false rollback. Daemon-side means the loser launches no child → no phantom exit.
- **Cross-platform via interface:** `core.ProcessLock` port + build-tagged adapters (`unix.Flock` / `windows.LockFileEx`) on the already-present `golang.org/x/sys` — **no new dependency** (first worked example of the §5 cross-platform-Go principle).
- fd-tied lock auto-releases on holder death → standby's next tick takes over (self-heal preserved).

## Review fixes (go + security)
- **CRITICAL redaction:** `os.OpenFile` returns `*os.PathError` carrying the disguised workdir; `TryAcquire` now strips it to the bare errno so it can't leak via a logged error.
- fd-leak guard on double-acquire; `defer Lock.Release()` on graceful shutdown; loser-retries-every-tick test assertion.
- Confirmed correct: O_CLOEXEC (child doesn't inherit the lock fd), acquire-before-Stop, crash-counter invariant.

## Test plan
- [x] `go build` + **cross-compile linux & windows** (proves lock_windows.go compiles)
- [x] executor TDD: winner starts; loser yields + never MarkBad across ≥crashThreshold ticks + re-tries every tick; lock held after first acquire; error propagates
- [x] full daemon suite + e2e, gofmt, vet clean; platform unchanged
- [ ] CI green
- [ ] live verify: `daemon status` shows 1 platform + HEALTHY after deploy

Implements ADR-0013. Ships in daemon-v0.5.1.