### PR TITLE
fix(daemon): derive platform asset name — restore self-heal (ADR-0017)

### DIFF
--- a/daemon/cmd/daemon/asset_derive_test.go
+++ b/daemon/cmd/daemon/asset_derive_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestPlatformAssetDerived locks the deterministic name: releases are
+// published as platform-{GOOS}-{GOARCH}, so the daemon must derive exactly
+// that — never an operator-supplied value.
+func TestPlatformAssetDerived(t *testing.T) {
+	want := "platform-" + runtime.GOOS + "-" + runtime.GOARCH
+	if got := platformAsset(); got != want {
+		t.Fatalf("platformAsset() = %q, want %q", got, want)
+	}
+}
+
+// TestParseDerivesAssetAndKeepsLaterArgs is the self-heal regression guard.
+// An already-baked plist argv carries a stale/WRONG --asset (the old bug
+// baked the daemon asset name as the platform asset → 404 → no recovery).
+// parse() must (a) IGNORE that baked value and derive the correct platform
+// asset, and (b) still parse the args that FOLLOW --asset (--roster/--r/
+// --mesh) — fully removing the flag would make flag.Parse choke on the
+// unknown flag and silently drop the rest, breaking an existing install.
+func TestParseDerivesAssetAndKeepsLaterArgs(t *testing.T) {
+	o := parse("run", []string{
+		"--asset", "daemon-darwin-arm64", // WRONG (daemon asset) — must be ignored
+		"--roster", "a.x,b.y,c.z",
+		"--r", "b",
+		"--mesh",
+	})
+	if o.asset != platformAsset() {
+		t.Fatalf("asset = %q, want derived %q (baked --asset must be ignored)", o.asset, platformAsset())
+	}
+	if len(o.roster) != 3 || o.roster[0] != "a.x" || o.roster[2] != "c.z" {
+		t.Fatalf("roster not parsed — args after --asset were dropped: %v", o.roster)
+	}
+	if o.role != "b" {
+		t.Fatalf("role = %q, want b — args after --asset were dropped", o.role)
+	}
+	if !o.mesh {
+		t.Fatal("--mesh not parsed — args after --asset were dropped")
+	}
+}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -147,7 +147,13 @@ func parse(name string, args []string) opts {
 	// values, so a 2s StartInterval there would be futile).
 	iv := fs.Duration("interval", workerHealInterval, "worker reconcile interval (fast in-process self-heal)")
 	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo for releases")
-	as := fs.String("asset", "", "release asset filename (per os/arch)")
+	// --asset is accepted ONLY for backward-compatibility with already-baked
+	// plists (their argv still carries it); its value is IGNORED. The platform
+	// asset is DERIVED (platformAsset) so a stale/wrong baked value — the old
+	// self-heal bug — can never break the fetch again. Keeping the flag defined
+	// also stops flag.Parse from choking on it and dropping later args
+	// (--roster/--mesh/--r) on an existing install's restart.
+	_ = fs.String("asset", "", "(deprecated, ignored) platform asset is derived from os/arch")
 	rd := fs.String("release-dir", "", "use a local fake release dir instead of GitHub")
 	hd := fs.Duration("healthy", 5*time.Second, "alive longer than this ⇒ promote good")
 	ud := fs.Duration("unhealthy", 3*time.Second, "exit sooner than this ⇒ crashed")
@@ -160,7 +166,7 @@ func parse(name string, args []string) opts {
 	// and can rebuild every sibling plist (FEATURE 10 / ADR-0014).
 	rs := fs.String("roster", "", "comma-joined 3-label mesh roster (set by the installer)")
 	_ = fs.Parse(args)
-	return opts{*wd, *iv, *gh, *as, *rd, *hd, *ud, *rl, *tm == "true", *mesh, splitRoster(*rs)}
+	return opts{*wd, *iv, *gh, platformAsset(), *rd, *hd, *ud, *rl, *tm == "true", *mesh, splitRoster(*rs)}
 }
 
 // workerHealInterval is the fast in-process worker reconcile cadence
@@ -169,6 +175,17 @@ func parse(name string, args []string) opts {
 // a person needs for the next one-at-a-time removal. The ensurer's
 // launchd StartInterval stays the slower osadapter.EnsureBackstopInterval.
 const workerHealInterval = 2 * time.Second
+
+// platformAsset is the protection-engine release asset name for THIS
+// daemon's OS/arch. Releases are named platform-{GOOS}-{GOARCH}, so the
+// name is FULLY DETERMINED — it is DERIVED, never an operator knob.
+// A free-form asset flag was a self-heal footgun: a wrong/empty value
+// (the daemon's own asset name, or "") silently 404'd the platform fetch,
+// so the engine binary could never be re-fetched and had to be hand-placed
+// — defeating the daemon's whole self-recovery purpose. KISS: derive,
+// don't configure, so every rebuild path (install, self-update, watchdog)
+// is correct by construction.
+func platformAsset() string { return "platform-" + runtime.GOOS + "-" + runtime.GOARCH }
 
 // splitRoster parses the comma-joined --roster flag into the label set.
 // Empty → nil (the dev/test fallback in Spec.Label takes over).
@@ -293,7 +310,6 @@ func doUpdate(args []string) int {
 	// target the operator chose.
 	wd := fs.String("workdir", "", "explicit daemon work directory (default: discover the running install)")
 	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo (for `update` with no version arg)")
-	as := fs.String("asset", "", "release asset filename")
 	_ = fs.Parse(args)
 	explicit := fs.Arg(0) // optional positional version, e.g. v1.2.3
 
@@ -311,7 +327,7 @@ func doUpdate(args []string) int {
 		return 1
 	}
 
-	o := opts{workdir: workdir, github: *gh, asset: *as}
+	o := opts{workdir: workdir, github: *gh, asset: platformAsset()}
 	_, log := build(o)
 
 	st := &core.Store{Dir: o.workdir}
@@ -404,7 +420,6 @@ func doInstall(args []string) int {
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	wd := fs.String("workdir", defaultWorkdir(), "daemon work directory")
 	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo")
-	as := fs.String("asset", "", "release asset filename")
 	desired := fs.String("v", "",
 		"REQUIRED desired platform version (e.g. v0.9.0) — the daemon does NOT auto-resolve from GitHub")
 	wantTest := registerTestMode(fs) // --test-mode only under -tags e2e
@@ -448,7 +463,7 @@ func doInstall(args []string) int {
 	}
 	spec := osadapter.Spec{
 		Mode: m, SelfPath: self, Workdir: *wd,
-		Github: *gh, Asset: *as,
+		Github: *gh, Asset: platformAsset(),
 		// FEATURE 10 / ADR-0014: the worker heal cadence is a FIXED ~2s
 		// security constant (it closes the manual-removal whack-a-mole), baked
 		// into the worker plists — NOT an operator knob (a stale --interval

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -146,7 +146,7 @@ func parse(name string, args []string) opts {
 	// StartInterval (still ~10s — launchd floors small StartInterval
 	// values, so a 2s StartInterval there would be futile).
 	iv := fs.Duration("interval", workerHealInterval, "worker reconcile interval (fast in-process self-heal)")
-	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo for releases")
+	gh := fs.String("github", defaultGithubRepo, "owner/repo for releases")
 	// --asset is accepted ONLY for backward-compatibility with already-baked
 	// plists (their argv still carries it); its value is IGNORED. The platform
 	// asset is DERIVED (platformAsset) so a stale/wrong baked value — the old
@@ -186,6 +186,12 @@ const workerHealInterval = 2 * time.Second
 // don't configure, so every rebuild path (install, self-update, watchdog)
 // is correct by construction.
 func platformAsset() string { return "platform-" + runtime.GOOS + "-" + runtime.GOARCH }
+
+// defaultGithubRepo is the fixed product release repo. Single source of
+// truth so the flag defaults and the watchdog's local rebuild (which has
+// no operator argv to read) can never drift to an empty/different value —
+// an empty repo would malform the fetch URL → 404 → no self-heal.
+const defaultGithubRepo = "eliteGoblin/focusd"
 
 // splitRoster parses the comma-joined --roster flag into the label set.
 // Empty → nil (the dev/test fallback in Spec.Label takes over).
@@ -309,7 +315,7 @@ func doUpdate(args []string) int {
 	// "discover the running install"; a non-empty value is an explicit
 	// target the operator chose.
 	wd := fs.String("workdir", "", "explicit daemon work directory (default: discover the running install)")
-	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo (for `update` with no version arg)")
+	gh := fs.String("github", defaultGithubRepo, "owner/repo (for `update` with no version arg)")
 	_ = fs.Parse(args)
 	explicit := fs.Arg(0) // optional positional version, e.g. v1.2.3
 
@@ -419,7 +425,7 @@ func doInstall(args []string) int {
 	}
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	wd := fs.String("workdir", defaultWorkdir(), "daemon work directory")
-	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo")
+	gh := fs.String("github", defaultGithubRepo, "owner/repo")
 	desired := fs.String("v", "",
 		"REQUIRED desired platform version (e.g. v0.9.0) — the daemon does NOT auto-resolve from GitHub")
 	wantTest := registerTestMode(fs) // --test-mode only under -tags e2e

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -67,7 +67,7 @@ func doSelfUpdate(args []string) int {
 func parseSelfUpdate(args []string) (selfUpdateOpts, int) {
 	fs := flag.NewFlagSet("self-update", flag.ContinueOnError)
 	wd := fs.String("workdir", "", "override discovered workdir")
-	gh := fs.String("github", "eliteGoblin/focusd", "owner/repo for releases")
+	gh := fs.String("github", defaultGithubRepo, "owner/repo for releases")
 	ap := fs.String("asset-pattern", "daemon-darwin-{arch}",
 		"asset name template — {arch} substituted with runtime.GOARCH")
 	rd := fs.String("release-dir", "", "use a local fake release dir instead of GitHub (testing)")

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -212,7 +212,11 @@ func runSelfUpdate(o selfUpdateOpts) int {
 		SelfPath: newPath,
 		Workdir:  workdir,
 		Github:   o.github,
-		Asset:    asset,
+		// The PLATFORM asset is derived (platform-{os}-{arch}), NOT the
+		// daemon asset `asset` used above to download the daemon binary.
+		// Baking the daemon asset here was the self-heal bug: the rebuilt
+		// mesh fetched a non-existent platform asset → 404 → no recovery.
+		Asset:    platformAsset(),
 		Interval: interval,
 		// Keep the ensurer's launchd StartInterval the slower backstop,
 		// decoupled from the fast worker --interval (FEATURE 10 / ADR-0014).

--- a/daemon/cmd/daemon/watchdog.go
+++ b/daemon/cmd/daemon/watchdog.go
@@ -94,9 +94,13 @@ func runWatchdog(
 	spec := osadapter.Spec{
 		Mode:     m,
 		SelfPath: self,
-		// Derived platform asset. This was EMPTY here — a latent 404 if the
-		// watchdog ever rebuilt the mesh (the run loop derives it too, so
-		// this is belt-and-suspenders, but keep the baked argv honest).
+		// Github + Asset must be set here too: the rebuilt plists bake BOTH
+		// into argv. Left empty, the worker would parse `--github ""` /
+		// `--asset ""` and the platform fetch URL would be malformed → 404,
+		// so a watchdog-rebuilt mesh could never re-fetch the engine (the
+		// exact self-heal class of bug ADR-0017 closes). Github is the fixed
+		// product repo; Asset is derived from os/arch.
+		Github:         defaultGithubRepo,
 		Asset:          platformAsset(),
 		Interval:       workerHealInterval,
 		EnsureInterval: osadapter.EnsureBackstopInterval,

--- a/daemon/cmd/daemon/watchdog.go
+++ b/daemon/cmd/daemon/watchdog.go
@@ -92,8 +92,12 @@ func runWatchdog(
 	// Mesh absent or incomplete → rebuild LOCALLY from this (copy) binary via
 	// the normal install path (fresh roster per FEATURE 10). No github fetch.
 	spec := osadapter.Spec{
-		Mode:           m,
-		SelfPath:       self,
+		Mode:     m,
+		SelfPath: self,
+		// Derived platform asset. This was EMPTY here — a latent 404 if the
+		// watchdog ever rebuilt the mesh (the run loop derives it too, so
+		// this is belt-and-suspenders, but keep the baked argv honest).
+		Asset:          platformAsset(),
 		Interval:       workerHealInterval,
 		EnsureInterval: osadapter.EnsureBackstopInterval,
 	}

--- a/requirements/REQUIREMENTS_REGISTER.md
+++ b/requirements/REQUIREMENTS_REGISTER.md
@@ -85,6 +85,28 @@ The two-faced nature of the user is the key insight. Most security designs assum
 
 ## 5. Cross-cutting design principles
 
+### Self-recovery is non-negotiable
+The whole system is designed to be reliable and self-healing: **every protection
+layer must recover without manual intervention after any single failure.** A
+status that reads "healthy" but secretly depends on a hand-placed or leftover
+artifact is a **latent failure, not health** — the moment that artifact is gone,
+protection is gone, with no green warning. "Recovered" must mean the system
+re-created what it needed *on its own* (re-fetched, re-installed, re-started),
+end-to-end. Therefore verification must exercise the **real failure-and-recover
+path**, not a surface-green check: tear the thing down for real and confirm it
+comes back by itself. (See §6 limitation 10 for the live lesson that motivated
+making this a named principle.)
+
+### KISS — streamline, don't be "too smart"
+KISS is a core philosophy, not a nicety. Prefer the **simplest correct**
+solution; avoid over-clever, over-configurable designs that make the product
+complex and create footguns. Concretely: **prefer deriving a deterministic value
+over exposing an operator-supplied knob.** Speculative flexibility that wasn't
+required is a defect surface, not a feature — every knob is one more thing that
+can be set wrong, drift between code paths, and fail silently. When a value can
+only ever be one correct thing, compute it once; don't let anyone configure it.
+(Captured as a decision in ADR-0017.)
+
 ### Friction, not cryptography
 None of the defenses are mathematically unbreakable. Every one is a delay or an inconvenience. The bet: an impulsive person will give up before paying the cost; a calm person who genuinely wants out has the 5-gated override.
 
@@ -141,6 +163,7 @@ Every commit message + every PR description includes an explicit "honest" or "ho
 7. **Customized settings don't pick up new shipped defaults.** When focusd ships a new default for a feature you've customized via an on-disk override, your override keeps your old value — focusd won't silently overwrite your choice, but it also won't merge in the new default. You must update the override to adopt new defaults. (Caught in practice: a release shipped the full Steam domain list, but an install whose override still held the old short list kept blocking only the short list until the override was refreshed.)
 8. **Single engine = shared fate.** If the one protection engine crashes, all protections pause for the few seconds it takes to auto-restart (the previous two-engine design failed independently). Accepted trade for simplicity — see ADR-0010.
 9. **Console-user assumption.** The step-down-to-user mechanism assumes one primary person at the keyboard; during login-window / fast-user-switch it correctly waits rather than mis-writing, and a shared/multi-user Mac is out of scope.
+10. **Latent self-heal gap: the protection engine couldn't actually re-fetch itself (in progress).** A serious flaw was found live: every rebuild path (first install, self-update, and the out-of-band watchdog) used the **wrong download identity for the protection-engine binary**, so the recovery download failed. It was masked for a long time because the binary had been placed by hand — so status read HEALTHY while auto-recovery was in fact broken (exactly the *latent failure* the self-recovery principle in §5 warns about). **Two root causes, both lessons:** (a) an over-configurable free-form input for a value that should always have been **derived** — directly the anti-pattern KISS / ADR-0017 now forbids; and (b) the same mistake **copied across every rebuild path**, so no single path was a safe fallback. **Fix (in progress):** derive the deterministic download identity once and remove the knob — every recovery path becomes correct by construction — and ship it via the in-place self-update so protection never drops. Tracked under §9 (this is the same load-bearing capability the open fetch-path follow-up depends on). Decision recorded in ADR-0017.
 
 ---
 
@@ -174,6 +197,7 @@ Platform releases ship bundled plugin binaries embedded via `//go:embed` (`platf
 - **(unfiled) Move the source repo to a path Claude (uid 502) cannot read**. The cheapest defense against Claude-as-threat specifically.
 - ~~**(unfiled) FEATURE 12 — out-of-band watchdog** is **defining** (ADR-0016 accepted)... Awaiting human gate before build.~~ **SHIPPED 2026-06-17 (PR #52).** Closes the total-atomic-teardown gap via a cron rail running a second copy of the daemon binary. Verified live (one-command install, redaction-safe status, total-teardown rebuilt in ~5s). The design questions raised here were resolved in DESIGN/build per ADR-0016.
 - **(unfiled, tracked) ADR-0015 fetch-storm bug still open.** Because of it, the platform v0.15.0 binary for the F12 deploy was **placed manually** rather than fetched. Fixing the fetch path so deploys don't need the manual pre-populate workaround is a tracked follow-up. **→ Recommended next priority (roadmap call 2026-06-17):** this is the only open item that breaks a *shipped, load-bearing* capability — the out-of-band watchdog (F12) can't actually self-recover the platform binary, so auto-recovery is not yet self-sufficient. Closing it before any new feature.
+- **(in progress) Wrong download identity for the protection-engine binary across all rebuild paths** — see §6 limitation 10 + ADR-0017. Every recovery path baked a wrong/empty download identity, so auto-recovery 404'd; masked because the binary had been hand-placed. Fix: derive the deterministic identity once, delete the knob, ship via in-place self-update. This is the **same self-recovery hole** the ADR-0015 fetch follow-up above is about — both must close before auto-recovery is genuinely self-sufficient.
 
 ---
 
@@ -215,4 +239,4 @@ Platform releases ship bundled plugin binaries embedded via `//go:embed` (`platf
 
 ---
 
-*Last updated: 2026-06-17 (release-review: FEATURE 12 shipped, PR #52). Maintainer: Frank Sun + Claude (joint).*
+*Last updated: 2026-06-17 (BA update: §5 +2 named principles [self-recovery, KISS]; §6 +limitation 10 [latent self-heal gap]; ADR-0017 derive-don't-configure). Maintainer: Frank Sun + Claude (joint).*

--- a/requirements/decisions/0017-derive-dont-configure-recovery-inputs.md
+++ b/requirements/decisions/0017-derive-dont-configure-recovery-inputs.md
@@ -1,0 +1,70 @@
+# ADR-0017 — Derive, don't configure: deterministic recovery inputs
+
+- **Status:** accepted (2026-06-17)
+- **Relates to:** §5 principles "Self-recovery is non-negotiable" + "KISS"; §6 limitation 10
+- **Decided by:** Frank (product owner), BA review
+
+## Context
+
+A serious self-heal flaw was found live. The system is supposed to recover every
+protection layer without manual intervention, but the protection engine could not
+actually re-fetch its own binary on recovery: every rebuild path (first install,
+self-update, and the out-of-band watchdog) used the **wrong download identity for
+the protection-engine binary**, so the recovery download failed.
+
+It stayed hidden for a long time because the binary had been **placed by hand**,
+so the health status read HEALTHY while auto-recovery was in fact broken — a
+latent failure, exactly the kind §5 warns against.
+
+Two things went wrong:
+1. The download identity was an **operator-supplied, free-form input** — a knob
+   for a value that can only ever be one correct thing.
+2. The same wrong handling was **copied across every rebuild path**, so there was
+   no correct fallback path to mask the others.
+
+## Decision
+
+**For any input to a recovery path that is fully determined by known facts,
+derive it once — do not expose it as a configurable knob.**
+
+Concretely for this case: derive the protection-engine binary's download identity
+deterministically in one place, remove the free-form knob entirely, and have every
+recovery path use that single derived value. With no knob to set wrong and one
+shared derivation, every rebuild path is **correct by construction**. Ship the fix
+via the in-place self-update so protection never drops during the change.
+
+This generalizes the KISS principle: speculative configurability is a defect
+surface. When a value has exactly one correct form, the product computes it; it is
+not something an operator (or a future code path) can get wrong.
+
+## Alternatives considered
+
+- **Keep the knob, fix each path's value.** Rejected: it fixes today's symptom but
+  leaves the footgun — the next path added can set it wrong again, and the same
+  bug can re-appear independently in each path. The knob itself is the defect.
+- **Validate the configured value at startup.** Rejected as not-KISS: a guard
+  around a knob that should not exist. Deriving the value removes the failure mode
+  instead of detecting it after the fact.
+
+## Consequences
+
+- One source of truth for the download identity; every recovery path is correct by
+  construction, and a whole class of "wrong identity" failures disappears.
+- Less configurability — which is the point: nothing to mis-set.
+- Reinforces the verification discipline in §5: recovery is now testable by
+  tearing protection down for real and confirming it rebuilds itself, rather than
+  trusting a green status that a hand-placed artifact could be propping up.
+
+## Honest limitation
+
+This ADR is a principle plus one applied fix; the fix itself is **in progress**
+at time of writing. Deriving this one identity does not retroactively prove every
+*other* recovery input is derived rather than configured — those should be reviewed
+against this principle. And derivation only removes the *configuration* failure
+mode; the recovery path still depends on the source it fetches from being
+reachable (see the still-open fetch-path follow-up, §9).
+
+## References
+- Self-recovery + KISS principles: `../REQUIREMENTS_REGISTER.md` Section 5
+- The live lesson: `../REQUIREMENTS_REGISTER.md` Section 6, limitation 10
+- Related open recovery follow-up: `../REQUIREMENTS_REGISTER.md` Section 9

--- a/requirements/e2e-verification.md
+++ b/requirements/e2e-verification.md
@@ -1,0 +1,70 @@
+# Vital-feature verification contract
+
+> **Self-recovery is non-negotiable** (see register §5). "Verified" means the
+> **real failure → recover path was exercised and the system healed itself** —
+> never a surface "it's up" check, never a state propped up by a hand-placed
+> artifact. Every release MUST exercise the features below and the verify
+> report MUST state, per feature, **VERIFIED** or **NOT VERIFIED** with the
+> actual evidence. No guessing. If it wasn't exercised, it is NOT verified —
+> say so and hand it to the human to test.
+
+## Why this doc exists
+A "healthy" status masked a broken self-heal for a long time: the protection
+engine binary had been hand-placed, so the daemon *looked* healthy while it
+could not actually re-fetch the engine on its own (ADR-0017). The lesson:
+**verify the recovery, not the steady state.** This contract lists the vital
+features and the failure each must self-heal from.
+
+## The vital features (must be verified every release)
+
+### V1 — Protection-engine self-heal
+The engine (and its plugins) must come back **without manual intervention**
+after it is taken down or its on-disk binary is removed.
+- **Exercise:** kill the engine process **and** delete its on-disk binary (so a
+  restart cannot reuse a deleted inode). Optionally wipe the work directory.
+- **Pass:** within the heal window the engine is running again **from a freshly
+  re-fetched binary** (fresh mtime / new pid), status HEALTHY — with no human
+  placing the binary.
+
+### V2 — Total-teardown recovery (out-of-band)
+A total atomic teardown (all mesh entries + all processes + the work directory,
+at once) must still recover.
+- **Exercise:** remove all mesh entries, kill all processes, wipe the workdir.
+- **Pass:** the out-of-band watchdog rebuilds the mesh and the engine is
+  re-fetched and running; status HEALTHY. (Recovery window is coarse — minutes —
+  by design.)
+
+### V3 — App removal (kill-steam)
+A blocklisted app that launches must be removed.
+- **Exercise:** install/launch Steam (e.g. `brew install --cask steam`, or open
+  `Steam.app`) and/or Dota 2.
+- **Pass:** the plugin removes the running process / on-disk app within its
+  schedule; confirm it is gone.
+
+### V4 — Claude-skill self-heal (skill-protector)
+Deleting the Claude refusal skill (or its rule / SessionStart hook) must
+auto-recover.
+- **Exercise:** delete `~/.claude/skills/focusd-protection/` (and/or the
+  always-on rule / the settings hook).
+- **Pass:** the plugin re-injects the files within its schedule; confirm they
+  are back and current.
+
+### V5 — Claude refusal stance
+Asking Claude to stop / disable / uninstall focusd must be **refused**; the
+5-gate override ritual is the only path.
+- **Exercise:** confirm the focusd-protection skill + always-on rule +
+  SessionStart hook are present and current; a disable request is refused.
+- **Pass:** refusal holds; no bypass without all override gates.
+
+## Per-release status table (fill HONESTLY)
+| # | Feature | Verified? | Evidence (what was actually exercised) |
+|---|---------|-----------|----------------------------------------|
+| V1 | Engine self-heal | — | |
+| V2 | Total-teardown recovery | — | |
+| V3 | App removal (kill-steam) | — | |
+| V4 | Skill self-heal | — | |
+| V5 | Claude refusal stance | — | |
+
+> Anything left `—` / NOT VERIFIED must be called out at the top of the verify
+> report and handed to the human to test. A green build is not a verified
+> feature.


### PR DESCRIPTION
## The flaw (serious — self-heal was silently broken)
The daemon's whole purpose is reliable self-recovery, but the protection-engine binary could **never** be auto-fetched. Every rebuild path baked the **wrong download asset name** into the worker argv:
- **self-update** baked the *daemon* asset name (`daemon-darwin-{arch}`) as the *platform* asset;
- the **out-of-band watchdog** baked an **empty** asset;
- and `install` exposed a free-form `--asset` flag that let it be fat-fingered (it was — the live mesh carried `daemon-darwin-arm64`).

All three → the fetch URL pointed at a non-existent asset → **404** → the engine binary had to be **hand-placed**, which masked the break as a green status. Confirmed live: wrong name → 404, correct `platform-darwin-arm64` → 200.

## Fix (KISS — ADR-0017 "derive-don't-configure")
The asset name is **fully determined** by os/arch (releases are `platform-{GOOS}-{GOARCH}`), so there is no reason to configure it. **Derive it** (`platformAsset()`) at every bake site (install, self-update, watchdog) and at the fetch site. The run loop still **accepts** `--asset` for backward-compat with already-baked plists (so `flag.Parse` doesn't choke and drop later `--roster`/`--mesh`/`--r`) but **ignores** its value. Existing installs self-correct the moment they run the new binary — no plist surgery, no uninstall ritual.

## Tests
- `TestPlatformAssetDerived` — derivation is exactly `platform-{GOOS}-{GOARCH}`.
- `TestParseDerivesAssetAndKeepsLaterArgs` — a **wrong baked `--asset`** is ignored AND the args that follow it still parse (the flag-removal footgun guard).
- Full daemon suite incl. e2e: green (`go build/vet/test -race`).

## Docs
- New **ADR-0017** "derive-don't-configure for deterministic recovery inputs".
- Register §5 records two now-explicit principles: **self-recovery is non-negotiable** and **KISS / derive-don't-configure**; §6 logs the masked self-heal defect.

## Deploy + verify plan (after merge)
Ship `daemon-v0.5.3`, self-update the live mesh (atomic, no protection drop), then **honestly battle-test the vital features**: platform self-heal (wipe/down → auto re-fetch via CDN → recover), kill-steam (`brew install steam` → removed), skill-protector (delete the Claude skill → auto re-injected), and the Claude refusal stance. Verify report will state exactly what's verified vs not.