### PR TITLE
fix(platformsvc): capture engine logs to platform.log (observability gap)

### DIFF
--- a/daemon/internal/platformsvc/process.go
+++ b/daemon/internal/platformsvc/process.go
@@ -4,6 +4,7 @@
 package platformsvc
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,7 +26,6 @@ type ProcSvc struct {
 	exited    bool
 	exitedAt  time.Time
 	exitCh    chan struct{} // closed by the SINGLE waiter when cmd exits
-	logf      *os.File      // captures the child's stdout+stderr; closed by the waiter
 }
 
 // PlatformLogName is the engine log file under the workdir. The engine's
@@ -64,7 +64,12 @@ func (p *ProcSvc) Start(binPath, v string) error {
 	// workdir is writable (it already holds state.db) — always succeeds.
 	logf, lerr := os.OpenFile(filepath.Join(p.Workdir, PlatformLogName),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if lerr == nil {
+	if lerr != nil {
+		// Observability must not fail SILENTLY. Record why on the daemon's
+		// own stderr (captured to daemon.log) before degrading to discarded
+		// engine output — so a missing platform.log is itself explained.
+		fmt.Fprintf(os.Stderr, "platformsvc: cannot open %s (engine output will be discarded): %v\n", PlatformLogName, lerr)
+	} else {
 		c.Stdout = logf
 		c.Stderr = logf
 	}
@@ -81,7 +86,6 @@ func (p *ProcSvc) Start(binPath, v string) error {
 	p.exited = false
 	p.exitedAt = time.Time{}
 	p.exitCh = exitCh
-	p.logf = logf
 
 	// The ONLY waiter for this child. Whoever needs to know it exited
 	// observes exitCh — no second Wait() (double-reap race).

--- a/daemon/internal/platformsvc/process.go
+++ b/daemon/internal/platformsvc/process.go
@@ -4,7 +4,9 @@
 package platformsvc
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -23,7 +25,16 @@ type ProcSvc struct {
 	exited    bool
 	exitedAt  time.Time
 	exitCh    chan struct{} // closed by the SINGLE waiter when cmd exits
+	logf      *os.File      // captures the child's stdout+stderr; closed by the waiter
 }
+
+// PlatformLogName is the engine log file under the workdir. The engine's
+// stdout+stderr (its slog stream, plugin job output, errors/warnings) are
+// captured here so the engine is OBSERVABLE. Previously the child's stdio
+// was left nil → connected to /dev/null, which silently discarded every
+// engine/plugin log line and hid real failures (the silent-failure trap the
+// observability principle forbids).
+const PlatformLogName = "platform.log"
 
 // New builds a ProcSvc with sane default windows.
 func New(workdir string) *ProcSvc {
@@ -46,7 +57,21 @@ func (p *ProcSvc) Start(binPath, v string) error {
 	defer p.mu.Unlock()
 
 	c := exec.Command(binPath, "--workdir", p.Workdir)
+	// Capture the engine's stdout+stderr to <workdir>/platform.log so the
+	// engine + plugins are observable. Best-effort: a log-open failure must
+	// NOT block protection from starting, so we degrade to the prior
+	// (discarded) behavior rather than refuse to run. The common path — the
+	// workdir is writable (it already holds state.db) — always succeeds.
+	logf, lerr := os.OpenFile(filepath.Join(p.Workdir, PlatformLogName),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if lerr == nil {
+		c.Stdout = logf
+		c.Stderr = logf
+	}
 	if err := c.Start(); err != nil {
+		if logf != nil {
+			logf.Close()
+		}
 		return err
 	}
 	exitCh := make(chan struct{})
@@ -56,6 +81,7 @@ func (p *ProcSvc) Start(binPath, v string) error {
 	p.exited = false
 	p.exitedAt = time.Time{}
 	p.exitCh = exitCh
+	p.logf = logf
 
 	// The ONLY waiter for this child. Whoever needs to know it exited
 	// observes exitCh — no second Wait() (double-reap race).
@@ -67,6 +93,9 @@ func (p *ProcSvc) Start(binPath, v string) error {
 			p.exitedAt = time.Now()
 		}
 		p.mu.Unlock()
+		if logf != nil {
+			logf.Close() // release the engine-log fd when the child exits
+		}
 		close(exitCh)
 	}()
 	return nil

--- a/daemon/internal/platformsvc/process_test.go
+++ b/daemon/internal/platformsvc/process_test.go
@@ -1,0 +1,66 @@
+package platformsvc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStartCapturesEngineLogToFile is the observability guard: the engine's
+// stdout AND stderr must be captured to <workdir>/platform.log. Previously the
+// child's stdio was left nil → /dev/null, silently discarding every engine and
+// plugin log line (and hiding real failures). A fake engine writes to both
+// streams; both must show up in the log file.
+func TestStartCapturesEngineLogToFile(t *testing.T) {
+	wd := t.TempDir()
+	script := filepath.Join(wd, "fake-engine")
+	body := "#!/bin/sh\necho ENGINE_STDOUT_LINE\necho ENGINE_STDERR_LINE >&2\nsleep 0.3\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	p := New(wd)
+	if err := p.Start(script, "v1"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	select {
+	case <-p.exitCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("engine did not exit in time")
+	}
+
+	b, err := os.ReadFile(filepath.Join(wd, PlatformLogName))
+	if err != nil {
+		t.Fatalf("read %s: %v", PlatformLogName, err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "ENGINE_STDOUT_LINE") {
+		t.Errorf("engine stdout not captured to %s; got: %q", PlatformLogName, got)
+	}
+	if !strings.Contains(got, "ENGINE_STDERR_LINE") {
+		t.Errorf("engine stderr not captured to %s; got: %q", PlatformLogName, got)
+	}
+}
+
+// TestStartAppendsAcrossRestarts confirms a restart appends (doesn't truncate)
+// — log history across engine restarts must be preserved.
+func TestStartAppendsAcrossRestarts(t *testing.T) {
+	wd := t.TempDir()
+	script := filepath.Join(wd, "fake-engine")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho RUN_MARKER\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := New(wd)
+	for i := 0; i < 2; i++ {
+		if err := p.Start(script, "v1"); err != nil {
+			t.Fatalf("start %d: %v", i, err)
+		}
+		<-p.exitCh
+	}
+	b, _ := os.ReadFile(filepath.Join(wd, PlatformLogName))
+	if n := strings.Count(string(b), "RUN_MARKER"); n != 2 {
+		t.Errorf("expected 2 appended markers across restarts, got %d", n)
+	}
+}

--- a/daemon/internal/platformsvc/process_test.go
+++ b/daemon/internal/platformsvc/process_test.go
@@ -59,7 +59,10 @@ func TestStartAppendsAcrossRestarts(t *testing.T) {
 		}
 		<-p.exitCh
 	}
-	b, _ := os.ReadFile(filepath.Join(wd, PlatformLogName))
+	b, err := os.ReadFile(filepath.Join(wd, PlatformLogName))
+	if err != nil {
+		t.Fatalf("read %s: %v", PlatformLogName, err)
+	}
 	if n := strings.Count(string(b), "RUN_MARKER"); n != 2 {
 		t.Errorf("expected 2 appended markers across restarts, got %d", n)
 	}

--- a/daemon/internal/platformsvc/process_test.go
+++ b/daemon/internal/platformsvc/process_test.go
@@ -57,7 +57,11 @@ func TestStartAppendsAcrossRestarts(t *testing.T) {
 		if err := p.Start(script, "v1"); err != nil {
 			t.Fatalf("start %d: %v", i, err)
 		}
-		<-p.exitCh
+		select {
+		case <-p.exitCh:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("engine restart %d did not exit in time", i)
+		}
 	}
 	b, err := os.ReadFile(filepath.Join(wd, PlatformLogName))
 	if err != nil {


### PR DESCRIPTION
## The gap
The daemon launches the engine with `exec.Command(...)` and **never sets `Stdout`/`Stderr`** → Go connects them to **/dev/null**. So the engine's entire log stream — its slog output, every plugin job's output, errors and warnings — was **silently discarded**. A component logging to /dev/null hides failures; this is a real reason the ADR-0017 self-heal bug stayed invisible for so long (the engine had nowhere to report the failed fetch).

Found during **V7 white-box verification** (`requirements/e2e-verification.md`).

## Fix (KISS)
Capture the engine child's stdout+stderr to `<workdir>/platform.log` (append, 0644), so every component is **observable** — the observability principle now in register §5. Best-effort: a log-open failure degrades to the prior behavior rather than blocking protection from starting; the fd is closed by the single waiter when the child exits.

## Tests
- `TestStartCapturesEngineLogToFile` — engine **stdout AND stderr** both land in `platform.log`.
- `TestStartAppendsAcrossRestarts` — restarts append (history preserved), not truncate.
- `go build/vet/test -race` green.

## Deploy + verify
Ship `daemon-v0.5.4`, self-update, then re-verify V7: confirm `platform.log` fills with engine/plugin activity and has no unexpected ERROR/WARN.