### PR TITLE
fix(kill-steam): remove Dota2/Steam data every run, not only when Steam.app present

### DIFF
--- a/plugins/kill-steam/internal/uninstaller/uninstaller.go
+++ b/plugins/kill-steam/internal/uninstaller/uninstaller.go
@@ -78,15 +78,15 @@ func (r *Reconciler) Detect() bool {
 	return err == nil
 }
 
-// Reconcile is the full pass: detect, then if found, sweep every known
-// Steam artifact (system + per-user). Idempotent — noop when Steam is
-// not installed; total removal when it is.
+// Reconcile is the full pass: sweep every known Steam artifact (system +
+// per-user) EVERY run, regardless of whether Steam.app is present. Gating on
+// Steam.app let the game data survive — e.g. Steam.app removed but the library
+// `~/Library/Application Support/Steam/steamapps/common/dota 2 beta` (Dota 2,
+// tens of GB) still on disk and re-launchable. Each removal is os.Stat-gated,
+// so a clean steady-state pass is cheap and idempotent; a pass with leftover
+// Dota 2 / Steam data removes it. (Detected is kept as informational only.)
 func (r *Reconciler) Reconcile() Outcome {
 	o := Outcome{Detected: r.Detect()}
-	if !o.Detected {
-		o.Reason = "noop (no Steam.app)"
-		return o
-	}
 
 	for _, t := range r.systemTargets() {
 		r.tryRemove(t.Path, t.What, &o)
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile() Outcome {
 
 	switch len(o.Removed) {
 	case 0:
-		o.Reason = "detected but nothing to remove (likely already partial)"
+		o.Reason = "clean (no Steam/Dota artifacts present)"
 	default:
 		o.Reason = fmt.Sprintf("removed %d artifact(s)", len(o.Removed))
 	}
@@ -179,6 +179,9 @@ func (r *Reconciler) perUserTargets() []perUserTarget {
 func (r *Reconciler) findUserHomes() ([]string, error) {
 	entries, err := os.ReadDir(r.usersDir())
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // no users dir (e.g. non-macOS / CI) → nothing to sweep
+		}
 		return nil, err
 	}
 	var homes []string

--- a/plugins/kill-steam/internal/uninstaller/uninstaller_test.go
+++ b/plugins/kill-steam/internal/uninstaller/uninstaller_test.go
@@ -7,7 +7,15 @@ import (
 )
 
 func TestDetect_AbsentIsCheap(t *testing.T) {
-	r := &Reconciler{AppPath: filepath.Join(t.TempDir(), "does-not-exist.app")}
+	// UsersDir MUST be a temp dir, not the default real /Users — Reconcile now
+	// always sweeps (no Steam.app gate), so a real /Users would delete the dev's
+	// actual Steam data and make this assertion machine-dependent.
+	root := t.TempDir()
+	r := &Reconciler{
+		AppPath:  filepath.Join(root, "does-not-exist.app"),
+		UsersDir: filepath.Join(root, "Users"), // empty → nothing to sweep
+		System:   []systemTarget{},
+	}
 	if r.Detect() {
 		t.Fatal("expected Detect() false when AppPath missing")
 	}
@@ -68,6 +76,50 @@ func TestReconcile_RemovesEverything(t *testing.T) {
 	// didn't crash). At least one removal recorded:
 	if len(o.Removed) < 3 {
 		t.Fatalf("expected ≥3 removals, got %d: %+v", len(o.Removed), o.Removed)
+	}
+}
+
+// TestReconcile_RemovesDataWhenAppAbsent locks the gap fix: the plugin must
+// remove the Steam library (incl. Dota 2) on EVERY pass even when Steam.app is
+// already gone. Gating removal on Steam.app let tens of GB of Dota 2 game data
+// survive under ~/Library/Application Support/Steam/steamapps/common/dota 2 beta
+// and stay re-launchable.
+func TestReconcile_RemovesDataWhenAppAbsent(t *testing.T) {
+	root := t.TempDir()
+	usersDir := filepath.Join(root, "Users")
+	appdata := filepath.Join(usersDir, "alice", "Library", "Application Support", "Steam")
+	os.MkdirAll(filepath.Join(appdata, "steamapps", "common", "dota 2 beta"), 0o755)
+	r := &Reconciler{
+		AppPath:  filepath.Join(root, "Apps", "Steam.app"), // does NOT exist
+		UsersDir: usersDir,
+		System:   []systemTarget{}, // no system target for this case
+	}
+	o := r.Reconcile()
+	if o.Detected {
+		t.Fatal("Steam.app absent → Detected should be false")
+	}
+	if len(o.Removed) == 0 {
+		t.Fatal("must remove the Steam library (incl Dota 2) even when Steam.app is absent")
+	}
+	if _, err := os.Stat(appdata); !os.IsNotExist(err) {
+		t.Fatal("Steam library (incl Dota 2) must be removed when Steam.app is absent")
+	}
+}
+
+// TestReconcile_MissingUsersDirIsClean: on a non-macOS host (CI ubuntu has no
+// /Users) the always-sweep pass must NOT report an error — a missing users dir
+// just means "no per-user artifacts to sweep". Regression for the CI break that
+// removing the Steam.app gate introduced.
+func TestReconcile_MissingUsersDirIsClean(t *testing.T) {
+	root := t.TempDir()
+	r := &Reconciler{
+		AppPath:  filepath.Join(root, "Steam.app"), // absent
+		UsersDir: filepath.Join(root, "Users"),     // absent
+		System:   []systemTarget{},
+	}
+	o := r.Reconcile()
+	if len(o.Errors) != 0 {
+		t.Fatalf("missing users dir must not error (non-macOS/CI): %v", o.Errors)
 	}
 }
 


### PR DESCRIPTION
The reconciler gated ALL removal on Steam.app existing — so once Steam.app was gone, the ~71GB Steam library (incl. `steamapps/common/dota 2 beta`) survived and Dota2 stayed re-launchable (the owner hit exactly this). Now it sweeps every Steam/Dota target each run; each removal is `os.Stat`-gated so a clean pass stays cheap. Regression test added (Steam.app absent + Dota2 data present → removed). KISS: covers the default Steam location; custom-folder installs remain out of scope per the owner.