### PR TITLE
feat(daemon): FEATURE 17 — recovery resilience (baked fallback + global singleton + idempotent cleanup)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -259,6 +260,40 @@ func platformAsset() string { return "platform-" + runtime.GOOS + "-" + runtime.
 // an empty repo would malform the fetch URL → 404 → no self-heal.
 const defaultGithubRepo = "eliteGoblin/focusd"
 
+// defaultPlatformVersion is the baked, compiled-in platform version the
+// reconcile loop adopts when the on-disk store carries NO desired version
+// (FEATURE 17, recovery resilience). A wiped workdir would otherwise leave
+// the daemon Blocked forever (no desired ⇒ no platform ⇒ no protection); the
+// baked fallback lets a survivor re-pin a known-good version and self-heal.
+//
+// FLOOR-not-ceiling: this is consulted ONLY when the store desired is empty.
+// `install -v` / `update` always WriteDesired and win, so the fallback can
+// never pin DOWN a newer pinned version. Bump it on each release so a
+// fresh-wiped install self-heals to a current build. Validated by
+// TestDefaultPlatformVersionValid against isValidVersionTag.
+const defaultPlatformVersion = "v0.16.3"
+
+// fixedSingletonLockName is the basename of the cross-generation platform
+// singleton lock (FEATURE 17, Item 2). It lives at a FIXED path under the
+// mode's Application Support root — NOT inside the rotating workdir — so the
+// flock elects exactly ONE platform supervisor even across path-rotating
+// self-update generations (a per-workdir lock would let each generation run
+// its own platform). Disguised as a dotted Apple-metadata-looking file so a
+// casual `ls` doesn't flag it; the durable commitment weight lives elsewhere.
+const fixedSingletonLockName = ".com.apple.metadata.plist.lck"
+
+// singletonLockPath returns the path of the cross-generation platform
+// singleton lock for a mode. user/system → the FIXED mode-keyed path under
+// SupportRoot (survives workdir rotation). test → the per-workdir path
+// (Store.LockPath()) so concurrent e2e installs stay isolated.
+func singletonLockPath(m mode.Mode, workdir string) string {
+	if m == mode.Test {
+		return (&core.Store{Dir: workdir}).LockPath()
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(mode.SupportRoot(m, home), fixedSingletonLockName)
+}
+
 // splitRoster parses the comma-joined --roster flag into the label set.
 // Empty → nil (the dev/test fallback in Spec.Label takes over).
 func splitRoster(s string) []string {
@@ -293,7 +328,17 @@ func build(o opts) (*core.Executor, *slog.Logger) {
 	// (loop()->Tick->apply) ever acquires it, electing one platform supervisor
 	// across the A/B mesh roles. Non-ticking callers (update/install) construct
 	// but never acquire. NewFileLock's zero value is unlocked.
-	return core.NewExecutor(st, f, p, core.NewFileLock(), log), log
+	e := core.NewExecutor(st, f, p, core.NewFileLock(), log)
+	// FEATURE 17 Item 1: bake the fallback platform version so a wiped workdir
+	// self-heals instead of blocking. Guard with the strict tag validator —
+	// an invalid baked value leaves Fallback empty (today's safe Blocked).
+	if isValidVersionTag(defaultPlatformVersion) {
+		e.Fallback = defaultPlatformVersion
+	}
+	// FEATURE 17 Item 2: elect one platform across path-rotating generations
+	// via a fixed, mode-keyed lock path (test mode stays per-workdir).
+	e.LockFilePath = singletonLockPath(o.modeVal(), o.workdir)
+	return e, log
 }
 
 func loop(args []string, once bool) int {
@@ -623,7 +668,24 @@ func installMesh(self string, spec *osadapter.Spec, desired string) error {
 	if err := st.WriteDesired(desired); err != nil {
 		return fmt.Errorf("write desired: %w", err)
 	}
-	return osadapter.Install(*spec)
+	if err := osadapter.Install(*spec); err != nil {
+		return err
+	}
+	// FEATURE 17 Item 3: the new generation is up FIRST (above); now retire any
+	// OLDER generations left behind by a wiped-state reinstall (distinct
+	// Ed25519-verified binary path ≠ the one we just installed). Best-effort —
+	// a retire failure must NOT fail an otherwise-successful install, and the
+	// retired labels/paths are never surfaced (count is logged at the call
+	// site if at all). Idempotent: with no older generation present it is a
+	// no-op. NOT called from the self-update path (in-place rotation transiently
+	// looks like two generations).
+	if n, rerr := osadapter.RetireOtherGenerations(spec.Mode, spec.SelfPath); rerr != nil {
+		// Generic message only: rerr could embed a disguised path.
+		fmt.Fprintln(os.Stderr, "install: retire prior generations (best-effort) failed")
+	} else if n > 0 {
+		fmt.Printf("retired %d prior generation(s)\n", n)
+	}
+	return nil
 }
 
 // installFailureHint returns the operator guidance printed when

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -290,7 +290,16 @@ func singletonLockPath(m mode.Mode, workdir string) string {
 	if m == mode.Test {
 		return (&core.Store{Dir: workdir}).LockPath()
 	}
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// No resolvable home → mode.SupportRoot would yield a RELATIVE path, and
+		// a relative singleton lock defeats the cross-generation election (each
+		// generation, started from its own cwd, would flock a different file →
+		// twin platforms). Fall back to the per-workdir lock: it still elects one
+		// platform within a generation, which is strictly safer than a relative
+		// path that elects none across them.
+		return (&core.Store{Dir: workdir}).LockPath()
+	}
 	return filepath.Join(mode.SupportRoot(m, home), fixedSingletonLockName)
 }
 
@@ -669,7 +678,7 @@ func installMesh(self string, spec *osadapter.Spec, desired string) error {
 		return fmt.Errorf("write desired: %w", err)
 	}
 	if err := osadapter.Install(*spec); err != nil {
-		return err
+		return fmt.Errorf("install mesh: %w", err)
 	}
 	// FEATURE 17 Item 3: the new generation is up FIRST (above); now retire any
 	// OLDER generations left behind by a wiped-state reinstall (distinct

--- a/daemon/cmd/daemon/recovery_test.go
+++ b/daemon/cmd/daemon/recovery_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/core"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// FEATURE 17 Item 1: the baked fallback platform version MUST be a strict
+// semver tag — otherwise build() leaves Executor.Fallback empty and the
+// wiped-workdir self-heal silently regresses to the old Blocked behavior.
+func TestDefaultPlatformVersionValid(t *testing.T) {
+	if !isValidVersionTag(defaultPlatformVersion) {
+		t.Fatalf("defaultPlatformVersion %q is not a strict semver tag", defaultPlatformVersion)
+	}
+}
+
+// FEATURE 17 Item 2: the singleton lock path is FIXED + mode-keyed for
+// user/system (survives workdir rotation) and per-workdir for test (e2e
+// isolation).
+func TestSingletonLockPath(t *testing.T) {
+	const wd = "/tmp/some/rotating/workdir"
+
+	// user/system → fixed path under the mode's support root, NOT under wd.
+	for _, m := range []mode.Mode{mode.User, mode.System} {
+		got := singletonLockPath(m, wd)
+		if filepath.Base(got) != fixedSingletonLockName {
+			t.Errorf("mode %s: basename = %q, want %q", m, filepath.Base(got), fixedSingletonLockName)
+		}
+		if strings.HasPrefix(got, wd) {
+			t.Errorf("mode %s: lock path %q must NOT live under the rotating workdir", m, got)
+		}
+		if !strings.Contains(got, "Application Support") {
+			t.Errorf("mode %s: lock path %q must live under the support root", m, got)
+		}
+	}
+
+	// system specifically resolves to the /Library support root.
+	if got := singletonLockPath(mode.System, wd); !strings.HasPrefix(got, "/Library/Application Support") {
+		t.Errorf("system lock path %q must be under /Library/Application Support", got)
+	}
+
+	// test → per-workdir path (matches Store.LockPath, stays inside wd).
+	wantTest := (&core.Store{Dir: wd}).LockPath()
+	if got := singletonLockPath(mode.Test, wd); got != wantTest {
+		t.Errorf("test lock path = %q, want per-workdir %q", got, wantTest)
+	}
+}

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -64,6 +64,26 @@ type Executor struct {
 	fetchRetryVersion string
 	// now is the clock seam (defaults to time.Now); tests inject a fake.
 	now func() time.Time
+	// Fallback is the baked, compiled-in platform version adopted ONLY when
+	// the on-disk store has no desired version (FEATURE 17, recovery
+	// resilience). A wiped workdir (store gone) would otherwise leave Decide
+	// permanently Blocked — no desired ⇒ no platform ⇒ no protection. With a
+	// Fallback set, the first tick on an empty store re-pins it (recreating the
+	// wiped workdir via WriteDesired's MkdirAll) and self-heals.
+	//
+	// FLOOR-not-ceiling: Fallback is consulted ONLY when the store desired is
+	// empty. An explicit `install -v` / `update` WriteDesired always wins and
+	// rolls forward — the fallback can never pin DOWN a newer pinned version.
+	// Empty Fallback ⇒ today's safe Blocked behavior (no self-heal).
+	Fallback string
+	// LockFilePath is the path of the cross-generation singleton lock the
+	// winning daemon flocks to elect ONE platform supervisor (FEATURE 17,
+	// Item 2). It is a FIXED, mode-keyed path that survives workdir rotation
+	// — NOT the per-workdir Store.LockPath() (which lets two path-rotating
+	// generations each run their own platform). Empty ⇒ fall back to
+	// Store.LockPath() (preserves existing tests + the test-mode per-workdir
+	// isolation, which build() sets explicitly).
+	LockFilePath string
 }
 
 // New builds an Executor.
@@ -116,9 +136,30 @@ func (e *Executor) Tick(ctx context.Context) (Action, error) {
 		}
 	}
 
+	desired := e.Store.Desired()
+	haveConfig := e.Store.HaveConfig()
+
+	// FEATURE 17 (recovery resilience): a wiped workdir leaves no desired
+	// version on disk, which Decide treats as Blocked → no platform → no
+	// protection. If a baked Fallback is set, adopt it: re-pin it to disk
+	// (WriteDesired's MkdirAll recreates the wiped workdir) so the very next
+	// tick drives EnsureRunning instead of Blocked. FLOOR-not-ceiling — this
+	// runs ONLY when the store desired is empty; an explicit pin always wins.
+	if desired == "" && e.Fallback != "" {
+		if e.Log != nil {
+			e.Log.Warn("no desired version on disk; adopting baked fallback")
+		}
+		// Best-effort persist. Even if the write fails (e.g. store not yet
+		// writable), drive toward the fallback THIS tick so a transient FS
+		// hiccup doesn't leave protection Blocked; the next tick re-attempts.
+		_ = e.Store.WriteDesired(e.Fallback)
+		desired = e.Fallback
+		haveConfig = true
+	}
+
 	st := State{
-		HaveConfig: e.Store.HaveConfig(),
-		Desired:    e.Store.Desired(),
+		HaveConfig: haveConfig,
+		Desired:    desired,
 		Running:    running,
 		Good:       e.Store.Good(),
 		Bad:        e.Store.BadSet(),
@@ -153,7 +194,17 @@ func (e *Executor) apply(ctx context.Context, a Action) error {
 		// Acquired ONCE before any Stop/Start so a standby never tears down
 		// the holder's child; the fd stays open for the executor's lifetime.
 		if !e.holdsLock {
-			ok, err := e.Lock.TryAcquire(e.Store.LockPath())
+			// FEATURE 17 (Item 2): elect ONE platform across path-rotating
+			// generations via a FIXED, mode-keyed lock path (LockFilePath),
+			// not the per-workdir Store.LockPath() — a rotated workdir would
+			// otherwise give each generation its own lock and run two
+			// platforms. Empty LockFilePath ⇒ per-workdir path (test-mode
+			// isolation + existing tests).
+			lockPath := e.LockFilePath
+			if lockPath == "" {
+				lockPath = e.Store.LockPath()
+			}
+			ok, err := e.Lock.TryAcquire(lockPath)
 			if err != nil {
 				return fmt.Errorf("singleton lock: %w", err)
 			}

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -84,6 +84,13 @@ type Executor struct {
 	// Store.LockPath() (preserves existing tests + the test-mode per-workdir
 	// isolation, which build() sets explicitly).
 	LockFilePath string
+	// fallbackWarned latches the one-shot "adopting baked fallback" WARN. When
+	// the workdir is persistently unwritable (the desired write keeps failing)
+	// the fallback branch runs every ~2s tick; without this latch it would spam
+	// the log forever. We log the FIRST adoption, suppress repeats, and re-arm
+	// (reset to false) the moment a real desired version is present on disk
+	// again — so a later recurrence is logged afresh.
+	fallbackWarned bool
 }
 
 // New builds an Executor.
@@ -139,6 +146,13 @@ func (e *Executor) Tick(ctx context.Context) (Action, error) {
 	desired := e.Store.Desired()
 	haveConfig := e.Store.HaveConfig()
 
+	// A real desired version is present again → re-arm the one-shot fallback
+	// WARN so a future wipe is reported afresh (and not silently suppressed by
+	// a latch left set from an earlier recovery).
+	if desired != "" {
+		e.fallbackWarned = false
+	}
+
 	// FEATURE 17 (recovery resilience): a wiped workdir leaves no desired
 	// version on disk, which Decide treats as Blocked → no platform → no
 	// protection. If a baked Fallback is set, adopt it: re-pin it to disk
@@ -146,8 +160,9 @@ func (e *Executor) Tick(ctx context.Context) (Action, error) {
 	// tick drives EnsureRunning instead of Blocked. FLOOR-not-ceiling — this
 	// runs ONLY when the store desired is empty; an explicit pin always wins.
 	if desired == "" && e.Fallback != "" {
-		if e.Log != nil {
+		if e.Log != nil && !e.fallbackWarned {
 			e.Log.Warn("no desired version on disk; adopting baked fallback")
+			e.fallbackWarned = true
 		}
 		// Best-effort persist. Even if the write fails (e.g. store not yet
 		// writable), drive toward the fallback THIS tick so a transient FS

--- a/daemon/internal/core/executor_test.go
+++ b/daemon/internal/core/executor_test.go
@@ -143,6 +143,67 @@ func TestExecutorPinnedDesiredStarts(t *testing.T) {
 	}
 }
 
+// FEATURE 17 Item 1: with NO desired version on disk but a baked Fallback,
+// the tick adopts the fallback — re-pins it to the store (recreating a wiped
+// workdir) and drives EnsureRunning, NOT Blocked. This is the wiped-workdir
+// self-heal.
+func TestExecutorFallbackAdoptedWhenNoDesired(t *testing.T) {
+	e, st, _, p := newExec(t)
+	e.Fallback = "v9"
+
+	a, err := e.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("fallback tick must not error, got %v", err)
+	}
+	if a.Kind != EnsureRunning || a.Target != "v9" {
+		t.Fatalf("no desired + fallback ⇒ EnsureRunning v9, got %+v", a)
+	}
+	if st.Desired() != "v9" {
+		t.Fatalf("fallback must be persisted to the store, got desired=%q", st.Desired())
+	}
+	if p.running != "v9" || !st.HaveBin("v9") {
+		t.Fatalf("fallback v9 must be brought up: running=%q bin=%v", p.running, st.HaveBin("v9"))
+	}
+}
+
+// Floor-not-ceiling: an explicit on-disk desired always wins; the fallback is
+// never consulted when a version is already pinned (even an older-looking one).
+func TestExecutorExplicitDesiredWinsOverFallback(t *testing.T) {
+	e, st, _, p := newExec(t)
+	e.Fallback = "v9"
+	if err := st.WriteDesired("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := e.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if a.Target != "v1" || p.running != "v1" {
+		t.Fatalf("explicit desired v1 must win over fallback v9, got %+v running=%q", a, p.running)
+	}
+	if st.Desired() != "v1" {
+		t.Fatalf("fallback must not overwrite an explicit desired, got %q", st.Desired())
+	}
+}
+
+// No desired AND no fallback ⇒ still Blocked (the safe default is preserved
+// when no fallback is baked in).
+func TestExecutorNoFallbackStillBlocked(t *testing.T) {
+	e, st, _, p := newExec(t)
+	// newExec leaves Fallback == "".
+	a, err := e.Tick(context.Background())
+	if err != nil || a.Kind != Blocked {
+		t.Fatalf("no desired + no fallback ⇒ Blocked, got %+v err=%v", a, err)
+	}
+	if st.Desired() != "" {
+		t.Fatalf("Blocked tick must not write desired, got %q", st.Desired())
+	}
+	if p.running != "" {
+		t.Fatalf("Blocked tick must start nothing, got %q", p.running)
+	}
+}
+
 func TestExecutorSteadyAndPromoteGood(t *testing.T) {
 	e, st, _, p := newExec(t)
 	st.WriteDesired("v1")

--- a/daemon/internal/osadapter/argv.go
+++ b/daemon/internal/osadapter/argv.go
@@ -82,6 +82,63 @@ func WorkdirFromBinary(self string) string {
 	return parent
 }
 
+// hasMeshFlag reports whether a parsed argv carries the "--mesh" marker —
+// the corroborating signal (alongside Ed25519 verification of argv[0]) that a
+// plist belongs to a focusd self-healing mesh worker (FEATURE 17, generation
+// cleanup). The ensure role's argv (`ensure`) does NOT carry --mesh; a
+// generation is recognised when its VERIFIED binary has at least one --mesh
+// plist, and all plists sharing that binary are then grouped into it.
+func hasMeshFlag(argv []string) bool {
+	for _, a := range argv {
+		if a == "--mesh" {
+			return true
+		}
+	}
+	return false
+}
+
+// safeToRemoveWorkdir reports whether dir is a safe os.RemoveAll target during
+// generation cleanup (FEATURE 17, Item 3). The teardown deletes an OLD
+// generation's workdir, so a malformed/disguised value must never widen the
+// blast radius. A dir is safe ONLY when ALL hold:
+//   - it is a non-empty, absolute path;
+//   - it is STRICTLY nested under supportRoot (never the root itself, never
+//     outside it) — so a bug can't delete "/Library/Application Support" or a
+//     sibling tree;
+//   - it is NOT the keep generation's workdir; and
+//   - it is NOT an ancestor of the keep workdir (deleting an ancestor would
+//     take the surviving install — and the out-of-band watchdog dir, which is
+//     a sibling under the same root — down with it).
+//
+// Pure → unit-tested on Linux CI.
+func safeToRemoveWorkdir(dir, supportRoot, keepWorkdir string) bool {
+	if dir == "" || supportRoot == "" || !filepath.IsAbs(dir) {
+		return false
+	}
+	dir = filepath.Clean(dir)
+	root := filepath.Clean(supportRoot)
+
+	// Must be strictly under root: a valid relative path that is neither "."
+	// (== root) nor an escape ("..").
+	rel, err := filepath.Rel(root, dir)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	if keepWorkdir != "" {
+		keep := filepath.Clean(keepWorkdir)
+		if dir == keep {
+			return false // never delete the surviving generation's workdir
+		}
+		// Reject dir being an ancestor of keep (would delete keep too).
+		if kr, kerr := filepath.Rel(dir, keep); kerr == nil &&
+			kr != ".." && !strings.HasPrefix(kr, ".."+string(filepath.Separator)) {
+			return false
+		}
+	}
+	return true
+}
+
 // intervalFromArgv pulls the reconcile interval following "--interval" out of
 // a parsed argv. Returns 0 when the flag is absent or unparseable — caller
 // substitutes a default.

--- a/daemon/internal/osadapter/argv.go
+++ b/daemon/internal/osadapter/argv.go
@@ -112,11 +112,29 @@ func hasMeshFlag(argv []string) bool {
 //
 // Pure → unit-tested on Linux CI.
 func safeToRemoveWorkdir(dir, supportRoot, keepWorkdir string) bool {
-	if dir == "" || supportRoot == "" || !filepath.IsAbs(dir) {
+	// BOTH must be absolute up front: a relative supportRoot would make the
+	// containment check meaningless (filepath.Rel against a relative base can
+	// spuriously "contain" almost anything), so refuse before resolving.
+	if dir == "" || supportRoot == "" || !filepath.IsAbs(dir) || !filepath.IsAbs(supportRoot) {
 		return false
 	}
-	dir = filepath.Clean(dir)
-	root := filepath.Clean(supportRoot)
+
+	// Resolve symlinks on BOTH before the containment check so RemoveAll and
+	// this guard agree on the REAL paths. Without this, a symlinked intermediate
+	// component of dir (e.g. <root>/link -> /outside) passes a lexical
+	// under-root check yet RemoveAll would follow the link and delete OUTSIDE
+	// root. EvalSymlinks also fails for a non-existent path → we refuse, which
+	// is correct: a workdir we cannot stat is not a workdir we should rm -rf.
+	rdir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return false
+	}
+	rroot, err := filepath.EvalSymlinks(supportRoot)
+	if err != nil {
+		return false
+	}
+	dir = filepath.Clean(rdir)
+	root := filepath.Clean(rroot)
 
 	// Must be strictly under root: a valid relative path that is neither "."
 	// (== root) nor an escape ("..").
@@ -126,7 +144,14 @@ func safeToRemoveWorkdir(dir, supportRoot, keepWorkdir string) bool {
 	}
 
 	if keepWorkdir != "" {
+		// Resolve keep too so the comparison is against real paths (matching the
+		// resolved dir). Best-effort: a not-yet-existing keep falls back to its
+		// cleaned form rather than refusing — the keep guard only ever ADDS
+		// safety, so a cleaned compare is acceptable when it can't be resolved.
 		keep := filepath.Clean(keepWorkdir)
+		if rk, kerr := filepath.EvalSymlinks(keepWorkdir); kerr == nil {
+			keep = filepath.Clean(rk)
+		}
 		if dir == keep {
 			return false // never delete the surviving generation's workdir
 		}

--- a/daemon/internal/osadapter/argv_test.go
+++ b/daemon/internal/osadapter/argv_test.go
@@ -1,6 +1,7 @@
 package osadapter
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -58,39 +59,74 @@ func TestHasMeshFlag(t *testing.T) {
 
 // TestSafeToRemoveWorkdir pins the os.RemoveAll guard for generation cleanup
 // (FEATURE 17, Item 3): only an absolute path STRICTLY under the support root,
-// that is neither the keep workdir nor an ancestor of it, may be removed.
+// that is neither the keep workdir nor an ancestor of it, may be removed. The
+// guard now resolves symlinks on BOTH dir and supportRoot, so real on-disk
+// dirs are required — t.TempDir() + os.MkdirAll give us those.
 func TestSafeToRemoveWorkdir(t *testing.T) {
-	root := "/Library/Application Support"
-	keep := filepath.Join(root, ".keepgen.aaaa")
+	mkdir := func(p string) string {
+		t.Helper()
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	root := t.TempDir()
+	// keep lives one level deep so we can also exercise an ancestor-of-keep dir.
+	keepParent := mkdir(filepath.Join(root, ".keepgen.aaaa"))
+	keep := mkdir(filepath.Join(keepParent, "inner"))
+	oldGen := mkdir(filepath.Join(root, ".oldgen.bbbb"))
+	nestedOld := mkdir(filepath.Join(oldGen, "bin"))
+	outside := t.TempDir() // a real dir entirely outside root
+
 	cases := []struct {
-		name string
-		dir  string
-		want bool
+		name        string
+		dir         string
+		supportRoot string
+		keep        string
+		want        bool
 	}{
-		{"valid old generation", filepath.Join(root, ".oldgen.bbbb"), true},
-		{"valid nested old generation", filepath.Join(root, ".oldgen.bbbb", "bin"), true},
-		{"empty dir", "", false},
-		{"relative dir", "oldgen", false},
-		{"the support root itself", root, false},
-		{"outside the support root", "/Library/LaunchDaemons/x", false},
-		{"escape via traversal sibling", "/Library/Application SupportXX/y", false},
-		{"the keep workdir", keep, false},
-		{"ancestor of keep (== root parent)", "/Library", false},
-		{"ancestor of keep (root)", root, false},
+		{"valid old generation", oldGen, root, keep, true},
+		{"valid nested old generation", nestedOld, root, keep, true},
+		{"empty dir", "", root, keep, false},
+		{"relative dir", "oldgen", root, keep, false},
+		{"relative supportRoot", oldGen, "Library/Application Support", keep, false},
+		{"non-existent dir under root", filepath.Join(root, ".ghost"), root, keep, false},
+		{"the support root itself", root, root, keep, false},
+		{"outside the support root", outside, root, keep, false},
+		{"the keep workdir", keep, root, keep, false},
+		{"ancestor of keep (under root)", keepParent, root, keep, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := safeToRemoveWorkdir(c.dir, root, keep); got != c.want {
-				t.Fatalf("safeToRemoveWorkdir(%q) = %v, want %v", c.dir, got, c.want)
+			if got := safeToRemoveWorkdir(c.dir, c.supportRoot, c.keep); got != c.want {
+				t.Fatalf("safeToRemoveWorkdir(%q, %q, %q) = %v, want %v",
+					c.dir, c.supportRoot, c.keep, got, c.want)
 			}
 		})
 	}
 
-	// Empty keepWorkdir must not weaken the under-root guard.
-	if !safeToRemoveWorkdir(filepath.Join(root, ".g.cccc"), root, "") {
+	// A symlinked INTERMEDIATE component that escapes the root must be refused:
+	// <root>/link -> <outside>, so <root>/link/evil is lexically under root but
+	// RemoveAll would follow the link and delete OUTSIDE root.
+	t.Run("symlinked intermediate escapes root", func(t *testing.T) {
+		linkRoot := t.TempDir()
+		escapeTarget := t.TempDir()
+		mkdir(filepath.Join(escapeTarget, "evil"))
+		if err := os.Symlink(escapeTarget, filepath.Join(linkRoot, "link")); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(linkRoot, "link", "evil") // resolves outside linkRoot
+		if safeToRemoveWorkdir(dir, linkRoot, "") {
+			t.Fatal("a dir whose intermediate symlink escapes the root must be refused")
+		}
+	})
+
+	// Empty keepWorkdir must not weaken the under-root guard (happy path).
+	if !safeToRemoveWorkdir(oldGen, root, "") {
 		t.Fatal("a valid under-root dir must be removable even with no keep workdir")
 	}
-	if safeToRemoveWorkdir("/etc", root, "") {
+	if safeToRemoveWorkdir(outside, root, "") {
 		t.Fatal("a path outside the root must never be removable")
 	}
 }

--- a/daemon/internal/osadapter/argv_test.go
+++ b/daemon/internal/osadapter/argv_test.go
@@ -1,6 +1,9 @@
 package osadapter
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 // TestWorkdirFromBinary covers the FEATURE 14 / ADR-0018 workdir recovery and
 // its edge guards: filepath.Dir yields "." for a relative path and "/" for a
@@ -27,5 +30,67 @@ func TestWorkdirFromBinary(t *testing.T) {
 				t.Fatalf("WorkdirFromBinary(%q) = %q, want %q", c.self, got, c.want)
 			}
 		})
+	}
+}
+
+// TestHasMeshFlag covers the FEATURE 17 generation-membership corroboration:
+// a worker argv (carries --mesh) is recognised; an ensure argv (`ensure`, no
+// --mesh) and an empty argv are not.
+func TestHasMeshFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{"worker run --mesh", []string{"/bin/x", "run", "--r", "a", "--mesh"}, true},
+		{"ensure (no mesh)", []string{"/bin/x", "ensure"}, false},
+		{"unrelated", []string{"/bin/x", "--github", "o/r"}, false},
+		{"empty", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasMeshFlag(c.argv); got != c.want {
+				t.Fatalf("hasMeshFlag(%v) = %v, want %v", c.argv, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSafeToRemoveWorkdir pins the os.RemoveAll guard for generation cleanup
+// (FEATURE 17, Item 3): only an absolute path STRICTLY under the support root,
+// that is neither the keep workdir nor an ancestor of it, may be removed.
+func TestSafeToRemoveWorkdir(t *testing.T) {
+	root := "/Library/Application Support"
+	keep := filepath.Join(root, ".keepgen.aaaa")
+	cases := []struct {
+		name string
+		dir  string
+		want bool
+	}{
+		{"valid old generation", filepath.Join(root, ".oldgen.bbbb"), true},
+		{"valid nested old generation", filepath.Join(root, ".oldgen.bbbb", "bin"), true},
+		{"empty dir", "", false},
+		{"relative dir", "oldgen", false},
+		{"the support root itself", root, false},
+		{"outside the support root", "/Library/LaunchDaemons/x", false},
+		{"escape via traversal sibling", "/Library/Application SupportXX/y", false},
+		{"the keep workdir", keep, false},
+		{"ancestor of keep (== root parent)", "/Library", false},
+		{"ancestor of keep (root)", root, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := safeToRemoveWorkdir(c.dir, root, keep); got != c.want {
+				t.Fatalf("safeToRemoveWorkdir(%q) = %v, want %v", c.dir, got, c.want)
+			}
+		})
+	}
+
+	// Empty keepWorkdir must not weaken the under-root guard.
+	if !safeToRemoveWorkdir(filepath.Join(root, ".g.cccc"), root, "") {
+		t.Fatal("a valid under-root dir must be removable even with no keep workdir")
+	}
+	if safeToRemoveWorkdir("/etc", root, "") {
+		t.Fatal("a path outside the root must never be removable")
 	}
 }

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -325,6 +326,180 @@ func UninstallProd() (removed []string, err error) {
 	return removed, nil
 }
 
+// Generation is one distinct, on-disk focusd mesh install identified by its
+// Ed25519-verified binary path (FEATURE 17, Item 3). A path-rotating
+// self-update or a wiped-state reinstall can leave multiple generations'
+// plists in the LaunchDir at once; cleanup retires all but the surviving one.
+type Generation struct {
+	BinaryPath string   // the shared, Ed25519-verified ProgramArguments[0]
+	Workdir    string   // Dir(BinaryPath) — the disguised binary lives in it
+	Labels     []string // every label whose plist points at BinaryPath
+	PlistPaths []string // aligned with Labels (same scan order)
+}
+
+// genAccum accumulates one generation's plists during the scan.
+type genAccum struct {
+	binaryPath string
+	workdir    string
+	labels     []string
+	plistPaths []string
+	meshSeen   bool // at least one plist carried the --mesh worker marker
+}
+
+// DiscoverAllGenerations scans the LaunchDir for the mode and groups every
+// genuine focusd plist by its DISTINCT Ed25519-verified binary path. The
+// signature check on ProgramArguments[0] is the authoritative safety belt — a
+// real third-party/vendor binary never verifies against our embedded key, so
+// no unrelated launchd job can ever be grouped (let alone retired). The
+// --mesh marker is a corroborating signal: a binary is treated as a real mesh
+// generation only when at least one of its plists carries --mesh (the ensure
+// role's `ensure` argv has none, but it is grouped in via the shared verified
+// binary). The out-of-band watchdog has NO LaunchDir plist (it is cron-driven)
+// so it is never seen here — by construction it can never be discovered or
+// retired. verify is the signature seam (nil ⇒ sig.VerifyFile); tests inject
+// a fake. Generations are returned in first-seen order.
+func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) {
+	if verify == nil {
+		verify = sig.VerifyFile
+	}
+	home, _ := os.UserHomeDir()
+	laDir := mode.LaunchDir(m, home)
+	entries, rerr := os.ReadDir(laDir)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return nil, nil
+		}
+		return nil, rerr
+	}
+	var order []string // binary paths in first-seen order
+	byBin := map[string]*genAccum{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
+			continue
+		}
+		pp := filepath.Join(laDir, e.Name())
+		label, bin, argv := parsePlist(pp)
+		if label == "" || bin == "" {
+			continue
+		}
+		if ok, verr := verify(bin); verr != nil || !ok {
+			continue // not a genuine focusd binary → never a generation
+		}
+		g := byBin[bin]
+		if g == nil {
+			g = &genAccum{binaryPath: bin, workdir: WorkdirFromBinary(bin)}
+			byBin[bin] = g
+			order = append(order, bin)
+		}
+		g.labels = append(g.labels, label)
+		g.plistPaths = append(g.plistPaths, pp)
+		if hasMeshFlag(argv) {
+			g.meshSeen = true
+		}
+	}
+	var out []Generation
+	for _, bin := range order {
+		g := byBin[bin]
+		if !g.meshSeen {
+			continue // verified binary but no --mesh plist → not a real mesh
+		}
+		out = append(out, Generation{
+			BinaryPath: g.binaryPath,
+			Workdir:    g.workdir,
+			Labels:     g.labels,
+			PlistPaths: g.plistPaths,
+		})
+	}
+	return out, nil
+}
+
+// RetireOtherGenerations discovers every focusd generation and tears down each
+// one whose binary path differs from keepBinaryPath (FEATURE 17, Item 3). For
+// each retired generation it boots out every label, removes every plist, best-
+// effort kills the old binary's processes, and (GUARDED by safeToRemoveWorkdir)
+// removes the old workdir. Best-effort throughout: it returns ONLY the count of
+// retired generations (never the disguised labels/paths), and a single retire
+// step's failure does not abort the rest. Called AFTER a successful install so
+// the new generation is already up; NEVER from the self-update path (in-place
+// rotation transiently looks like two generations).
+func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
+	gens, err := DiscoverAllGenerations(m, sig.VerifyFile)
+	if err != nil {
+		return 0, err
+	}
+	home, _ := os.UserHomeDir()
+	root := mode.SupportRoot(m, home)
+	c := launchctlCtl{m: m}
+	return retireGenerations(gens, keepBinaryPath, root,
+		c.bootout, os.Remove, pkillBinary, os.RemoveAll), nil
+}
+
+// retireGenerations is the seam-injected core of RetireOtherGenerations, split
+// out so the teardown ordering + the os.RemoveAll path-sanity gating are unit-
+// tested with fakes (no real launchd / FS deletion). bootout/removePlist/
+// killBin/removeAll are the side-effecting seams. Returns the number of
+// generations retired (those whose BinaryPath != keepBinaryPath).
+func retireGenerations(
+	gens []Generation, keepBinaryPath, supportRoot string,
+	bootout func(string) error,
+	removePlist func(string) error,
+	killBin func(string),
+	removeAll func(string) error,
+) int {
+	keepWorkdir := ""
+	if keepBinaryPath != "" {
+		keepWorkdir = filepath.Dir(keepBinaryPath)
+	}
+	retired := 0
+	for _, g := range gens {
+		if g.BinaryPath == keepBinaryPath {
+			continue // the surviving generation — never retire it
+		}
+		for i, lbl := range g.Labels {
+			_ = bootout(lbl)
+			if i < len(g.PlistPaths) {
+				_ = removePlist(g.PlistPaths[i])
+			}
+		}
+		if g.BinaryPath != "" {
+			killBin(g.BinaryPath) // best-effort; no surviving daemon shares this path
+		}
+		// GUARD: only RemoveAll a workdir that is strictly under the mode's
+		// support root, is not the keep workdir, and is not an ancestor of it.
+		if safeToRemoveWorkdir(g.Workdir, supportRoot, keepWorkdir) {
+			_ = removeAll(g.Workdir)
+		}
+		retired++
+	}
+	return retired
+}
+
+// pkillBinary best-effort kills any process whose argv matches bin. Used only
+// during generation retirement, where the binary is about to be removed and no
+// surviving daemon shares its (rotated) path.
+func pkillBinary(bin string) { _ = exec.Command("pkill", "-f", bin).Run() }
+
+// plutilToXML converts a (possibly binary-format) plist to XML on stdout via
+// `plutil -convert xml1`. Returns "" on any failure so callers degrade to the
+// raw bytes instead of crashing.
+func plutilToXML(path string) string {
+	out, err := exec.Command("plutil", "-convert", "xml1", "-o", "-", path).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// interTagSpaceRE matches whitespace between two adjacent XML tags.
+var interTagSpaceRE = regexp.MustCompile(`>\s+<`)
+
+// collapseInterTagSpace removes whitespace between adjacent tags so plutil's
+// multi-line xml1 output (e.g. "</key>\n<string>") presents the
+// "</key><string>" / "<array><string>" adjacency the substring scanner in
+// parsePlist expects. Values inside a single <string> element have no inner
+// tags, so they are untouched.
+func collapseInterTagSpace(s string) string { return interTagSpaceRE.ReplaceAllString(s, "><") }
+
 // parsePlist extracts the Label, the first ProgramArguments string
 // (the binary path) and the full argv (binary path + arguments) from
 // one of our generated plists. argv[0] == bin; len(argv) == 0 on parse
@@ -335,6 +510,18 @@ func parsePlist(path string) (label, bin string, argv []string) {
 		return "", "", nil
 	}
 	s := string(b)
+	// Harden against BINARY-format plists (FEATURE 17): the substring scanner
+	// below only understands XML. A binary plist (magic "bplist00") or any
+	// non-XML content is converted via `plutil -convert xml1` first; the
+	// converted output is whitespace-normalized so the "</key><string>" /
+	// "<array><string>" adjacency the scanner expects holds. Degrade, don't
+	// crash: on any plutil failure we keep the raw bytes and the scan simply
+	// finds nothing (the plist is skipped).
+	if !strings.Contains(s, "<plist") {
+		if conv := plutilToXML(path); conv != "" {
+			s = collapseInterTagSpace(conv)
+		}
+	}
 	label = between(s, "<key>Label</key><string>", "</string>")
 	i := strings.Index(s, "<key>ProgramArguments</key><array>")
 	if i < 0 {

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -423,6 +423,13 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 // the new generation is already up; NEVER from the self-update path (in-place
 // rotation transiently looks like two generations).
 func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
+	// Refuse to retire ANYTHING without a surviving generation to keep: an
+	// empty keepBinaryPath would make every discovered generation "other" and
+	// tear the whole mesh down (the bootout + os.RemoveAll blast radius). A
+	// caller with no keep target is a bug, not a request to wipe everything.
+	if keepBinaryPath == "" {
+		return 0, fmt.Errorf("retire: keepBinaryPath must not be empty")
+	}
 	gens, err := DiscoverAllGenerations(m, sig.VerifyFile)
 	if err != nil {
 		return 0, err
@@ -446,10 +453,12 @@ func retireGenerations(
 	killBin func(string),
 	removeAll func(string) error,
 ) int {
-	keepWorkdir := ""
-	if keepBinaryPath != "" {
-		keepWorkdir = filepath.Dir(keepBinaryPath)
+	// Defense in depth (mirrors RetireOtherGenerations): with no keep target
+	// EVERY generation would be "other" and get torn down. Retire nothing.
+	if keepBinaryPath == "" {
+		return 0
 	}
+	keepWorkdir := filepath.Dir(keepBinaryPath)
 	retired := 0
 	for _, g := range gens {
 		if g.BinaryPath == keepBinaryPath {

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -26,6 +26,24 @@ type Verifier func(path string) (bool, error)
 func FindCurrentInstall(mode.Mode, Verifier) (CurInstall, error) {
 	return CurInstall{}, ErrUnsupported
 }
+
+// Generation mirrors the darwin definition so cross-platform code that
+// references it compiles on non-darwin (where discovery is unsupported).
+type Generation struct {
+	BinaryPath string
+	Workdir    string
+	Labels     []string
+	PlistPaths []string
+}
+
+func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, error) {
+	return nil, ErrUnsupported
+}
+
+// RetireOtherGenerations is a no-op on non-darwin (no launchd mesh to retire).
+// It returns (0, nil) so the cross-platform install path treats it as "nothing
+// to do" rather than surfacing ErrUnsupported on every install.
+func RetireOtherGenerations(mode.Mode, string) (int, error) { return 0, nil }
 func MeshStatus(mode.Mode) (loaded, total int, found bool, err error) {
 	return 0, 0, false, ErrUnsupported
 }

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -1,0 +1,264 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// writeGeneration writes the three mesh plists for one generation into laDir,
+// with the disguised binary living inside its own workdir (mirrors
+// relocate.RelocateInto). Returns the binary path + workdir.
+func writeGeneration(t *testing.T, home, laDir, tag string, roster []string) (binPath, wd string) {
+	t.Helper()
+	wd = filepath.Join(home, "Library", "Application Support", "."+tag)
+	binPath = filepath.Join(wd, tag+".bin")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON-"+tag), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: wd, Roster: roster}
+	for _, r := range AllRoles {
+		pp := filepath.Join(laDir, s.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(s, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return binPath, wd
+}
+
+func laDirUnderHome(t *testing.T) (home, laDir string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	laDir = filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return home, laDir
+}
+
+// TestDiscoverAllGenerationsGroupsByVerifiedBinary: two generations + one
+// unrelated (non-verifying) plist. Discovery groups by verified binary path,
+// yields exactly the two generations (3 plists each), and ignores the vendor
+// plist entirely.
+func TestDiscoverAllGenerationsGroupsByVerifiedBinary(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+	roster1 := []string{"com.apple.metadata.helper.1111", "com.google.keystone.daemon.1112", "org.mozilla.updater.agent.1113"}
+	roster2 := []string{"com.docker.helper.2221", "us.zoom.ZoomDaemon.svc.2222", "io.tailscale.ipnextension.relay.2223"}
+	bin1, wd1 := writeGeneration(t, home, laDir, "gen1", roster1)
+	bin2, wd2 := writeGeneration(t, home, laDir, "gen2", roster2)
+
+	// An unrelated vendor plist whose binary the verifier rejects.
+	vendorBin := filepath.Join(home, "vendor", "thing")
+	if err := os.MkdirAll(filepath.Dir(vendorBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vendorBin, []byte("VENDOR"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vs := Spec{Mode: mode.User, SelfPath: vendorBin, Workdir: filepath.Dir(vendorBin),
+		Roster: []string{"com.vendor.a", "com.vendor.b", "com.vendor.c"}}
+	for _, r := range AllRoles {
+		pp := filepath.Join(laDir, vs.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(vs, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verifier accepts ONLY the two real generation binaries.
+	verify := Verifier(func(p string) (bool, error) { return p == bin1 || p == bin2, nil })
+
+	gens, err := DiscoverAllGenerations(mode.User, verify)
+	if err != nil {
+		t.Fatalf("DiscoverAllGenerations: %v", err)
+	}
+	if len(gens) != 2 {
+		t.Fatalf("want 2 generations, got %d: %+v", len(gens), gens)
+	}
+	byBin := map[string]Generation{}
+	for _, g := range gens {
+		byBin[g.BinaryPath] = g
+	}
+	for bin, wd := range map[string]string{bin1: wd1, bin2: wd2} {
+		g, ok := byBin[bin]
+		if !ok {
+			t.Fatalf("generation for %q missing", bin)
+		}
+		if g.Workdir != wd {
+			t.Errorf("workdir = %q, want %q", g.Workdir, wd)
+		}
+		if len(g.Labels) != 3 || len(g.PlistPaths) != 3 {
+			t.Errorf("generation %q: want 3 labels/plists, got %d/%d", bin, len(g.Labels), len(g.PlistPaths))
+		}
+	}
+}
+
+// TestDiscoverAllGenerationsExcludesNonMesh: a verified binary whose only plist
+// is the ensure role (`ensure` — no --mesh) is NOT a real mesh generation and
+// must be dropped. This pins the regression that a non-mesh plist is never
+// retired.
+func TestDiscoverAllGenerationsExcludesNonMesh(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+	wd := filepath.Join(home, "Library", "Application Support", ".ensureonly")
+	binPath := filepath.Join(wd, "ensureonly.bin")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("FAKE-DAEMON"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: wd,
+		Roster: []string{"com.a.x", "com.b.y", "com.c.z"}}
+	// Only the ensure plist (no --mesh) is present.
+	pp := filepath.Join(laDir, s.Label(RoleEnsure)+".plist")
+	if err := os.WriteFile(pp, []byte(Plist(s, RoleEnsure)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
+	gens, err := DiscoverAllGenerations(mode.User, verify)
+	if err != nil {
+		t.Fatalf("DiscoverAllGenerations: %v", err)
+	}
+	if len(gens) != 0 {
+		t.Fatalf("a verified-but-non-mesh generation must be excluded, got %+v", gens)
+	}
+}
+
+// TestDiscoverAllGenerationsNoLaunchDir: a missing LaunchAgents dir yields zero
+// generations and no error.
+func TestDiscoverAllGenerationsNoLaunchDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	gens, err := DiscoverAllGenerations(mode.User, Verifier(func(string) (bool, error) { return false, nil }))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(gens) != 0 {
+		t.Fatalf("want zero generations, got %+v", gens)
+	}
+}
+
+// fakeRetire records the side effects of retireGenerations.
+type fakeRetire struct {
+	bootedOut    []string
+	removedPlist []string
+	killed       []string
+	removedAll   []string
+}
+
+// TestRetireGenerationsKeepsKeepRetiresOthers: the keep generation is never
+// touched; every other generation is booted out + plists removed + binary
+// killed, and its workdir is RemoveAll'd ONLY when path-sanity allows.
+func TestRetireGenerationsKeepsKeepRetiresOthers(t *testing.T) {
+	root := "/Library/Application Support"
+	keepBin := filepath.Join(root, ".keep", "keep.bin")
+	keepWorkdir := filepath.Dir(keepBin)
+
+	gens := []Generation{
+		{ // surviving generation — must be skipped entirely
+			BinaryPath: keepBin, Workdir: keepWorkdir,
+			Labels:     []string{"k1", "k2", "k3"},
+			PlistPaths: []string{"/p/k1", "/p/k2", "/p/k3"},
+		},
+		{ // old generation with a SAFE workdir → fully retired incl. RemoveAll
+			BinaryPath: filepath.Join(root, ".old1", "old1.bin"),
+			Workdir:    filepath.Join(root, ".old1"),
+			Labels:     []string{"o1a", "o1b", "o1c"},
+			PlistPaths: []string{"/p/o1a", "/p/o1b", "/p/o1c"},
+		},
+		{ // old generation with an UNSAFE workdir (outside root) → no RemoveAll
+			BinaryPath: "/somewhere/else/old2.bin",
+			Workdir:    "/somewhere/else",
+			Labels:     []string{"o2a"},
+			PlistPaths: []string{"/p/o2a"},
+		},
+	}
+
+	f := &fakeRetire{}
+	n := retireGenerations(gens, keepBin, root,
+		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
+		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
+		func(b string) { f.killed = append(f.killed, b) },
+		func(d string) error { f.removedAll = append(f.removedAll, d); return nil },
+	)
+
+	if n != 2 {
+		t.Fatalf("retired count = %d, want 2", n)
+	}
+	// Keep generation untouched.
+	for _, l := range f.bootedOut {
+		if l == "k1" || l == "k2" || l == "k3" {
+			t.Fatalf("keep generation label %q must never be booted out", l)
+		}
+	}
+	if contains(f.removedAll, keepWorkdir) {
+		t.Fatalf("keep workdir must never be RemoveAll'd")
+	}
+	// Old1 fully retired including its (safe) workdir.
+	if !contains(f.removedAll, filepath.Join(root, ".old1")) {
+		t.Fatalf("safe old1 workdir must be RemoveAll'd, got %v", f.removedAll)
+	}
+	// Old2's unsafe workdir must NOT be removed, but it is still booted out.
+	if contains(f.removedAll, "/somewhere/else") {
+		t.Fatalf("unsafe workdir must NOT be RemoveAll'd, got %v", f.removedAll)
+	}
+	if !contains(f.bootedOut, "o2a") {
+		t.Fatalf("old2 label must still be booted out, got %v", f.bootedOut)
+	}
+	if !contains(f.killed, "/somewhere/else/old2.bin") {
+		t.Fatalf("old2 binary must be killed, got %v", f.killed)
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestParsePlistBinaryFormat: a BINARY-format plist (the real-world hardening
+// case) is converted via plutil and parsed correctly — label, binary path, and
+// argv (including --mesh) are all recovered.
+func TestParsePlistBinaryFormat(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "com.apple.metadata.helper.bbbb")
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: dir,
+		Roster: []string{"com.apple.metadata.helper.1", "com.google.keystone.daemon.2", "org.mozilla.updater.agent.3"}}
+	plistPath := filepath.Join(dir, "gen.plist")
+	if err := os.WriteFile(plistPath, []byte(Plist(s, RoleA)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Convert the on-disk plist to BINARY format in place.
+	if out, err := exec.Command("plutil", "-convert", "binary1", plistPath).CombinedOutput(); err != nil {
+		t.Skipf("plutil unavailable or failed (%v): %s", err, out)
+	}
+	// Sanity: it really is binary now (raw scan would fail).
+	raw, _ := os.ReadFile(plistPath)
+	if strings.Contains(string(raw), "<plist") {
+		t.Fatal("expected a binary plist, but it still looks like XML")
+	}
+
+	label, bin, argv := parsePlist(plistPath)
+	if label != s.Label(RoleA) {
+		t.Errorf("label = %q, want %q", label, s.Label(RoleA))
+	}
+	if bin != binPath {
+		t.Errorf("bin = %q, want %q", bin, binPath)
+	}
+	if !hasMeshFlag(argv) {
+		t.Errorf("argv must carry --mesh, got %v", argv)
+	}
+}

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -158,11 +158,22 @@ type fakeRetire struct {
 
 // TestRetireGenerationsKeepsKeepRetiresOthers: the keep generation is never
 // touched; every other generation is booted out + plists removed + binary
-// killed, and its workdir is RemoveAll'd ONLY when path-sanity allows.
+// killed, and its workdir is RemoveAll'd ONLY when path-sanity allows. Uses
+// real on-disk dirs because safeToRemoveWorkdir now resolves symlinks (a
+// non-existent workdir is refused).
 func TestRetireGenerationsKeepsKeepRetiresOthers(t *testing.T) {
-	root := "/Library/Application Support"
-	keepBin := filepath.Join(root, ".keep", "keep.bin")
-	keepWorkdir := filepath.Dir(keepBin)
+	mkdir := func(p string) string {
+		t.Helper()
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	root := t.TempDir()
+	keepWorkdir := mkdir(filepath.Join(root, ".keep"))
+	keepBin := filepath.Join(keepWorkdir, "keep.bin")
+	old1Workdir := mkdir(filepath.Join(root, ".old1")) // SAFE: real, under root
+	old2Workdir := t.TempDir()                         // UNSAFE: real, outside root
 
 	gens := []Generation{
 		{ // surviving generation — must be skipped entirely
@@ -171,14 +182,14 @@ func TestRetireGenerationsKeepsKeepRetiresOthers(t *testing.T) {
 			PlistPaths: []string{"/p/k1", "/p/k2", "/p/k3"},
 		},
 		{ // old generation with a SAFE workdir → fully retired incl. RemoveAll
-			BinaryPath: filepath.Join(root, ".old1", "old1.bin"),
-			Workdir:    filepath.Join(root, ".old1"),
+			BinaryPath: filepath.Join(old1Workdir, "old1.bin"),
+			Workdir:    old1Workdir,
 			Labels:     []string{"o1a", "o1b", "o1c"},
 			PlistPaths: []string{"/p/o1a", "/p/o1b", "/p/o1c"},
 		},
 		{ // old generation with an UNSAFE workdir (outside root) → no RemoveAll
-			BinaryPath: "/somewhere/else/old2.bin",
-			Workdir:    "/somewhere/else",
+			BinaryPath: filepath.Join(old2Workdir, "old2.bin"),
+			Workdir:    old2Workdir,
 			Labels:     []string{"o2a"},
 			PlistPaths: []string{"/p/o2a"},
 		},
@@ -205,18 +216,52 @@ func TestRetireGenerationsKeepsKeepRetiresOthers(t *testing.T) {
 		t.Fatalf("keep workdir must never be RemoveAll'd")
 	}
 	// Old1 fully retired including its (safe) workdir.
-	if !contains(f.removedAll, filepath.Join(root, ".old1")) {
+	if !contains(f.removedAll, old1Workdir) {
 		t.Fatalf("safe old1 workdir must be RemoveAll'd, got %v", f.removedAll)
 	}
 	// Old2's unsafe workdir must NOT be removed, but it is still booted out.
-	if contains(f.removedAll, "/somewhere/else") {
+	if contains(f.removedAll, old2Workdir) {
 		t.Fatalf("unsafe workdir must NOT be RemoveAll'd, got %v", f.removedAll)
 	}
 	if !contains(f.bootedOut, "o2a") {
 		t.Fatalf("old2 label must still be booted out, got %v", f.bootedOut)
 	}
-	if !contains(f.killed, "/somewhere/else/old2.bin") {
+	if !contains(f.killed, filepath.Join(old2Workdir, "old2.bin")) {
 		t.Fatalf("old2 binary must be killed, got %v", f.killed)
+	}
+}
+
+// TestRetireGenerationsNoopOnEmptyKeep: an empty keepBinaryPath is a bug, not a
+// request to wipe everything. With a real generation present and no keep target,
+// retireGenerations must retire NOTHING and never touch launchd/FS — otherwise
+// the empty keep would make every generation "other" and tear the mesh down
+// (ROOT bootout + os.RemoveAll blast radius).
+func TestRetireGenerationsNoopOnEmptyKeep(t *testing.T) {
+	root := t.TempDir()
+	gens := []Generation{
+		{
+			BinaryPath: filepath.Join(root, ".only", "only.bin"),
+			Workdir:    filepath.Join(root, ".only"),
+			Labels:     []string{"a", "b", "c"},
+			PlistPaths: []string{"/p/a", "/p/b", "/p/c"},
+		},
+	}
+	f := &fakeRetire{}
+	n := retireGenerations(gens, "", root,
+		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
+		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
+		func(b string) { f.killed = append(f.killed, b) },
+		func(d string) error { f.removedAll = append(f.removedAll, d); return nil },
+	)
+	if n != 0 {
+		t.Fatalf("empty keep must retire 0, got %d", n)
+	}
+	if len(f.bootedOut) != 0 {
+		t.Fatalf("empty keep must never bootout, got %v", f.bootedOut)
+	}
+	if len(f.removedPlist) != 0 || len(f.killed) != 0 || len(f.removedAll) != 0 {
+		t.Fatalf("empty keep must have zero side effects, got plist=%v killed=%v removedAll=%v",
+			f.removedPlist, f.killed, f.removedAll)
 	}
 }
 


### PR DESCRIPTION
Fixes the live incident: deleting the workdir lost the desired version → daemon BLOCKED → no platform recovery; repeated installs piled up 6 generations / 2 platforms.

- **Baked fallback platform version**: no on-disk desired → adopt the compiled-in fallback, re-fetch, run (no BLOCK). Floor-not-ceiling (install/update still roll forward).
- **Global singleton**: platform flock moved to a fixed mode-keyed path (survives workdir rotation) so generations can't each run a platform.
- **Idempotent install / generation cleanup**: on install, retire other generations (bootout + rm plist + pkill + guarded RemoveAll), gated by Ed25519-verify + the `--mesh` marker (never touches legit vendors despite the name disguise) + symlink-resolved path-sanity (the root RemoveAll is hardened: refuses empty-keep, relative/symlinked/outside-SupportRoot targets).

go+local-reviewed (3 HIGH root-RemoveAll issues fixed). Verified live against the teardown matrix (TC-14 workdir-delete recovers, TC-19 no pileup) post-merge.