### PR TITLE
feat(daemon): FEATURE 14 — minimize mesh argv leak (ADR-0018)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -160,13 +160,74 @@ func parse(name string, args []string) opts {
 	rl := fs.String("r", "a", "mesh role: a|b")
 	tm := fs.String("test-mode-flag", "false", "use test-mode launchd labels")
 	mesh := fs.Bool("mesh", false, "self-heal the launchd mesh (set only by the installer)")
-	// --roster carries the 3 independent mesh labels (comma-joined,
-	// AllRoles order) baked into every plist by the installer, so any
-	// survivor relaunched cold reconstructs Spec.Roster from its own argv
-	// and can rebuild every sibling plist (FEATURE 10 / ADR-0014).
-	rs := fs.String("roster", "", "comma-joined 3-label mesh roster (set by the installer)")
+	// --roster is still ACCEPTED for backward-compatibility with OLD plists
+	// (their argv still bakes the comma-joined 3-label roster). When present
+	// it WINS — an old plist on a new binary keeps working unchanged. New
+	// (FEATURE 14 / ADR-0018) plists omit it entirely: the roster lives only
+	// in the masked workdir file. Keeping the flag DEFINED also stops
+	// flag.Parse from choking on an old plist's --roster and dropping the
+	// trailing --mesh/--r that follow it.
+	rs := fs.String("roster", "", "(backward-compat) comma-joined 3-label mesh roster from old plists")
+	// Track whether the caller explicitly passed --workdir so a mesh role
+	// can prefer an explicit value over the os.Executable()-derived one.
+	wdSet := false
 	_ = fs.Parse(args)
-	return opts{*wd, *iv, *gh, platformAsset(), *rd, *hd, *ud, *rl, *tm == "true", *mesh, splitRoster(*rs)}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "workdir" {
+			wdSet = true
+		}
+	})
+
+	testMode := *tm == "true"
+	roster := splitRoster(*rs)
+	workdir := *wd
+
+	// FEATURE 14 / ADR-0018: a mesh role (a `run … --mesh` worker or the
+	// `ensure` subcommand) launched from a NEW minimized plist carries
+	// neither --workdir nor --roster. Recover both off the command line:
+	//   - workdir: explicit --workdir wins; else the parent dir of the
+	//     daemon binary (it is relocated INSIDE the workdir); else the
+	//     default. os.Executable() failure falls back to the default.
+	//   - roster: an explicit --roster (old plist) wins; else, for a non-test
+	//     mesh role, read it from the masked workdir file. A read error leaves
+	//     the roster nil (Spec.Label's dev fallback applies; never crash).
+	// CLI subcommands that run a binary OUTSIDE the workdir (update,
+	// self-update, status, watchdog, install) do NOT call parse(), so this
+	// derivation never touches their workdir logic.
+	if isMeshRole(name, *mesh) {
+		if !wdSet {
+			workdir = deriveMeshWorkdir()
+		}
+		if roster == nil && !testMode {
+			if labels, rerr := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); rerr == nil {
+				roster = labels
+			}
+		}
+	}
+
+	return opts{workdir, *iv, *gh, platformAsset(), *rd, *hd, *ud, *rl, testMode, *mesh, roster}
+}
+
+// isMeshRole reports whether a parsed invocation is a mesh member that
+// must self-recover workdir + roster off-argv (FEATURE 14 / ADR-0018): a
+// `run … --mesh` worker, or the `ensure` subcommand.
+func isMeshRole(name string, mesh bool) bool {
+	return name == "ensure" || mesh
+}
+
+// deriveMeshWorkdir resolves a mesh member's workdir from its own binary
+// path (the disguised binary lives inside the workdir, FEATURE 14 /
+// ADR-0018). Falls back to defaultWorkdir() when os.Executable() fails or
+// yields no usable parent — never empty.
+func deriveMeshWorkdir() string {
+	self, err := os.Executable()
+	if err != nil {
+		return defaultWorkdir()
+	}
+	if wd := osadapter.WorkdirFromBinary(self); wd != "" {
+		return wd
+	}
+	return defaultWorkdir()
 }
 
 // workerHealInterval is the fast in-process worker reconcile cadence

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -199,7 +199,12 @@ func parse(name string, args []string) opts {
 			workdir = deriveMeshWorkdir()
 		}
 		if roster == nil && !testMode {
-			if labels, rerr := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); rerr == nil {
+			// Require the EXACT mesh size: core.ReadRoster validates non-empty
+			// labels but not count, so a truncated/edited .roster could yield a
+			// short slice and let Spec.Label backfill missing positions with dev
+			// labels (corrupting mesh labels). A non-3 slice is treated as
+			// unreadable → roster stays nil (Spec.Label dev fallback). (Copilot.)
+			if labels, rerr := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); rerr == nil && len(labels) == len(osadapter.AllRoles) {
 				roster = labels
 			}
 		}

--- a/daemon/cmd/daemon/parse_mesh_test.go
+++ b/daemon/cmd/daemon/parse_mesh_test.go
@@ -99,6 +99,21 @@ func TestParseMeshMissingRosterFileLeavesNil(t *testing.T) {
 	}
 }
 
+func TestParseMeshShortRosterFileLeavesNil(t *testing.T) {
+	// A truncated/edited masked file with fewer than the 3 mesh labels must be
+	// treated as unreadable → roster stays nil (NOT a partial slice that would
+	// let Spec.Label backfill missing positions with dev labels). (Copilot.)
+	wd := t.TempDir()
+	if err := core.WriteRoster((&core.Store{Dir: wd}).RosterPath(),
+		[]string{"only.one.label"}); err != nil {
+		t.Fatal(err)
+	}
+	o := parse("run", []string{"--r", "a", "--mesh", "--workdir", wd})
+	if o.roster != nil {
+		t.Fatalf("short masked roster must be rejected (nil), got %v", o.roster)
+	}
+}
+
 func TestParseNonMeshDoesNotDeriveOrLoad(t *testing.T) {
 	// A plain `run` (no --mesh) is NOT a mesh role: it must keep the default
 	// workdir and must NOT read a masked roster file.

--- a/daemon/cmd/daemon/parse_mesh_test.go
+++ b/daemon/cmd/daemon/parse_mesh_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/core"
+)
+
+// FEATURE 14 / ADR-0018: a mesh role (a `run … --mesh` worker or the
+// `ensure` subcommand) launched from a NEW minimized plist carries neither
+// --workdir nor --roster. parse() must recover both off-argv: the workdir
+// from the daemon binary's parent dir, the roster from the masked workdir
+// file. These tests lock that derivation + the old-plist backward-compat.
+
+// execDir is the parent dir of the running test binary — what
+// deriveMeshWorkdir() resolves to (filepath.Dir(os.Executable())) when no
+// explicit --workdir is given.
+func execDir(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	return filepath.Dir(self)
+}
+
+func TestParseMeshDerivesWorkdirFromBinary(t *testing.T) {
+	// A worker mesh role (`run … --mesh`) with NO --workdir must derive the
+	// workdir from the binary's parent dir.
+	o := parse("run", []string{"--r", "a", "--mesh"})
+	if o.workdir != execDir(t) {
+		t.Fatalf("mesh workdir = %q, want derived %q", o.workdir, execDir(t))
+	}
+}
+
+func TestParseEnsureMeshDerivesWorkdir(t *testing.T) {
+	// The `ensure` subcommand is a mesh role even without --mesh.
+	o := parse("ensure", []string{})
+	if o.workdir != execDir(t) {
+		t.Fatalf("ensure workdir = %q, want derived %q", o.workdir, execDir(t))
+	}
+}
+
+func TestParseMeshExplicitWorkdirWins(t *testing.T) {
+	// An explicit --workdir (old plist, or operator) overrides derivation.
+	o := parse("run", []string{"--r", "a", "--mesh", "--workdir", "/explicit/wd"})
+	if o.workdir != "/explicit/wd" {
+		t.Fatalf("explicit --workdir not honored: got %q", o.workdir)
+	}
+}
+
+func TestParseMeshLoadsRosterFromMaskedFile(t *testing.T) {
+	// New minimized plist: no --roster on argv. parse() must read the roster
+	// from the masked file under the (explicit) workdir.
+	wd := t.TempDir()
+	want := []string{
+		"com.apple.metadata.helper.7f3a2c11ab",
+		"com.google.keystone.daemon.8c1f4e9d22",
+		"org.mozilla.updater.agent.0a1b2c3d4e",
+	}
+	if err := core.WriteRoster((&core.Store{Dir: wd}).RosterPath(), want); err != nil {
+		t.Fatal(err)
+	}
+	o := parse("run", []string{"--r", "a", "--mesh", "--workdir", wd})
+	if len(o.roster) != 3 {
+		t.Fatalf("roster not loaded from masked file: %v", o.roster)
+	}
+	for i := range want {
+		if o.roster[i] != want[i] {
+			t.Fatalf("roster[%d] = %q, want %q", i, o.roster[i], want[i])
+		}
+	}
+}
+
+func TestParseMeshExplicitRosterWins(t *testing.T) {
+	// Old plist: --roster on argv. It must WIN even when a masked file is
+	// present (backward-compat: the old plist's baked roster is authoritative
+	// for that already-running mesh).
+	wd := t.TempDir()
+	if err := core.WriteRoster((&core.Store{Dir: wd}).RosterPath(),
+		[]string{"file.a", "file.b", "file.c"}); err != nil {
+		t.Fatal(err)
+	}
+	o := parse("run", []string{"--r", "a", "--mesh", "--workdir", wd, "--roster", "argv.a,argv.b,argv.c"})
+	if len(o.roster) != 3 || o.roster[0] != "argv.a" || o.roster[2] != "argv.c" {
+		t.Fatalf("explicit --roster must win over masked file: %v", o.roster)
+	}
+}
+
+func TestParseMeshMissingRosterFileLeavesNil(t *testing.T) {
+	// No --roster AND no masked file → roster stays nil (Spec.Label's dev
+	// fallback applies; parse must NOT crash).
+	wd := t.TempDir() // empty: no .roster file
+	o := parse("run", []string{"--r", "a", "--mesh", "--workdir", wd})
+	if o.roster != nil {
+		t.Fatalf("missing roster file must leave roster nil, got %v", o.roster)
+	}
+}
+
+func TestParseNonMeshDoesNotDeriveOrLoad(t *testing.T) {
+	// A plain `run` (no --mesh) is NOT a mesh role: it must keep the default
+	// workdir and must NOT read a masked roster file.
+	o := parse("run", []string{"--r", "a"})
+	if o.workdir != defaultWorkdir() {
+		t.Fatalf("non-mesh run must keep default workdir, got %q", o.workdir)
+	}
+	if o.roster != nil {
+		t.Fatalf("non-mesh run must not load a roster, got %v", o.roster)
+	}
+}

--- a/daemon/internal/osadapter/argv.go
+++ b/daemon/internal/osadapter/argv.go
@@ -67,12 +67,19 @@ func workdirFromArgv(argv []string) string {
 // INSIDE the workdir, so its parent directory IS the workdir — this lets a
 // minimized-argv mesh process find its workdir (and thus the masked roster)
 // without carrying --workdir on the command line. Returns "" for an empty
-// input so the caller can fall back to the default workdir.
+// input, a relative path, or a root-level binary so the caller can fall back
+// to the default workdir: filepath.Dir yields "." for a relative path and "/"
+// for a root path — both non-empty, which would otherwise short-circuit the
+// caller's fallback into a nonsensical workdir.
 func WorkdirFromBinary(self string) string {
 	if self == "" {
 		return ""
 	}
-	return filepath.Dir(self)
+	parent := filepath.Dir(self)
+	if !filepath.IsAbs(parent) || parent == "/" {
+		return ""
+	}
+	return parent
 }
 
 // intervalFromArgv pulls the reconcile interval following "--interval" out of

--- a/daemon/internal/osadapter/argv.go
+++ b/daemon/internal/osadapter/argv.go
@@ -1,6 +1,7 @@
 package osadapter
 
 import (
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -59,6 +60,19 @@ func workdirFromArgv(argv []string) string {
 		}
 	}
 	return ""
+}
+
+// WorkdirFromBinary recovers the mesh workdir from the daemon's own
+// binary path (FEATURE 14 / ADR-0018). The disguised binary is relocated
+// INSIDE the workdir, so its parent directory IS the workdir — this lets a
+// minimized-argv mesh process find its workdir (and thus the masked roster)
+// without carrying --workdir on the command line. Returns "" for an empty
+// input so the caller can fall back to the default workdir.
+func WorkdirFromBinary(self string) string {
+	if self == "" {
+		return ""
+	}
+	return filepath.Dir(self)
 }
 
 // intervalFromArgv pulls the reconcile interval following "--interval" out of

--- a/daemon/internal/osadapter/argv_test.go
+++ b/daemon/internal/osadapter/argv_test.go
@@ -1,0 +1,31 @@
+package osadapter
+
+import "testing"
+
+// TestWorkdirFromBinary covers the FEATURE 14 / ADR-0018 workdir recovery and
+// its edge guards: filepath.Dir yields "." for a relative path and "/" for a
+// root-level binary — both non-empty, which would otherwise short-circuit the
+// caller's fallback (deriveMeshWorkdir → defaultWorkdir) into a nonsensical
+// workdir. The guard collapses those to "" so the caller falls back cleanly.
+func TestWorkdirFromBinary(t *testing.T) {
+	cases := []struct {
+		name string
+		self string
+		want string
+	}{
+		{"absolute nested", "/foo/bar", "/foo"},
+		{"root-level binary", "/foo", ""},
+		{"root self", "/", ""},
+		{"relative path", "bar/baz", ""},
+		{"bare relative", "baz", ""},
+		{"dot relative", ".", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := WorkdirFromBinary(c.self); got != c.want {
+				t.Fatalf("WorkdirFromBinary(%q) = %q, want %q", c.self, got, c.want)
+			}
+		})
+	}
+}

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -171,12 +171,16 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 		return CurInstall{}, rerr
 	}
 	cur := CurInstall{Mode: m}
-	// lastArgv keeps the argv of the most recently matched plist so the
-	// post-loop workdir/roster recovery can fall back to OLD-plist argv
-	// flags (--workdir/--roster) when the masked file / Dir(bin) path
-	// isn't available. All three mesh plists carry the same values, so any
-	// one of them is a valid fallback source.
+	// lastArgv keeps the argv of the most recently matched plist; matchedArgvs
+	// keeps EVERY matched plist's argv. The post-loop workdir/roster recovery
+	// falls back to OLD-plist argv flags (--workdir/--roster) when the masked
+	// file / Dir(bin) path isn't available. In a HALF-MIGRATED install only
+	// SOME plists still carry --roster in argv (new minimized plists dropped
+	// it, FEATURE 14 / ADR-0018), so the roster fallback must scan ALL matched
+	// argvs — not just the last one, which may be a minimized plist with no
+	// --roster.
 	var lastArgv []string
+	var matchedArgvs [][]string
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
 			continue
@@ -208,6 +212,7 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 		cur.PlistPaths = append(cur.PlistPaths, pp)
 		cur.Labels = append(cur.Labels, label)
 		lastArgv = argv
+		matchedArgvs = append(matchedArgvs, argv)
 	}
 	// Recover the workdir + roster ONCE, after the binary path is known.
 	// FEATURE 14 / ADR-0018:
@@ -219,7 +224,7 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 	//     the --roster argv the installer baked.
 	if cur.BinaryPath != "" {
 		cur.Workdir = recoverWorkdir(cur.BinaryPath, lastArgv)
-		cur.Roster = recoverRoster(cur.Workdir, lastArgv)
+		cur.Roster = recoverRoster(cur.Workdir, matchedArgvs)
 	}
 	return cur, nil
 }
@@ -239,13 +244,25 @@ func recoverWorkdir(bin string, argv []string) string {
 // ADR-0018). The masked workdir file is the single source of truth; an OLD
 // plist's --roster argv is the fallback for installs predating the masked
 // file (or when the file is unreadable).
-func recoverRoster(workdir string, argv []string) []string {
+//
+// argvs is EVERY matched plist's argv: in a half-migrated install only the
+// OLD plist(s) still carry --roster (new minimized plists dropped it), and
+// scan order may make a minimized plist the last one, so we scan all of them
+// and take the first that yields a non-nil roster. Returns nil (the accepted
+// degraded mode) only when no plist carries a roster AND the masked file is
+// absent/unreadable.
+func recoverRoster(workdir string, argvs [][]string) []string {
 	if workdir != "" {
 		if labels, err := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); err == nil {
 			return labels
 		}
 	}
-	return rosterFromArgv(argv)
+	for _, argv := range argvs {
+		if labels := rosterFromArgv(argv); labels != nil {
+			return labels
+		}
+	}
+	return nil
 }
 
 // MeshStatus reports how many of the discovered mesh roles are currently

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eliteGoblin/focusd/daemon/internal/core"
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/sig"
 )
@@ -127,10 +128,10 @@ func modeFromTestFlag(testMode bool) mode.Mode {
 // the installer baked into every plist — NOT by a shared label stem.
 type CurInstall struct {
 	Mode       mode.Mode     // user | system (Test is not discovered this way)
-	Roster     []string      // the 3 independent mesh labels (AllRoles order), from --roster argv
-	Workdir    string        // recovered from the plist's --workdir argv
-	BinaryPath string        // the ProgramArguments[0] binary path
-	Interval   time.Duration // reconcile interval recovered from --interval argv (0 if absent)
+	Roster     []string      // the 3 independent mesh labels (AllRoles order), from the masked workdir file (FEATURE 14); --roster argv is the old-plist fallback
+	Workdir    string        // recovered as filepath.Dir(BinaryPath) (FEATURE 14); --workdir argv is the old-plist fallback
+	BinaryPath string        // the ProgramArguments[0] binary path — the FEATURE 14 correlation key
+	Interval   time.Duration // reconcile interval recovered from --interval argv (0 if absent / new plist)
 	PlistPaths []string      // up to 3, in scan order
 	Labels     []string      // up to 3, in scan order (aligned with PlistPaths)
 }
@@ -142,9 +143,10 @@ type CurInstall struct {
 // daemon_design.md §6). Returns (zero, nil) when no genuine install is
 // found, an error only for filesystem failure.
 //
-// All three mesh entries must agree on the same binary path and the
-// same --roster label set; otherwise the function returns whatever it
-// could parse and the caller decides.
+// All three mesh entries must agree on the same Ed25519-verified binary
+// path (FEATURE 14 / ADR-0018 correlation key); otherwise the function
+// returns whatever it could parse and the caller decides. The roster and
+// workdir are then recovered off-argv (masked file + Dir(bin)).
 // Verifier is the signature-check seam — production passes sig.VerifyFile
 // (the real Ed25519 check against the embedded public key); tests pass
 // a fake to avoid needing the offline private key in CI. Replaces the
@@ -169,6 +171,12 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 		return CurInstall{}, rerr
 	}
 	cur := CurInstall{Mode: m}
+	// lastArgv keeps the argv of the most recently matched plist so the
+	// post-loop workdir/roster recovery can fall back to OLD-plist argv
+	// flags (--workdir/--roster) when the masked file / Dir(bin) path
+	// isn't available. All three mesh plists carry the same values, so any
+	// one of them is a valid fallback source.
+	var lastArgv []string
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
 			continue
@@ -181,32 +189,63 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 		if ok, verr := verify(bin); verr != nil || !ok {
 			continue // not a genuine focusd binary → not ours
 		}
-		// Establish the install's binary path + roster from the FIRST
-		// matched plist; subsequent matches must agree on BOTH. The
-		// roster (--roster argv) is the FEATURE 10 correlation key that
-		// replaced the retired shared-base check: the three independent
-		// labels share no stem, but every plist carries the same roster.
+		// FEATURE 14 / ADR-0018: correlation key is the shared, Ed25519-
+		// verified BINARY PATH across the three plists — NOT the --roster
+		// argv (new minimized plists no longer carry it). argv[0] is shared
+		// across all three mesh members and is a strictly stronger key: it
+		// is the verified install identity. Establish it from the FIRST
+		// matched plist; subsequent matches must agree.
 		if cur.BinaryPath == "" {
 			cur.BinaryPath = bin
 		} else if cur.BinaryPath != bin {
 			continue // unrelated focusd install (different rotation)
 		}
-		roster := rosterFromArgv(argv)
-		if cur.Roster == nil {
-			cur.Roster = roster
-		} else if !sameRoster(cur.Roster, roster) {
-			continue // a different mesh's plist (different roster) → not ours
-		}
-		if cur.Workdir == "" {
-			cur.Workdir = workdirFromArgv(argv)
-		}
+		// Recover the interval from argv if an OLD plist still bakes it;
+		// new plists omit it (the worker cadence is a fixed constant).
 		if cur.Interval == 0 {
 			cur.Interval = intervalFromArgv(argv)
 		}
 		cur.PlistPaths = append(cur.PlistPaths, pp)
 		cur.Labels = append(cur.Labels, label)
+		lastArgv = argv
+	}
+	// Recover the workdir + roster ONCE, after the binary path is known.
+	// FEATURE 14 / ADR-0018:
+	//   - Workdir: the disguised binary is relocated INSIDE the workdir, so
+	//     filepath.Dir(BinaryPath) IS the workdir. workdirFromArgv is the
+	//     fallback only for an OLD plist whose binary path has no parent.
+	//   - Roster: read from the masked workdir file (the single source of
+	//     truth). For an OLD plist where the file isn't present, fall back to
+	//     the --roster argv the installer baked.
+	if cur.BinaryPath != "" {
+		cur.Workdir = recoverWorkdir(cur.BinaryPath, lastArgv)
+		cur.Roster = recoverRoster(cur.Workdir, lastArgv)
 	}
 	return cur, nil
+}
+
+// recoverWorkdir resolves a discovered install's workdir (FEATURE 14 /
+// ADR-0018). The disguised binary lives inside the workdir, so the binary's
+// parent directory IS the workdir; workdirFromArgv (an OLD plist's --workdir)
+// is only the fallback when Dir(bin) yields nothing usable.
+func recoverWorkdir(bin string, argv []string) string {
+	if wd := WorkdirFromBinary(bin); wd != "" {
+		return wd
+	}
+	return workdirFromArgv(argv)
+}
+
+// recoverRoster resolves a discovered install's roster (FEATURE 14 /
+// ADR-0018). The masked workdir file is the single source of truth; an OLD
+// plist's --roster argv is the fallback for installs predating the masked
+// file (or when the file is unreadable).
+func recoverRoster(workdir string, argv []string) []string {
+	if workdir != "" {
+		if labels, err := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); err == nil {
+			return labels
+		}
+	}
+	return rosterFromArgv(argv)
 }
 
 // MeshStatus reports how many of the discovered mesh roles are currently

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -253,7 +253,12 @@ func recoverWorkdir(bin string, argv []string) string {
 // absent/unreadable.
 func recoverRoster(workdir string, argvs [][]string) []string {
 	if workdir != "" {
-		if labels, err := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); err == nil {
+		// Require the EXACT mesh size. core.ReadRoster validates non-empty
+		// labels but not count; a truncated/edited .roster yielding a short
+		// slice would let Spec.Label backfill missing positions with dev
+		// labels and corrupt correlation/rebuild — treat that as unreadable
+		// and fall through to the argv fallback (Copilot review).
+		if labels, err := core.ReadRoster((&core.Store{Dir: workdir}).RosterPath()); err == nil && len(labels) == len(AllRoles) {
 			return labels
 		}
 	}

--- a/daemon/internal/osadapter/find_install_test.go
+++ b/daemon/internal/osadapter/find_install_test.go
@@ -327,6 +327,64 @@ func TestFindCurrentInstallMixedPlists(t *testing.T) {
 	}
 }
 
+// TestFindCurrentInstallMixedPlists_NoMaskedFile is the REAL transitional
+// state: a crash between self-update writing the new minimized plists and
+// writing the masked .roster file. Two plists are NEW (minimized argv, no
+// --roster), one is OLD (carries --roster in argv), and NO masked file exists
+// on disk. FindCurrentInstall must still correlate the install by the shared
+// verified binary path AND recover the roster by scanning ALL matched plists'
+// argv for a --roster fallback.
+//
+// CRITICAL fixture detail: the OLD (roster-carrying) plist is RoleA, which
+// sorts FIRST in ReadDir order; the rosterless RoleEnsure sorts LAST and so
+// becomes the loop's lastArgv. This is exactly the scan order that a naive
+// lastArgv-only recoverRoster would mishandle (last plist has no --roster →
+// nil roster). It pins the regression the all-argv scan fixes.
+func TestFindCurrentInstallMixedPlists_NoMaskedFile(t *testing.T) {
+	_, laDir, wd, binPath := meshFixture(t)
+	// Deliberately NO masked roster file → forces the argv fallback.
+	rosterCSV := strings.Join(migrationRoster, ",")
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: wd, Roster: migrationRoster}
+
+	// RoleA → OLD-style plist carrying --roster in argv. RoleA's dev-fallback
+	// label sorts FIRST, so this roster-bearing plist is NOT the last scanned.
+	oldA := filepath.Join(laDir, s.Label(RoleA)+".plist")
+	if err := os.WriteFile(oldA, []byte(oldStylePlist(s.Label(RoleA), binPath, wd, rosterCSV)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// RoleB + RoleEnsure → NEW minimized plists (no --roster in argv). RoleEnsure
+	// sorts LAST → it is the loop's lastArgv, and it carries NO roster.
+	newPlistB := filepath.Join(laDir, s.Label(RoleB)+".plist")
+	if err := os.WriteFile(newPlistB, []byte(Plist(s, RoleB)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newEnsure := filepath.Join(laDir, s.Label(RoleEnsure)+".plist")
+	if err := os.WriteFile(newEnsure, []byte(Plist(s, RoleEnsure)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
+	cur, err := FindCurrentInstall(mode.User, verify)
+	if err != nil {
+		t.Fatalf("FindCurrentInstall: %v", err)
+	}
+	if cur.BinaryPath != binPath {
+		t.Errorf("BinaryPath = %q, want %q", cur.BinaryPath, binPath)
+	}
+	if cur.Workdir != wd {
+		t.Errorf("Workdir = %q, want %q (Dir(bin))", cur.Workdir, wd)
+	}
+	// The whole point: roster recovered from the OLD plist's --roster argv,
+	// even though no masked file exists and a NEW (rosterless) plist may be
+	// the last one scanned.
+	if !sameRoster(cur.Roster, migrationRoster) {
+		t.Errorf("Roster = %v, want %v (from --roster argv fallback across all plists)", cur.Roster, migrationRoster)
+	}
+	if len(cur.PlistPaths) != 3 || len(cur.Labels) != 3 {
+		t.Fatalf("want 3 plists+labels, got %d/%d", len(cur.PlistPaths), len(cur.Labels))
+	}
+}
+
 func TestFindCurrentInstallNoneInstalled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/daemon/internal/osadapter/find_install_test.go
+++ b/daemon/internal/osadapter/find_install_test.go
@@ -10,38 +10,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eliteGoblin/focusd/daemon/internal/core"
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 )
 
-// TestParsePlistReturnsArgv checks that the rewritten parsePlist
-// extracts Label + ProgramArguments[0] AND the full argv (needed by
-// self-update to recover --workdir from an existing install).
+// TestParsePlistReturnsArgv checks that the parsePlist walker extracts
+// Label + ProgramArguments[0] AND the full argv. It uses a TEST-MODE spec
+// because, post-FEATURE 14, only the test-mode plist still bakes --workdir
+// into argv (prod argv is minimized to role+mesh); this keeps a meaningful
+// workdirFromArgv round-trip while exercising the "--flag value" pair walk.
 func TestParsePlistReturnsArgv(t *testing.T) {
 	dir := t.TempDir()
 	binPath := "/x/y/com.apple.metadata.helper.7f3a"
 	plistPath := filepath.Join(dir, "test.plist")
 
-	roster := []string{
-		"com.apple.metadata.helper.7f3a2c11ab",
-		"com.google.keystone.daemon.8c1f4e9d22",
-		"org.mozilla.updater.agent.0a1b2c3d4e",
-	}
 	s := Spec{
-		Mode:     mode.User,
+		Mode:     mode.Test,
 		SelfPath: binPath,
 		Workdir:  "/some/hidden/wd",
-		Github:   "o/r",
-		Asset:    "daemon-darwin-arm64",
 		Interval: 10 * time.Second,
-		Roster:   roster,
 	}
 	if err := os.WriteFile(plistPath, []byte(Plist(s, RoleA)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	wantLabel := s.Label(RoleA)
 	label, bin, argv := parsePlist(plistPath)
-	if label != roster[0] {
-		t.Fatalf("label = %q, want %q", label, roster[0])
+	if label != wantLabel {
+		t.Fatalf("label = %q, want %q", label, wantLabel)
 	}
 	if bin != binPath {
 		t.Fatalf("bin = %q, want %q", bin, binPath)
@@ -113,10 +109,14 @@ func TestSameRoster(t *testing.T) {
 	}
 }
 
-// TestFindCurrentInstallHappyPath writes the 3 mesh plists into a
-// per-test "launch dir" (overridden via HOME), stubs the verifier to
-// accept the install's binary, and asserts FindCurrentInstall recovers
-// {Base, Workdir, BinaryPath, 3 PlistPaths/Labels}.
+// TestFindCurrentInstallHappyPath writes the 3 NEW (FEATURE 14, minimized
+// argv) mesh plists into a per-test "launch dir" (overridden via HOME),
+// stubs the verifier to accept the install's binary, and asserts
+// FindCurrentInstall recovers {Roster, Workdir, BinaryPath, 3 Plists/Labels}.
+//
+// FEATURE 14 reality: the disguised binary is relocated INSIDE the workdir,
+// so the binary's parent dir IS the workdir, and the roster lives in the
+// masked workdir file (NOT argv). The fixture mirrors that.
 func TestFindCurrentInstallHappyPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -124,19 +124,25 @@ func TestFindCurrentInstallHappyPath(t *testing.T) {
 	if err := os.MkdirAll(laDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	binPath := filepath.Join(home, "hidden", "com.apple.metadata.helper.7f3a")
-	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+	// The binary lives INSIDE the workdir (as relocate.RelocateInto does),
+	// so Dir(bin) == workdir is the FEATURE 14 workdir-recovery path.
+	wd := filepath.Join(home, "Library", "Application Support", ".com.apple.metadata.7f3a")
+	binPath := filepath.Join(wd, "com.apple.metadata.helper.7f3a")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	wd := filepath.Join(home, "Library", "Application Support", ".com.apple.metadata.7f3a")
 	roster := []string{
 		"com.apple.metadata.helper.7f3a2c11ab",
 		"com.google.keystone.daemon.8c1f4e9d22",
 		"org.mozilla.updater.agent.0a1b2c3d4e",
+	}
+	// The masked workdir roster file is the single source of truth (F14).
+	if err := core.WriteRoster((&core.Store{Dir: wd}).RosterPath(), roster); err != nil {
+		t.Fatal(err)
 	}
 	s := Spec{
 		Mode: mode.User, SelfPath: binPath, Workdir: wd,
@@ -182,6 +188,142 @@ func TestFindCurrentInstallHappyPath(t *testing.T) {
 		if !strings.HasSuffix(pp, cur.Labels[i]+".plist") {
 			t.Errorf("plist[%d]=%q does not match label %q", i, pp, cur.Labels[i])
 		}
+	}
+}
+
+// oldStylePlist renders a pre-FEATURE-14 plist whose ProgramArguments bake
+// --workdir/--github/--asset/--interval/--roster into argv (the leak F14
+// removed). Used to prove FindCurrentInstall still discovers + correlates an
+// OLD on-disk install on the NEW binary (backward-compat / migration safety).
+func oldStylePlist(label, bin, wd, roster string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>Label</key><string>` + label + `</string>
+  <key>ProgramArguments</key><array>
+    <string>` + bin + `</string>
+    <string>run</string>
+    <string>--r</string>
+    <string>a</string>
+    <string>--mesh</string>
+    <string>--workdir</string>
+    <string>` + wd + `</string>
+    <string>--github</string>
+    <string>o/r</string>
+    <string>--asset</string>
+    <string>daemon-darwin-arm64</string>
+    <string>--interval</string>
+    <string>2s</string>
+    <string>--roster</string>
+    <string>` + roster + `</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+</dict></plist>
+`
+}
+
+// meshFixture sets up HOME + a hidden workdir with the daemon binary inside
+// it (mirrors relocate.RelocateInto) and returns {home, laDir, wd, binPath}.
+func meshFixture(t *testing.T) (home, laDir, wd, binPath string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	laDir = filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wd = filepath.Join(home, "Library", "Application Support", ".com.apple.metadata.7f3a")
+	binPath = filepath.Join(wd, "com.apple.metadata.helper.7f3a")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return home, laDir, wd, binPath
+}
+
+var migrationRoster = []string{
+	"com.apple.metadata.helper.7f3a2c11ab",
+	"com.google.keystone.daemon.8c1f4e9d22",
+	"org.mozilla.updater.agent.0a1b2c3d4e",
+}
+
+// TestFindCurrentInstallOldPlists proves migration safety: an install whose
+// three plists are all OLD-STYLE (roster + workdir baked in argv, NO masked
+// file) is still discovered + correlated by the NEW binary. Workdir falls
+// back to Dir(bin) (== wd here), roster falls back to the --roster argv.
+func TestFindCurrentInstallOldPlists(t *testing.T) {
+	_, laDir, wd, binPath := meshFixture(t)
+	rosterCSV := strings.Join(migrationRoster, ",")
+	// NO masked roster file written → forces the argv fallback.
+	for _, lbl := range migrationRoster {
+		pp := filepath.Join(laDir, lbl+".plist")
+		if err := os.WriteFile(pp, []byte(oldStylePlist(lbl, binPath, wd, rosterCSV)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
+	cur, err := FindCurrentInstall(mode.User, verify)
+	if err != nil {
+		t.Fatalf("FindCurrentInstall: %v", err)
+	}
+	if cur.BinaryPath != binPath {
+		t.Errorf("BinaryPath = %q, want %q", cur.BinaryPath, binPath)
+	}
+	if cur.Workdir != wd {
+		t.Errorf("Workdir = %q, want %q (Dir(bin))", cur.Workdir, wd)
+	}
+	if !sameRoster(cur.Roster, migrationRoster) {
+		t.Errorf("Roster = %v, want %v (from --roster argv fallback)", cur.Roster, migrationRoster)
+	}
+	if len(cur.PlistPaths) != 3 {
+		t.Fatalf("want 3 plists, got %d", len(cur.PlistPaths))
+	}
+}
+
+// TestFindCurrentInstallMixedPlists proves a HALF-MIGRATED install (some
+// plists NEW/minimized, some OLD) is still discovered + correlated. The new
+// correlation key is the shared verified binary path, which all plists share
+// regardless of their argv shape; workdir+roster recover off the masked file.
+func TestFindCurrentInstallMixedPlists(t *testing.T) {
+	_, laDir, wd, binPath := meshFixture(t)
+	// Masked file present (the new source of truth).
+	if err := core.WriteRoster((&core.Store{Dir: wd}).RosterPath(), migrationRoster); err != nil {
+		t.Fatal(err)
+	}
+	rosterCSV := strings.Join(migrationRoster, ",")
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: wd, Roster: migrationRoster}
+
+	// RoleA + RoleB → NEW minimized plists; RoleEnsure → OLD-style plist.
+	newPlistA := filepath.Join(laDir, s.Label(RoleA)+".plist")
+	if err := os.WriteFile(newPlistA, []byte(Plist(s, RoleA)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newPlistB := filepath.Join(laDir, s.Label(RoleB)+".plist")
+	if err := os.WriteFile(newPlistB, []byte(Plist(s, RoleB)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldEnsure := filepath.Join(laDir, s.Label(RoleEnsure)+".plist")
+	if err := os.WriteFile(oldEnsure, []byte(oldStylePlist(s.Label(RoleEnsure), binPath, wd, rosterCSV)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
+	cur, err := FindCurrentInstall(mode.User, verify)
+	if err != nil {
+		t.Fatalf("FindCurrentInstall: %v", err)
+	}
+	if cur.BinaryPath != binPath {
+		t.Errorf("BinaryPath = %q, want %q", cur.BinaryPath, binPath)
+	}
+	if cur.Workdir != wd {
+		t.Errorf("Workdir = %q, want %q", cur.Workdir, wd)
+	}
+	if !sameRoster(cur.Roster, migrationRoster) {
+		t.Errorf("Roster = %v, want %v", cur.Roster, migrationRoster)
+	}
+	if len(cur.PlistPaths) != 3 || len(cur.Labels) != 3 {
+		t.Fatalf("want 3 plists+labels across mixed install, got %d/%d", len(cur.PlistPaths), len(cur.Labels))
 	}
 }
 

--- a/daemon/internal/osadapter/plist.go
+++ b/daemon/internal/osadapter/plist.go
@@ -7,48 +7,34 @@ import (
 )
 
 // args returns the daemon argv for a role. A/B run the supervised loop
-// (`run --r <role>` — reconcile platform + recreate siblings); ensure
-// runs the one-shot mesh repair (`ensure`).
+// (`run --r <role> --mesh` — reconcile platform + recreate siblings);
+// ensure runs the one-shot mesh repair (`ensure`).
+//
+// FEATURE 14 / ADR-0018: the PROD argv is minimized to "role + mesh
+// marker" and nothing else — none of the disguised identifiers ride on
+// the command line where `ps` exposes them to root. Specifically NOT
+// baked: the three roster labels (the `launchctl bootout` keys, the worst
+// leak), --github (a focusd-identity tell), --asset, --interval, and
+// --workdir. A relaunched survivor reconstructs everything else:
+//   - the roster from the masked workdir file (single source of truth),
+//   - the workdir from filepath.Dir(os.Executable()) — the disguised binary
+//     lives inside the workdir (argv[0] is unavoidably visible anyway),
+//   - the github channel + platform asset are derived/compiled in.
+//
+// TEST-MODE EXCEPTION: e2e installs still bake --test-mode-flag + --workdir
+// because the throwaway e2e workdir is NOT derivable from argv[0] (it is a
+// caller-provided temp dir, and the binary is not relocated inside it). No
+// prod identifiers are ever baked.
 func args(s Spec, r Role) []string {
-	common := []string{
-		"--workdir", s.Workdir,
-		"--github", s.Github,
-		"--asset", s.Asset,
-		"--interval", s.Interval.String(),
-		"--test-mode-flag", boolStr(s.isTest()),
-		// FEATURE 10 / ADR-0014: every role carries the FULL 3-label
-		// roster (comma-joined, AllRoles order) so any survivor relaunched
-		// cold reconstructs Spec.Roster from its own launch args and can
-		// rebuild every sibling plist — no shared base, no separate
-		// registry. The masked .roster workdir file is the cold-start /
-		// sibling fallback when a plist isn't to hand.
-		"--roster", rosterArg(s),
+	var tail []string
+	if s.isTest() {
+		tail = []string{"--test-mode-flag", "true", "--workdir", s.Workdir}
 	}
 	if r == RoleEnsure {
-		return append([]string{"ensure"}, common...)
+		return append([]string{"ensure"}, tail...)
 	}
 	// --mesh: only an installed worker self-heals the launchd mesh.
-	return append([]string{"run", "--r", string(r), "--mesh"}, common...)
-}
-
-func boolStr(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
-// rosterArg renders the comma-joined 3-label roster baked into every
-// plist's argv. It uses s.Label over AllRoles so the value reflects the
-// ACTUAL resolved labels (test-mode e2e, disguised roster, or dev
-// fallback) — whatever a survivor must rebuild. Aligned with AllRoles so
-// `--r <role>` + this roster pins each sibling's label by position.
-func rosterArg(s Spec) string {
-	labels := make([]string, len(AllRoles))
-	for i, r := range AllRoles {
-		labels[i] = s.Label(r)
-	}
-	return strings.Join(labels, ",")
+	return append([]string{"run", "--r", string(r), "--mesh"}, tail...)
 }
 
 // EnsureBackstopInterval is the default ensurer StartInterval (FEATURE 10

--- a/daemon/internal/osadapter/plist_test.go
+++ b/daemon/internal/osadapter/plist_test.go
@@ -40,11 +40,12 @@ func TestPlistWorkerVsEnsurer(t *testing.T) {
 	}
 }
 
-// TestPlistEmitsFullRoster asserts FEATURE 10: each plist's argv carries
-// the FULL 3-label roster (not a --mesh-base), so any survivor relaunched
-// from its own launch args reconstructs Spec.Roster. The roster value is
-// the three labels joined — every plist is self-describing.
-func TestPlistEmitsFullRoster(t *testing.T) {
+// TestPlistProdArgvMinimized asserts FEATURE 14 / ADR-0018: a PROD mesh
+// plist's argv is reduced to role + mesh marker and NONE of the disguised
+// identifiers (the three roster labels — the bootout keys — plus --github,
+// --asset, --interval, --workdir, --test-mode-flag). The masked workdir
+// file, not argv, is the single source of truth for the labels.
+func TestPlistProdArgvMinimized(t *testing.T) {
 	roster := []string{
 		"com.apple.metadata.helper.7f3a2c11ab",
 		"com.google.keystone.daemon.8c1f4e9d22",
@@ -54,39 +55,81 @@ func TestPlistEmitsFullRoster(t *testing.T) {
 		Github: "o/r", Asset: "platform-darwin-arm64",
 		Interval: 10 * time.Second, Roster: roster}
 
+	// Forbidden tokens: the leak FEATURE 14 closes. The three labels are
+	// the worst (bootout keys); the rest each narrow the search. We scan the
+	// ProgramArguments (what `ps` shows), NOT the plist Label key — the
+	// launchd Label legitimately carries the disguised name on disk (that is
+	// FEATURE 10's masked-roster concern, not this feature's argv concern).
+	forbidden := []string{
+		"--roster", "--github", "--asset", "--interval",
+		"--workdir", "--test-mode-flag", "/wd", "o/r",
+		"platform-darwin-arm64",
+	}
+	forbidden = append(forbidden, roster...)
+
 	for _, r := range AllRoles {
-		p := Plist(s, r)
-		if strings.Contains(p, "--mesh-base") {
-			t.Errorf("%s plist must NOT carry the retired --mesh-base flag", r)
+		argv := args(s, r)
+		for _, tok := range forbidden {
+			for _, a := range argv {
+				if a == tok {
+					t.Errorf("%s prod argv leaks %q: %v", r, tok, argv)
+				}
+			}
 		}
-		if !strings.Contains(p, "<string>--roster</string>") {
-			t.Errorf("%s plist must carry --roster", r)
+	}
+
+	// Workers carry exactly: run --r <role> --mesh.
+	for _, r := range []Role{RoleA, RoleB} {
+		got := args(s, r)
+		want := []string{"run", "--r", string(r), "--mesh"}
+		if !equalArgs(got, want) {
+			t.Errorf("%s worker argv = %v, want %v", r, got, want)
 		}
-		want := strings.Join(roster, ",")
-		if !strings.Contains(p, "<string>"+want+"</string>") {
-			t.Errorf("%s plist missing full roster %q:\n%s", r, want, p)
+	}
+	// Ensurer carries exactly: ensure.
+	if got := args(s, RoleEnsure); !equalArgs(got, []string{"ensure"}) {
+		t.Errorf("ensurer argv = %v, want [ensure]", got)
+	}
+}
+
+// TestPlistTestModeArgvCarriesWorkdir asserts the FEATURE 14 test-mode
+// EXCEPTION: e2e installs still bake --test-mode-flag true + --workdir,
+// because the throwaway e2e workdir is NOT derivable from argv[0] (the
+// binary is not relocated inside it). No prod identifiers are baked.
+func TestPlistTestModeArgvCarriesWorkdir(t *testing.T) {
+	s := Spec{Mode: mode.Test, SelfPath: "/d/daemon", Workdir: "/tmp/e2e-wd",
+		Github: "o/r", Asset: "platform-darwin-arm64", Interval: 2 * time.Second}
+
+	worker := args(s, RoleA)
+	wantWorker := []string{"run", "--r", "a", "--mesh", "--test-mode-flag", "true", "--workdir", "/tmp/e2e-wd"}
+	if !equalArgs(worker, wantWorker) {
+		t.Errorf("test-mode worker argv = %v, want %v", worker, wantWorker)
+	}
+	ensure := args(s, RoleEnsure)
+	wantEnsure := []string{"ensure", "--test-mode-flag", "true", "--workdir", "/tmp/e2e-wd"}
+	if !equalArgs(ensure, wantEnsure) {
+		t.Errorf("test-mode ensurer argv = %v, want %v", ensure, wantEnsure)
+	}
+	// Still no --roster / --github / --asset / --interval even in test mode.
+	for _, tok := range []string{"--roster", "--github", "--asset", "--interval"} {
+		for _, a := range append(worker, ensure...) {
+			if a == tok {
+				t.Errorf("test-mode argv must not carry %q", tok)
+			}
 		}
 	}
 }
 
-// TestRosterArgvRoundTrip asserts the survivor-reconstruct contract: the
-// roster flag value parses back into the same three labels.
-func TestRosterArgvRoundTrip(t *testing.T) {
-	roster := []string{
-		"com.apple.metadata.helper.7f3a2c11ab",
-		"com.google.keystone.daemon.8c1f4e9d22",
-		"org.mozilla.updater.agent.0a1b2c3d4e",
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
 	}
-	joined := strings.Join(roster, ",")
-	got := strings.Split(joined, ",")
-	if len(got) != 3 {
-		t.Fatalf("round-trip len = %d", len(got))
-	}
-	for i := range roster {
-		if got[i] != roster[i] {
-			t.Errorf("round-trip[%d] = %q, want %q", i, got[i], roster[i])
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
 	}
+	return true
 }
 
 func TestIntervalSecondsFloor(t *testing.T) {
@@ -111,9 +154,12 @@ func TestEnsureIntervalDecoupledFromWorker(t *testing.T) {
 	if !strings.Contains(e, "<key>StartInterval</key><integer>"+strconv.Itoa(want)+"</integer>") {
 		t.Fatalf("ensurer must use the %ds backstop, not the 2s worker cadence:\n%s", want, e)
 	}
-	// And the worker argv must still carry the fast 2s --interval.
+	// FEATURE 14 / ADR-0018: the worker no longer bakes --interval into argv
+	// (the fast cadence is the daemon's built-in default; a baked value would
+	// leak the cadence in `ps`). The ensurer's StartInterval — a launchd plist
+	// key, NOT an argv flag — still carries the decoupled backstop above.
 	a := Plist(s, RoleA)
-	if !strings.Contains(a, "<string>--interval</string>") || !strings.Contains(a, "<string>2s</string>") {
-		t.Fatalf("worker --interval should be the fast 2s cadence:\n%s", a)
+	if strings.Contains(a, "<string>--interval</string>") {
+		t.Fatalf("worker argv must NOT bake --interval (FEATURE 14):\n%s", a)
 	}
 }

--- a/daemon/internal/osadapter/selfupdate.go
+++ b/daemon/internal/osadapter/selfupdate.go
@@ -3,6 +3,7 @@ package osadapter
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 )
 
@@ -152,11 +153,21 @@ func SelfUpdate(
 	// mesh left behind (FEATURE 10 / ADR-0014). Without this, the workdir
 	// .roster still names the OLD labels: a new worker's cold-start read
 	// would succeed (valid mask) yet recover the wrong mesh, and ensureAll
-	// wouldn't rewrite it because the read didn't error. Best-effort: the
-	// new plists' --roster argv is the primary source of truth, so a write
-	// failure here does not roll back a healthy swap.
+	// wouldn't rewrite it because the read didn't error.
+	//
+	// FEATURE 14 / ADR-0018: the new minimized plists NO LONGER carry the
+	// roster in their --roster argv, so this masked file is now the SOLE
+	// cold-start roster source for the new mesh. A write failure does not
+	// roll back an otherwise-healthy swap (the new mesh is already serving),
+	// but it leaves a stale/nil roster for the next FindCurrentInstall —
+	// surface it loudly so the gap is diagnosable from the daemon log
+	// instead of swallowed.
 	if rs != nil {
-		_ = rs.writeRoster(rosterLabels(newSpec))
+		if err := rs.writeRoster(rosterLabels(newSpec)); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"WARN osadapter/selfupdate: persist masked roster failed (swap kept; next cold-start roster may be stale/nil): %v\n",
+				err)
+		}
 	}
 
 	// G. SWAP. Bootout old in REVERSE order (ensurer first, then B,


### PR DESCRIPTION
## FEATURE 14 — Minimize the mesh's disguise footprint (ADR-0018)

### Problem
The launchd self-protection mesh baked sensitive identifiers into each plist's `ProgramArguments`, fully visible in `ps -axww`/`ps aux` to root. Worst of all, the argv carried the **full comma-joined roster** — all three launchd labels, i.e. the exact `launchctl bootout` keys — in one line. That completely defeated FEATURE 10's label-decorrelation: F10 added a masked on-disk roster file precisely so the labels couldn't be grepped as a cluster, but argv printed them in clear text anyway. `--github eliteGoblin/focusd` was also a focusd-identity giveaway.

### Change (mostly removal)
Prod plist argv shrinks to **role + mesh marker only**:
- worker → `run --r <role> --mesh`
- ensurer → `ensure`

Dropped from baked argv: `--roster`, `--workdir`, `--github`, `--asset`, `--interval`, `--test-mode-flag false`. The masked `.roster` file becomes the **single source of truth** for the labels (ADR-0018, refining ADR-0014); workdir derives from `filepath.Dir(os.Executable())` for mesh roles; channel/asset are compiled-in/derived.

Test-mode keeps `--test-mode-flag true --workdir` (the e2e dir isn't derivable from argv[0]).

### Load-bearing detail
`FindCurrentInstall` previously parsed `--roster`/`--workdir` back out of plist argv to correlate the 3 mesh plists into one install. That correlation key moved to the **Ed25519-verified binary path** (shared across all 3 plists), with workdir recovered from `Dir(binary)` and roster from the masked file. Argv-parse fallbacks retained for old plists. Migration rides the next self-update path-rotation (no eager hot-tick rewrite that would drop a live mesh); old plists keep working on the new binary.

### Honest limitations
- **`argv[0]` (the binary path) is always visible in `ps` to root** — unhideable. This removes the bootout keys + identity, not the path itself.
- **btm / Login Items stale-record accumulation** (path-rotation leaves inert records) is documented as an accepted limitation; no supported per-record deregistration API. Iceboxed.

### Verification
- **Live (real launchd test-mesh):** `ps -axww` confirms argv carries **none** of the 3 labels / `--github` / `--asset` / `--interval`. Self-heal (bootout/kill/disable) at parity-or-better with master.
- **Unit/integration:** prod-minimal argv, masked-file roster read, FindCurrentInstall old/new/mixed-plist migration matrix, WorkdirFromBinary edge guards. Full matrix green incl. `GOOS=linux` + `-race` + `-tags e2e`.
- **Not live-verified (honest):** live *prod* mesh + live self-update migration (needs a system deploy). Unit-proven only.

Spec: `requirements/features/14-mesh-argv-leak-minimization.md` · Decision: `requirements/decisions/0018-roster-source-of-truth-off-argv.md`
