### PR TITLE
fix(fetch): direct release-download URL kills the ADR-0015 fetch-storm

### DIFF
--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 )
 
 // Seams — real implementations hit GitHub / launchd / processes; tests
@@ -50,14 +51,37 @@ type Executor struct {
 	// The lock is acquired ONCE (its fd stays open for the executor's
 	// lifetime) so later ticks skip re-acquisition.
 	holdsLock bool
+	// fetchRetryAfter throttles platform-binary fetch retries (ADR-0015):
+	// after a failed EnsureBinary the next attempt is deferred until this
+	// time, so a persistently-failing fetch (network down, CDN hiccup) is
+	// retried ~once per fetchRetryCooldown rather than every ~2s reconcile
+	// tick. This throttles only the *fetch*, never the mesh heal cadence.
+	fetchRetryAfter time.Time
+	// now is the clock seam (defaults to time.Now); tests inject a fake.
+	now func() time.Time
 }
 
 // New builds an Executor.
 func NewExecutor(st *Store, f Fetcher, p Platform, lk ProcessLock, log *slog.Logger) *Executor {
-	return &Executor{Store: st, Fetch: f, Plat: p, Lock: lk, Log: log, crashHit: map[string]int{}}
+	return &Executor{Store: st, Fetch: f, Plat: p, Lock: lk, Log: log, crashHit: map[string]int{}, now: time.Now}
 }
 
 const crashThreshold = 3 // consecutive fast exits ⇒ mark version bad
+
+// fetchRetryCooldown caps how often a failing platform-binary fetch is
+// retried (ADR-0015 defense-in-depth). The reconcile loop ticks ~2s; a
+// failing fetch must NOT be re-attempted every tick. This throttles the
+// fetch retry only — it does NOT change the mesh worker-heal cadence.
+const fetchRetryCooldown = 30 * time.Second
+
+// nowOrDefault returns the executor clock (time.Now unless a test injected
+// a fake), tolerating zero-valued executors built without NewExecutor.
+func (e *Executor) nowOrDefault() time.Time {
+	if e.now != nil {
+		return e.now()
+	}
+	return time.Now()
+}
 
 // Tick performs exactly one reconcile step. Returns the Action taken.
 func (e *Executor) Tick(ctx context.Context) (Action, error) {
@@ -140,9 +164,18 @@ func (e *Executor) apply(ctx context.Context, a Action) error {
 		// WITHOUT having stopped anything — the old platform keeps
 		// running uninterrupted. Replacement-running invariant first.
 		if !e.Store.HaveBin(v) {
+			// ADR-0015 fetch-retry cooldown: a fetch that failed recently is
+			// not re-attempted until fetchRetryAfter, so a persistent failure
+			// (network down, CDN hiccup) is retried ~once/30s instead of every
+			// ~2s tick. The old platform keeps running meanwhile.
+			if now := e.nowOrDefault(); now.Before(e.fetchRetryAfter) {
+				return fmt.Errorf("ensure binary %s: deferred until %s (fetch cooldown)", v, e.fetchRetryAfter.Format(time.RFC3339))
+			}
 			if err := e.Fetch.EnsureBinary(ctx, e.Store, v); err != nil {
+				e.fetchRetryAfter = e.nowOrDefault().Add(fetchRetryCooldown)
 				return fmt.Errorf("ensure binary %s: %w", v, err)
 			}
+			e.fetchRetryAfter = time.Time{} // success: clear the cooldown
 		}
 
 		// Step 2 — snapshot the current running version BEFORE stopping

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -57,6 +57,11 @@ type Executor struct {
 	// retried ~once per fetchRetryCooldown rather than every ~2s reconcile
 	// tick. This throttles only the *fetch*, never the mesh heal cadence.
 	fetchRetryAfter time.Time
+	// fetchRetryVersion scopes the cooldown to the version whose fetch
+	// failed. If the desired target changes (operator pins a different
+	// version) the new version's first fetch must NOT be deferred by the
+	// prior version's cooldown — so we only defer when v matches.
+	fetchRetryVersion string
 	// now is the clock seam (defaults to time.Now); tests inject a fake.
 	now func() time.Time
 }
@@ -168,14 +173,16 @@ func (e *Executor) apply(ctx context.Context, a Action) error {
 			// not re-attempted until fetchRetryAfter, so a persistent failure
 			// (network down, CDN hiccup) is retried ~once/30s instead of every
 			// ~2s tick. The old platform keeps running meanwhile.
-			if now := e.nowOrDefault(); now.Before(e.fetchRetryAfter) {
+			if now := e.nowOrDefault(); v == e.fetchRetryVersion && now.Before(e.fetchRetryAfter) {
 				return fmt.Errorf("ensure binary %s: deferred until %s (fetch cooldown)", v, e.fetchRetryAfter.Format(time.RFC3339))
 			}
 			if err := e.Fetch.EnsureBinary(ctx, e.Store, v); err != nil {
 				e.fetchRetryAfter = e.nowOrDefault().Add(fetchRetryCooldown)
+				e.fetchRetryVersion = v
 				return fmt.Errorf("ensure binary %s: %w", v, err)
 			}
 			e.fetchRetryAfter = time.Time{} // success: clear the cooldown
+			e.fetchRetryVersion = ""
 		}
 
 		// Step 2 — snapshot the current running version BEFORE stopping

--- a/daemon/internal/core/executor_test.go
+++ b/daemon/internal/core/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // --- fakes ---
@@ -23,6 +24,9 @@ type fakeFetch struct {
 	// error for that version (and NOT lay down the binary) — covers the
 	// "fetch fails before we touch the running platform" invariant.
 	ensureErr map[string]error
+	// ensureCalls counts EnsureBinary invocations so the fetch-cooldown
+	// regression can assert the fetch is throttled, not re-tried per tick.
+	ensureCalls int
 }
 
 func (f *fakeFetch) ResolveLatest(context.Context) (string, error) {
@@ -35,6 +39,7 @@ func (f *fakeFetch) EnsureBinary(_ context.Context, st *Store, v string) error {
 	if f.panicOnAny {
 		panic("fakeFetch.EnsureBinary must not be called from reconcile")
 	}
+	f.ensureCalls++
 	if err, ok := f.ensureErr[v]; ok {
 		return err
 	}
@@ -231,6 +236,53 @@ func TestExecutorObserveErrorPropagates(t *testing.T) {
 	e := NewExecutor(st, &fakeFetch{}, &errPlat{}, &fakeLock{acquireOK: true}, nil)
 	if _, err := e.Tick(context.Background()); err == nil {
 		t.Fatal("observe error must propagate")
+	}
+}
+
+// ADR-0015 defense-in-depth: a platform-binary fetch that fails must NOT
+// be re-attempted on every ~2s tick. The cooldown defers the retry; once
+// it elapses the fetch is attempted again (and on success the binary lands
+// and the platform starts).
+func TestExecutorFetchFailureBacksOff(t *testing.T) {
+	e, st, f, p := newExec(t)
+	st.WriteDesired("v1")
+	p.running = ""
+
+	// Drive a controllable clock.
+	clk := time.Unix(1_000_000, 0)
+	e.now = func() time.Time { return clk }
+
+	// First tick: fetch fails → cooldown armed, nothing started.
+	f.ensureErr = map[string]error{"v1": errors.New("network down")}
+	if _, err := e.Tick(context.Background()); err == nil {
+		t.Fatal("first fetch failure must surface an error")
+	}
+	if f.ensureCalls != 1 {
+		t.Fatalf("expected 1 fetch attempt, got %d", f.ensureCalls)
+	}
+
+	// Subsequent ticks BEFORE the cooldown elapses must NOT re-fetch.
+	clk = clk.Add(10 * time.Second) // < 30s cooldown
+	if _, err := e.Tick(context.Background()); err == nil {
+		t.Fatal("deferred tick still has no binary → still errors")
+	}
+	if f.ensureCalls != 1 {
+		t.Fatalf("fetch must be throttled within cooldown: attempts=%d (want 1)", f.ensureCalls)
+	}
+
+	// After the cooldown elapses, the fetch is retried — now it succeeds,
+	// the binary lands, and the platform starts.
+	clk = clk.Add(25 * time.Second) // total 35s > 30s cooldown
+	f.ensureErr = nil               // recovery
+	a, err := e.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("post-cooldown tick: %v", err)
+	}
+	if f.ensureCalls != 2 {
+		t.Fatalf("fetch must be retried after cooldown: attempts=%d (want 2)", f.ensureCalls)
+	}
+	if a.Kind != EnsureRunning || p.running != "v1" || !st.HaveBin("v1") {
+		t.Fatalf("after recovery v1 must start: act=%+v running=%q bin=%v", a, p.running, st.HaveBin("v1"))
 	}
 }
 

--- a/daemon/internal/core/executor_test.go
+++ b/daemon/internal/core/executor_test.go
@@ -286,6 +286,44 @@ func TestExecutorFetchFailureBacksOff(t *testing.T) {
 	}
 }
 
+// TestExecutorFetchCooldownScopedToVersion proves the cooldown is keyed to the
+// version that FAILED, not applied globally: pinning a different version after
+// a failure must fetch it immediately, even within the prior version's cooldown
+// window (Copilot review on PR #54).
+func TestExecutorFetchCooldownScopedToVersion(t *testing.T) {
+	e, st, f, p := newExec(t)
+	st.WriteDesired("v1")
+	p.running = ""
+
+	clk := time.Unix(1_000_000, 0)
+	e.now = func() time.Time { return clk }
+
+	// v1 fetch fails → cooldown armed for v1.
+	f.ensureErr = map[string]error{"v1": errors.New("network down")}
+	if _, err := e.Tick(context.Background()); err == nil {
+		t.Fatal("first fetch failure must surface an error")
+	}
+	if f.ensureCalls != 1 {
+		t.Fatalf("expected 1 fetch attempt, got %d", f.ensureCalls)
+	}
+
+	// Operator re-pins to v2, still WITHIN v1's cooldown window. v2 must NOT
+	// be deferred by v1's cooldown — it fetches immediately and starts.
+	clk = clk.Add(5 * time.Second) // << 30s cooldown
+	st.WriteDesired("v2")
+	f.ensureErr = nil // v2 fetch succeeds
+	a, err := e.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("v2 tick within v1 cooldown must not be deferred: %v", err)
+	}
+	if f.ensureCalls != 2 {
+		t.Fatalf("v2 fetch must be attempted immediately: attempts=%d (want 2)", f.ensureCalls)
+	}
+	if a.Kind != EnsureRunning || p.running != "v2" || !st.HaveBin("v2") {
+		t.Fatalf("v2 must start despite v1 cooldown: act=%+v running=%q bin=%v", a, p.running, st.HaveBin("v2"))
+	}
+}
+
 type errPlat struct{}
 
 func (*errPlat) RunningVersion() (string, error) { return "", os.ErrPermission }

--- a/daemon/internal/fetch/github.go
+++ b/daemon/internal/fetch/github.go
@@ -30,10 +30,6 @@ func (g *GitHub) client() *http.Client {
 
 type ghRelease struct {
 	TagName string `json:"tag_name"`
-	Assets  []struct {
-		Name string `json:"name"`
-		URL  string `json:"browser_download_url"`
-	} `json:"assets"`
 }
 
 func (g *GitHub) get(ctx context.Context, url string) (*http.Response, error) {
@@ -60,7 +56,7 @@ func (g *GitHub) ResolveLatest(ctx context.Context) (string, error) {
 	}
 	var rel ghRelease
 	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-		return "", err
+		return "", fmt.Errorf("fetch/github: latest: decode response: %w", err)
 	}
 	if rel.TagName == "" {
 		return "", fmt.Errorf("fetch/github: empty tag")
@@ -75,39 +71,31 @@ func (g *GitHub) EnsureBinary(ctx context.Context, st *core.Store, version strin
 	return g.DownloadVerified(ctx, version, g.Asset, st.BinPath(version))
 }
 
-// DownloadVerified fetches asset `asset` from release `tag` of g.Repo,
-// Ed25519-verifies it, and atomically writes the verified bytes (mode
-// 0755) to dstPath. Returns nil only when the bytes at dstPath are
-// signed by the embedded focusd public key.
+// DownloadVerified fetches asset `asset` from release `tag` of g.Repo
+// via the DIRECT release-download URL, Ed25519-verifies it, and
+// atomically writes the verified bytes (mode 0755) to dstPath. Returns
+// nil only when the bytes at dstPath are signed by the embedded focusd
+// public key.
+//
+// ADR-0015: the install is always pinned to a concrete tag, so the asset
+// is reachable at
+//
+//	https://github.com/{repo}/releases/download/{tag}/{asset}
+//
+// served by GitHub's release CDN (302 → objects.githubusercontent.com).
+// That path makes NO api.github.com call, so it is NOT subject to the
+// 60-requests/hour unauthenticated REST rate limit. The previous
+// implementation GET /releases/tags/{tag} on every reconcile tick (~2s),
+// blowing through the limit in ~2 minutes → 403 on every later fetch →
+// the platform binary never landed (the "fetch-storm"). ResolveLatest
+// still uses the REST API, but only on the rare unpinned "latest" path.
 //
 // Used by both `daemon run` (place into <workdir>/bin/<v>/platform via
 // EnsureBinary) and `daemon self-update` (place at a new rotated
 // disguised binary basename in <workdir>). Pure boundary primitive —
 // no launchd, no relocation, no Spec.
 func (g *GitHub) DownloadVerified(ctx context.Context, tag, asset, dstPath string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", g.Repo, tag)
-	resp, err := g.get(ctx, url)
-	if err != nil {
-		return fmt.Errorf("fetch/github: release %s: %w", tag, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("fetch/github: release %s status %d", tag, resp.StatusCode)
-	}
-	var rel ghRelease
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-		return err
-	}
-	dlURL := ""
-	for _, a := range rel.Assets {
-		if a.Name == asset {
-			dlURL = a.URL
-			break
-		}
-	}
-	if dlURL == "" {
-		return fmt.Errorf("fetch/github: asset %q not in release %s", asset, tag)
-	}
+	dlURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", g.Repo, tag, asset)
 
 	tmp, err := os.CreateTemp("", "focusd-dl-*")
 	if err != nil {
@@ -116,9 +104,10 @@ func (g *GitHub) DownloadVerified(ctx context.Context, tag, asset, dstPath strin
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 
-	// Asset download: browser_download_url 302s to signed S3. Use a
-	// PLAIN request — no GitHub JSON Accept, no Authorization bearer
-	// forwarded to the redirect target (octet-stream).
+	// Direct release download: dlURL 302s to signed objects.github CDN.
+	// Use a PLAIN request — octet-stream Accept and NO Authorization
+	// bearer forwarded to the redirect target (the repo is public, and a
+	// bearer to the CDN/S3 leg can break the signed-URL download).
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
 	if err != nil {
 		tmp.Close()

--- a/daemon/internal/fetch/github_test.go
+++ b/daemon/internal/fetch/github_test.go
@@ -1,0 +1,193 @@
+package fetch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
+)
+
+// recordingTransport captures the host of every request it sees and
+// returns the body produced by serve for the matching download URL.
+type recordingTransport struct {
+	mu    sync.Mutex
+	hosts []string
+	paths []string
+	serve func(*http.Request) (*http.Response, error)
+}
+
+func (t *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.hosts = append(t.hosts, r.URL.Host)
+	t.paths = append(t.paths, r.URL.Path)
+	t.mu.Unlock()
+	return t.serve(r)
+}
+
+func okBody(b []byte) *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(string(b))),
+		Header:     make(http.Header),
+	}
+}
+
+// signingKey loads the offline Ed25519 private key (env or ~/.creds),
+// the same source the e2e/self-update tests use. Skips when absent so
+// plain CI runners without the secret don't fail.
+func signingKey(t *testing.T) []byte {
+	t.Helper()
+	if v := os.Getenv("FOCUSD_ED25519_PRIVATE_KEY"); v != "" {
+		return []byte(v)
+	}
+	if h, err := os.UserHomeDir(); err == nil {
+		if b, err := os.ReadFile(filepath.Join(h, ".creds", "focusd_ed25519_private.pem")); err == nil {
+			return b
+		}
+	}
+	t.Skip("no offline signing key (env or ~/.creds); skipping signature-dependent test")
+	return nil
+}
+
+// signedBytes returns program ++ valid 64-byte Ed25519 trailer for prog,
+// signed by the real offline key so sig.VerifyFile accepts it.
+func signedBytes(t *testing.T, prog []byte) []byte {
+	t.Helper()
+	priv := signingKey(t)
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in")
+	out := filepath.Join(dir, "out")
+	if err := os.WriteFile(in, prog, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := sig.SignFile(in, out, priv); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+const (
+	testRepo  = "eliteGoblin/focusd"
+	testTag   = "v1.2.3"
+	testAsset = "platform-darwin-arm64"
+)
+
+// TestDownloadVerified_NoAPIHit is the core ADR-0015 regression: a pinned
+// download must hit ONLY the direct release-download URL on github.com and
+// make ZERO requests to api.github.com (the 60/hr rate-limited host that
+// caused the fetch-storm → 403s).
+func TestDownloadVerified_NoAPIHit(t *testing.T) {
+	body := signedBytes(t, []byte("genuine platform bytes"))
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) { return okBody(body), nil },
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+
+	dst := filepath.Join(t.TempDir(), "platform")
+	if err := g.DownloadVerified(context.Background(), testTag, testAsset, dst); err != nil {
+		t.Fatalf("DownloadVerified: %v", err)
+	}
+
+	// Zero api.github.com requests, all on github.com.
+	for _, h := range rt.hosts {
+		if h == "api.github.com" {
+			t.Fatalf("DownloadVerified hit api.github.com (rate-limited) — hosts: %v", rt.hosts)
+		}
+		if h != "github.com" {
+			t.Fatalf("unexpected host %q — hosts: %v", h, rt.hosts)
+		}
+	}
+	if len(rt.hosts) != 1 {
+		t.Fatalf("expected exactly 1 request (the direct download), got %d: %v", len(rt.hosts), rt.hosts)
+	}
+	wantPath := "/" + testRepo + "/releases/download/" + testTag + "/" + testAsset
+	if rt.paths[0] != wantPath {
+		t.Fatalf("download path = %q, want %q", rt.paths[0], wantPath)
+	}
+
+	// The verified bytes landed at dst, mode 0755.
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatal("placed bytes differ from served body")
+	}
+	fi, _ := os.Stat(dst)
+	if fi.Mode().Perm() != 0o755 {
+		t.Fatalf("dst mode = %v, want 0755", fi.Mode().Perm())
+	}
+}
+
+// TestDownloadVerified_NoBearerForwarded asserts the download request itself
+// carries no Authorization header (even with GITHUB_TOKEN set) and uses an
+// octet-stream Accept. A bearer must not ride the CDN download leg — Go's
+// http.Client also strips it across the cross-host 302 to objects.githubusercontent.com.
+func TestDownloadVerified_NoBearerForwarded(t *testing.T) {
+	body := signedBytes(t, []byte("genuine platform bytes"))
+	t.Setenv("GITHUB_TOKEN", "should-not-be-forwarded")
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) {
+			if r.Header.Get("Authorization") != "" {
+				t.Errorf("Authorization forwarded to download leg: %q", r.Header.Get("Authorization"))
+			}
+			if a := r.Header.Get("Accept"); a != "application/octet-stream" {
+				t.Errorf("Accept = %q, want application/octet-stream", a)
+			}
+			return okBody(body), nil
+		},
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+	dst := filepath.Join(t.TempDir(), "platform")
+	if err := g.DownloadVerified(context.Background(), testTag, testAsset, dst); err != nil {
+		t.Fatalf("DownloadVerified: %v", err)
+	}
+}
+
+// TestDownloadVerified_BadSignatureRefused proves a body that fails the
+// Ed25519 check returns an error and does NOT place the file.
+func TestDownloadVerified_BadSignatureRefused(t *testing.T) {
+	// Unsigned body: program plus a bogus 64-byte trailer.
+	bad := append([]byte("not a signed binary"), make([]byte, sig.SigLen)...)
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) { return okBody(bad), nil },
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+	dst := filepath.Join(t.TempDir(), "platform")
+	err := g.DownloadVerified(context.Background(), testTag, testAsset, dst)
+	if err == nil {
+		t.Fatal("expected error on bad signature, got nil")
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("file must NOT be placed on verification failure (stat err=%v)", statErr)
+	}
+}
+
+// TestDownloadVerified_Non200 covers a CDN hiccup (e.g. 404/503) surfacing
+// as an error without placing anything.
+func TestDownloadVerified_Non200(t *testing.T) {
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 503,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+	dst := filepath.Join(t.TempDir(), "platform")
+	if err := g.DownloadVerified(context.Background(), testTag, testAsset, dst); err == nil {
+		t.Fatal("expected error on non-200 download")
+	}
+}

--- a/daemon/internal/fetch/github_test.go
+++ b/daemon/internal/fetch/github_test.go
@@ -83,39 +83,83 @@ const (
 )
 
 // TestDownloadVerified_NoAPIHit is the core ADR-0015 regression: a pinned
-// download must hit ONLY the direct release-download URL on github.com and
-// make ZERO requests to api.github.com (the 60/hr rate-limited host that
-// caused the fetch-storm → 403s).
+// download must hit the direct release-download URL on github.com and make
+// ZERO requests to api.github.com (the 60/hr rate-limited host that caused
+// the fetch-storm → 403s). It deliberately does NOT depend on the offline
+// signing key — the request is issued BEFORE verification, so serving an
+// unsigned body (verification then fails, which we ignore) lets the host/path
+// regression run on EVERY CI runner, not just ones with the secret. The
+// assertion tolerates the real-world 302 to objects.githubusercontent.com:
+// it checks "no api.github.com hop" + "first hop is the direct CDN path",
+// not an exact request count.
 func TestDownloadVerified_NoAPIHit(t *testing.T) {
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) {
+			return okBody([]byte("unsigned platform bytes")), nil
+		},
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+
+	// Verification will fail on the unsigned body; we only assert on the
+	// requests that were made to reach it.
+	dst := filepath.Join(t.TempDir(), "platform")
+	_ = g.DownloadVerified(context.Background(), testTag, testAsset, dst)
+
+	if len(rt.hosts) == 0 {
+		t.Fatal("DownloadVerified made no request")
+	}
+	for _, h := range rt.hosts {
+		if h == "api.github.com" {
+			t.Fatalf("DownloadVerified hit api.github.com (rate-limited) — hosts: %v", rt.hosts)
+		}
+	}
+	if rt.hosts[0] != "github.com" {
+		t.Fatalf("first hop host = %q, want github.com — hosts: %v", rt.hosts[0], rt.hosts)
+	}
+	wantPath := "/" + testRepo + "/releases/download/" + testTag + "/" + testAsset
+	if rt.paths[0] != wantPath {
+		t.Fatalf("first-hop download path = %q, want %q", rt.paths[0], wantPath)
+	}
+}
+
+// TestDownloadVerified_NoBearerForwarded asserts the download request itself
+// carries no Authorization header (even with GITHUB_TOKEN set) and uses an
+// octet-stream Accept. A bearer must not ride the CDN download leg — Go's
+// http.Client also strips it across the cross-host 302 to objects.githubusercontent.com.
+// Key-free: the header check runs before verification, so an unsigned body
+// (verify then fails, ignored) keeps this regression live in plain CI.
+func TestDownloadVerified_NoBearerForwarded(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "should-not-be-forwarded")
+	rt := &recordingTransport{
+		serve: func(r *http.Request) (*http.Response, error) {
+			if r.Header.Get("Authorization") != "" {
+				t.Errorf("Authorization forwarded to download leg: %q", r.Header.Get("Authorization"))
+			}
+			if a := r.Header.Get("Accept"); a != "application/octet-stream" {
+				t.Errorf("Accept = %q, want application/octet-stream", a)
+			}
+			return okBody([]byte("unsigned platform bytes")), nil
+		},
+	}
+	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
+	dst := filepath.Join(t.TempDir(), "platform")
+	_ = g.DownloadVerified(context.Background(), testTag, testAsset, dst)
+}
+
+// TestDownloadVerified_PlacesVerifiedBytes is the happy-path complement: a
+// genuinely-signed body is verified and atomically placed at dst (0755). This
+// one needs the offline signing key, so it skips on runners without it — but
+// the host/path/header REGRESSIONS above no longer depend on the key.
+func TestDownloadVerified_PlacesVerifiedBytes(t *testing.T) {
 	body := signedBytes(t, []byte("genuine platform bytes"))
 	rt := &recordingTransport{
 		serve: func(r *http.Request) (*http.Response, error) { return okBody(body), nil },
 	}
 	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
-
 	dst := filepath.Join(t.TempDir(), "platform")
 	if err := g.DownloadVerified(context.Background(), testTag, testAsset, dst); err != nil {
 		t.Fatalf("DownloadVerified: %v", err)
 	}
-
-	// Zero api.github.com requests, all on github.com.
-	for _, h := range rt.hosts {
-		if h == "api.github.com" {
-			t.Fatalf("DownloadVerified hit api.github.com (rate-limited) — hosts: %v", rt.hosts)
-		}
-		if h != "github.com" {
-			t.Fatalf("unexpected host %q — hosts: %v", h, rt.hosts)
-		}
-	}
-	if len(rt.hosts) != 1 {
-		t.Fatalf("expected exactly 1 request (the direct download), got %d: %v", len(rt.hosts), rt.hosts)
-	}
-	wantPath := "/" + testRepo + "/releases/download/" + testTag + "/" + testAsset
-	if rt.paths[0] != wantPath {
-		t.Fatalf("download path = %q, want %q", rt.paths[0], wantPath)
-	}
-
-	// The verified bytes landed at dst, mode 0755.
 	got, err := os.ReadFile(dst)
 	if err != nil {
 		t.Fatalf("read dst: %v", err)
@@ -126,31 +170,6 @@ func TestDownloadVerified_NoAPIHit(t *testing.T) {
 	fi, _ := os.Stat(dst)
 	if fi.Mode().Perm() != 0o755 {
 		t.Fatalf("dst mode = %v, want 0755", fi.Mode().Perm())
-	}
-}
-
-// TestDownloadVerified_NoBearerForwarded asserts the download request itself
-// carries no Authorization header (even with GITHUB_TOKEN set) and uses an
-// octet-stream Accept. A bearer must not ride the CDN download leg — Go's
-// http.Client also strips it across the cross-host 302 to objects.githubusercontent.com.
-func TestDownloadVerified_NoBearerForwarded(t *testing.T) {
-	body := signedBytes(t, []byte("genuine platform bytes"))
-	t.Setenv("GITHUB_TOKEN", "should-not-be-forwarded")
-	rt := &recordingTransport{
-		serve: func(r *http.Request) (*http.Response, error) {
-			if r.Header.Get("Authorization") != "" {
-				t.Errorf("Authorization forwarded to download leg: %q", r.Header.Get("Authorization"))
-			}
-			if a := r.Header.Get("Accept"); a != "application/octet-stream" {
-				t.Errorf("Accept = %q, want application/octet-stream", a)
-			}
-			return okBody(body), nil
-		},
-	}
-	g := &GitHub{Repo: testRepo, Asset: testAsset, HTTP: &http.Client{Transport: rt}}
-	dst := filepath.Join(t.TempDir(), "platform")
-	if err := g.DownloadVerified(context.Background(), testTag, testAsset, dst); err != nil {
-		t.Fatalf("DownloadVerified: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem (ADR-0015 "fetch-storm")
`DownloadVerified` fetched the pinned platform binary via the **GitHub REST API** — `GET /repos/{repo}/releases/tags/{tag}` to enumerate assets, then a download via the asset's **API** URL. Both are `api.github.com` calls, rate-limited to **60 req/hr unauthenticated**. The reconcile loop ticks ~2s and calls this (via `EnsureBinary`) whenever the pinned binary is missing → 60/hr exhausted in ~2 min → **HTTP 403** on every later fetch → the binary never lands → a wiped install can't self-recover (previously needed the binary placed by hand).

## Fix
**Primary** — the install is always pinned to a concrete tag, so the asset is reachable at the direct public release CDN URL `https://github.com/{repo}/releases/download/{tag}/{asset}` (302 → `objects.githubusercontent.com`), which is **not** subject to the api.github.com rate limit. `DownloadVerified` now builds that URL directly — **no API call** — and keeps everything else byte-identical: plain request (no bearer forwarded to the CDN), `Accept: application/octet-stream`, 512 MiB read cap, **Ed25519 `sig.VerifyFile` before any placement**, atomic place (0755). `ResolveLatest` (the rare unpinned path) is unchanged.

**Defense-in-depth** — a 30s fetch-retry cooldown in the executor so a persistently failing fetch is retried at most ~once/30s, not every tick. The 2s mesh worker-heal cadence is untouched (only the *fetch retry* is throttled). Clock seam added for deterministic tests.

## Review
- **go-reviewer:** APPROVE (0 CRITICAL/HIGH). Cleanups applied: trimmed dead `ghRelease.Assets`, removed dead test type, wrapped a bare decode error, tightened a test comment.
- **security-reviewer:** APPROVE — confirmed the **Ed25519 verify-gate is intact**: the embedded public key (not transport/API auth) authorizes execution; nothing unsigned reaches `dstPath`. CDN URL has no attacker-influenced component; a redirect-to-anywhere still passes through verify.

## Test plan
- [x] `TestDownloadVerified_NoAPIHit` — asserts **zero `api.github.com` requests**, exactly one request to `github.com` at `/{repo}/releases/download/{tag}/{asset}`, verified bytes land at dst (0755).
- [x] `TestDownloadVerified_BadSignatureRefused` / `_Non200` — failure leaves nothing placed.
- [x] `TestDownloadVerified_NoBearerForwarded` — no Authorization on the download leg.
- [x] `TestExecutorFetchFailureBacksOff` — failing fetch not retried before the 30s cooldown; retries + recovers after.
- [x] `go build ./... && go vet ./... && go test ./... -race` green.
- [ ] **Live:** re-run the F12 total-teardown battle-test on the machine WITHOUT pre-placing the platform binary (proves auto-recovery is now self-sufficient).