### PR TITLE
feat(daemon): F19 deeper disguise (hide --mesh argv) + F17 convergence fix (TC-21)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -69,8 +69,20 @@ func main() { os.Exit(run(os.Args[1:])) }
 
 func run(args []string) int {
 	if len(args) == 0 {
-		usage()
-		return 2
+		// PROD launchd start (FEATURE 19): the minimized plist's
+		// ProgramArguments is the binary alone — the role/mesh marker rides in
+		// the plist's EnvironmentVariables (off-argv, hidden from `ps`).
+		// Reconstruct the legacy subcommand argv from that env var so every
+		// downstream path (parse/loop/doEnsure) sees exactly the argv it always
+		// did. A missing or malformed var yields nil → fall through to usage()
+		// unchanged (a human `daemon <cmd>` always passes non-empty argv and so
+		// never reaches this branch).
+		if synth := osadapter.ArgvFromEnv(); len(synth) > 0 {
+			args = synth
+		} else {
+			usage()
+			return 2
+		}
 	}
 	switch args[0] {
 	case "version", "-v", "--version":

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -4,8 +4,10 @@ package osadapter
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -339,6 +341,21 @@ type Generation struct {
 	PlistPaths []string // aligned with Labels (same scan order)
 }
 
+// DeadGeneration is a focusd mesh generation whose binary has been DELETED —
+// the zombie left behind by a workdir-delete/recovery cycle (FEATURE 17
+// follow-up, TC-21). Its ProgramArguments[0] names a path that no longer
+// exists, so it can NOT be Ed25519-verified; the only signal that it is ours is
+// the mesh worker marker on at least one of its plists. Its launchd entries and
+// orphan platform/daemon processes still reference the (now-dangling) binary
+// path in their argv, so retirement boots out the labels, removes the plists,
+// and pkill-matches the dangling path to reap the orphans.
+type DeadGeneration struct {
+	BinaryPath string   // the DELETED ProgramArguments[0] path (still in the plist + the orphans' argv)
+	Workdir    string   // Dir(BinaryPath) — may itself be gone (then RemoveAll is a guarded no-op)
+	Labels     []string // every label whose plist points at the dead BinaryPath
+	PlistPaths []string // aligned with Labels (same scan order)
+}
+
 // genAccum accumulates one generation's plists during the scan.
 type genAccum struct {
 	binaryPath string
@@ -362,7 +379,17 @@ type genAccum struct {
 // so it is never seen here — by construction it can never be discovered or
 // retired. verify is the signature seam (nil ⇒ sig.VerifyFile); tests inject
 // a fake. Generations are returned in first-seen order.
-func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) {
+//
+// FEATURE 17 follow-up (TC-21): a generation whose binary was DELETED by a
+// workdir-delete/recovery cycle can no longer be Ed25519-verified — os.ReadFile
+// returns ENOENT, so verify errors. Such a plist is NOT silently dropped (the
+// old behavior that let invisible-zombie generations + orphan platforms
+// accumulate). Instead it is grouped into the SECOND return value, the dead
+// generations, keyed by its dangling binary path and corroborated by the SAME
+// mesh worker marker — so a non-focusd vendor plist whose binary merely happens
+// to be absent is never treated as ours. A binary that EXISTS but fails the
+// signature (a genuine vendor binary) is still skipped, as before.
+func DiscoverAllGenerations(m mode.Mode, verify Verifier) (live []Generation, dead []DeadGeneration, err error) {
 	if verify == nil {
 		verify = sig.VerifyFile
 	}
@@ -371,29 +398,22 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 	entries, rerr := os.ReadDir(laDir)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, rerr
+		return nil, nil, rerr
 	}
-	var order []string // binary paths in first-seen order
+	var order []string // live binary paths in first-seen order
 	byBin := map[string]*genAccum{}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
-			continue
-		}
-		pp := filepath.Join(laDir, e.Name())
-		label, bin, argv, env := parsePlist(pp)
-		if label == "" || bin == "" {
-			continue
-		}
-		if ok, verr := verify(bin); verr != nil || !ok {
-			continue // not a genuine focusd binary → never a generation
-		}
-		g := byBin[bin]
+	var deadOrder []string // dead (deleted) binary paths in first-seen order
+	deadByBin := map[string]*genAccum{}
+	// accumulate groups one plist into the given bin-keyed map, mirroring the
+	// live and dead grouping so the corroboration logic is identical.
+	accumulate := func(into map[string]*genAccum, ord *[]string, bin, label, pp string, argv []string, env map[string]string) {
+		g := into[bin]
 		if g == nil {
 			g = &genAccum{binaryPath: bin, workdir: WorkdirFromBinary(bin)}
-			byBin[bin] = g
-			order = append(order, bin)
+			into[bin] = g
+			*ord = append(*ord, bin)
 		}
 		g.labels = append(g.labels, label)
 		g.plistPaths = append(g.plistPaths, pp)
@@ -405,20 +425,62 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 			g.meshSeen = true
 		}
 	}
-	var out []Generation
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".plist") {
+			continue
+		}
+		pp := filepath.Join(laDir, e.Name())
+		label, bin, argv, env := parsePlist(pp)
+		if label == "" || bin == "" {
+			continue
+		}
+		ok, verr := verify(bin)
+		switch {
+		case verr == nil && ok:
+			// Live generation: a present, Ed25519-verified binary.
+			accumulate(byBin, &order, bin, label, pp, argv, env)
+		case verr != nil && errors.Is(verr, fs.ErrNotExist):
+			// Dead generation: ProgramArguments[0] names a binary that no
+			// longer exists (its workdir was deleted by a recovery cycle). A
+			// file that is gone cannot be Ed25519-verified, so the mesh worker
+			// marker is the ONLY signal this orphan plist is ours — group +
+			// corroborate it exactly like a live generation, keyed by the
+			// (now-dangling) bin path so the sibling ensure plist (no marker)
+			// is swept in via the shared path.
+			accumulate(deadByBin, &deadOrder, bin, label, pp, argv, env)
+		default:
+			// ok==false: a binary that EXISTS but fails the signature (a real
+			// vendor binary) → never ours. A non-ENOENT verify error (a present
+			// but malformed/unreadable file) → cannot classify → skip. Either
+			// way, leave it untouched.
+			continue
+		}
+	}
 	for _, bin := range order {
 		g := byBin[bin]
 		if !g.meshSeen {
 			continue // verified binary but no --mesh plist → not a real mesh
 		}
-		out = append(out, Generation{
+		live = append(live, Generation{
 			BinaryPath: g.binaryPath,
 			Workdir:    g.workdir,
 			Labels:     g.labels,
 			PlistPaths: g.plistPaths,
 		})
 	}
-	return out, nil
+	for _, bin := range deadOrder {
+		g := deadByBin[bin]
+		if !g.meshSeen {
+			continue // deleted binary but no mesh marker → not ours (vendor)
+		}
+		dead = append(dead, DeadGeneration{
+			BinaryPath: g.binaryPath,
+			Workdir:    g.workdir,
+			Labels:     g.labels,
+			PlistPaths: g.plistPaths,
+		})
+	}
+	return live, dead, nil
 }
 
 // RetireOtherGenerations discovers every focusd generation and tears down each
@@ -430,6 +492,12 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 // step's failure does not abort the rest. Called AFTER a successful install so
 // the new generation is already up; NEVER from the self-update path (in-place
 // rotation transiently looks like two generations).
+//
+// FEATURE 17 follow-up (TC-21): it ALSO retires DEAD generations — zombies whose
+// binary was deleted by a workdir-delete/recovery cycle. Their launchd entries
+// and orphan platform/daemon processes persist invisibly otherwise (the old
+// "retired 1 while ≥2 live generations remain" bug). pkill -f against the
+// dangling binary path matches the orphans' argv and reaps them.
 func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
 	// Refuse to retire ANYTHING without a surviving generation to keep: an
 	// empty keepBinaryPath would make every discovered generation "other" and
@@ -438,14 +506,14 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
 	if keepBinaryPath == "" {
 		return 0, fmt.Errorf("retire: keepBinaryPath must not be empty")
 	}
-	gens, err := DiscoverAllGenerations(m, sig.VerifyFile)
+	gens, dead, err := DiscoverAllGenerations(m, sig.VerifyFile)
 	if err != nil {
 		return 0, err
 	}
 	home, _ := os.UserHomeDir()
 	root := mode.SupportRoot(m, home)
 	c := launchctlCtl{m: m}
-	return retireGenerations(gens, keepBinaryPath, root,
+	return retireGenerations(gens, dead, keepBinaryPath, root,
 		c.bootout, os.Remove, pkillBinary, os.RemoveAll), nil
 }
 
@@ -453,9 +521,10 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
 // out so the teardown ordering + the os.RemoveAll path-sanity gating are unit-
 // tested with fakes (no real launchd / FS deletion). bootout/removePlist/
 // killBin/removeAll are the side-effecting seams. Returns the number of
-// generations retired (those whose BinaryPath != keepBinaryPath).
+// generations retired (live others whose BinaryPath != keepBinaryPath, PLUS
+// every dead/zombie generation).
 func retireGenerations(
-	gens []Generation, keepBinaryPath, supportRoot string,
+	gens []Generation, dead []DeadGeneration, keepBinaryPath, supportRoot string,
 	bootout func(string) error,
 	removePlist func(string) error,
 	killBin func(string),
@@ -468,25 +537,42 @@ func retireGenerations(
 	}
 	keepWorkdir := filepath.Dir(keepBinaryPath)
 	retired := 0
+	// retire performs the common teardown — bootout every label, remove every
+	// plist, best-effort kill the binary's processes, and (GUARDED) RemoveAll
+	// the workdir. Shared by live-other and dead generations so the ordering +
+	// gating are identical.
+	retire := func(bin, workdir string, labels, plistPaths []string) {
+		for i, lbl := range labels {
+			_ = bootout(lbl)
+			if i < len(plistPaths) {
+				_ = removePlist(plistPaths[i])
+			}
+		}
+		if bin != "" {
+			killBin(bin) // best-effort; no surviving daemon shares this path
+		}
+		// GUARD: only RemoveAll a workdir that is strictly under the mode's
+		// support root, is not the keep workdir, and is not an ancestor of it.
+		if safeToRemoveWorkdir(workdir, supportRoot, keepWorkdir) {
+			_ = removeAll(workdir)
+		}
+		retired++
+	}
 	for _, g := range gens {
 		if g.BinaryPath == keepBinaryPath {
 			continue // the surviving generation — never retire it
 		}
-		for i, lbl := range g.Labels {
-			_ = bootout(lbl)
-			if i < len(g.PlistPaths) {
-				_ = removePlist(g.PlistPaths[i])
-			}
+		retire(g.BinaryPath, g.Workdir, g.Labels, g.PlistPaths)
+	}
+	// Dead/zombie generations: binary already deleted, so by construction never
+	// the keep (whose binary is present + verified). pkill -f against the
+	// dangling path reaps the orphan platform/daemon procs still showing it in
+	// argv. Defensive equality guard against a pathological keep == dead bin.
+	for _, d := range dead {
+		if d.BinaryPath == keepBinaryPath {
+			continue
 		}
-		if g.BinaryPath != "" {
-			killBin(g.BinaryPath) // best-effort; no surviving daemon shares this path
-		}
-		// GUARD: only RemoveAll a workdir that is strictly under the mode's
-		// support root, is not the keep workdir, and is not an ancestor of it.
-		if safeToRemoveWorkdir(g.Workdir, supportRoot, keepWorkdir) {
-			_ = removeAll(g.Workdir)
-		}
-		retired++
+		retire(d.BinaryPath, d.Workdir, d.Labels, d.PlistPaths)
 	}
 	return retired
 }

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -187,7 +187,9 @@ func FindCurrentInstall(m mode.Mode, verify Verifier) (CurInstall, error) {
 			continue
 		}
 		pp := filepath.Join(laDir, e.Name())
-		label, bin, argv := parsePlist(pp)
+		// FindCurrentInstall correlates on the Ed25519-verified binary path
+		// (argv[0]); the env marker is not needed here (discarded).
+		label, bin, argv, _ := parsePlist(pp)
 		if label == "" || bin == "" {
 			continue
 		}
@@ -350,11 +352,13 @@ type genAccum struct {
 // genuine focusd plist by its DISTINCT Ed25519-verified binary path. The
 // signature check on ProgramArguments[0] is the authoritative safety belt — a
 // real third-party/vendor binary never verifies against our embedded key, so
-// no unrelated launchd job can ever be grouped (let alone retired). The
-// --mesh marker is a corroborating signal: a binary is treated as a real mesh
-// generation only when at least one of its plists carries --mesh (the ensure
-// role's `ensure` argv has none, but it is grouped in via the shared verified
-// binary). The out-of-band watchdog has NO LaunchDir plist (it is cron-driven)
+// no unrelated launchd job can ever be grouped (let alone retired). The mesh
+// WORKER marker is a corroborating signal: a binary is treated as a real mesh
+// generation only when at least one of its plists is a worker — carrying the
+// FEATURE 19 env marker (MeshEnvKey="run:<role>") OR the legacy --mesh argv
+// (isFocusdMeshWorkerPlist). The ensure role's plist has neither, but it is
+// grouped in via the shared verified binary. The out-of-band watchdog has NO
+// LaunchDir plist (it is cron-driven)
 // so it is never seen here — by construction it can never be discovered or
 // retired. verify is the signature seam (nil ⇒ sig.VerifyFile); tests inject
 // a fake. Generations are returned in first-seen order.
@@ -378,7 +382,7 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 			continue
 		}
 		pp := filepath.Join(laDir, e.Name())
-		label, bin, argv := parsePlist(pp)
+		label, bin, argv, env := parsePlist(pp)
 		if label == "" || bin == "" {
 			continue
 		}
@@ -393,7 +397,11 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) ([]Generation, error) 
 		}
 		g.labels = append(g.labels, label)
 		g.plistPaths = append(g.plistPaths, pp)
-		if hasMeshFlag(argv) {
+		// FEATURE 19 union: a NEW plist corroborates via its env worker marker
+		// (MeshEnvKey="run:<role>"), an OLD plist via the legacy --mesh argv.
+		// The ensure role corroborates neither — an ensure-only generation is
+		// not a real mesh (preserved from FEATURE 17).
+		if isFocusdMeshWorkerPlist(env, argv) {
 			g.meshSeen = true
 		}
 	}
@@ -509,14 +517,19 @@ var interTagSpaceRE = regexp.MustCompile(`>\s+<`)
 // tags, so they are untouched.
 func collapseInterTagSpace(s string) string { return interTagSpaceRE.ReplaceAllString(s, "><") }
 
-// parsePlist extracts the Label, the first ProgramArguments string
-// (the binary path) and the full argv (binary path + arguments) from
-// one of our generated plists. argv[0] == bin; len(argv) == 0 on parse
-// failure.
-func parsePlist(path string) (label, bin string, argv []string) {
+// parsePlist extracts the Label, the first ProgramArguments string (the binary
+// path), the full argv (binary path + arguments), and the plist's
+// EnvironmentVariables map from one of our generated plists. argv[0] == bin;
+// len(argv) == 0 and env == nil on parse failure.
+//
+// FEATURE 19: the env map carries the mesh role marker (MeshEnvKey) that the
+// minimized prod argv no longer holds — DiscoverAllGenerations unions it with
+// the legacy --mesh argv marker so generation cleanup recognises both new and
+// old plists (see isFocusdMeshWorkerPlist).
+func parsePlist(path string) (label, bin string, argv []string, env map[string]string) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return "", "", nil
+		return "", "", nil, nil
 	}
 	s := string(b)
 	// Harden against BINARY-format plists (FEATURE 17): the substring scanner
@@ -531,10 +544,11 @@ func parsePlist(path string) (label, bin string, argv []string) {
 			s = collapseInterTagSpace(conv)
 		}
 	}
+	env = parseEnvDict(s)
 	label = between(s, "<key>Label</key><string>", "</string>")
 	i := strings.Index(s, "<key>ProgramArguments</key><array>")
 	if i < 0 {
-		return label, "", nil
+		return label, "", nil, env
 	}
 	// Walk the inner <string>...</string> entries up to the closing
 	// </array>; preserves order and handles the "--flag value" pair
@@ -542,7 +556,7 @@ func parsePlist(path string) (label, bin string, argv []string) {
 	tail := s[i+len("<key>ProgramArguments</key><array>"):]
 	end := strings.Index(tail, "</array>")
 	if end < 0 {
-		return label, "", nil
+		return label, "", nil, env
 	}
 	inner := tail[:end]
 	for {
@@ -561,7 +575,54 @@ func parsePlist(path string) (label, bin string, argv []string) {
 	if len(argv) > 0 {
 		bin = argv[0]
 	}
-	return label, bin, argv
+	return label, bin, argv, env
+}
+
+// parseEnvDict extracts the plist's EnvironmentVariables <dict> into a map of
+// <key>→<string> (FEATURE 19). Returns nil when there is no EnvironmentVariables
+// dict (an OLD plist, the test-mode plist, or a vendor plist). It walks the same
+// "<key>…</key><string>…</string>" adjacency the ProgramArguments scanner relies
+// on; binary plists are normalized via collapseInterTagSpace upstream so the
+// adjacency holds.
+func parseEnvDict(s string) map[string]string {
+	const head = "<key>EnvironmentVariables</key><dict>"
+	i := strings.Index(s, head)
+	if i < 0 {
+		return nil
+	}
+	tail := s[i+len(head):]
+	end := strings.Index(tail, "</dict>")
+	if end < 0 {
+		return nil
+	}
+	inner := tail[:end]
+	out := map[string]string{}
+	for {
+		ks := strings.Index(inner, "<key>")
+		if ks < 0 {
+			break
+		}
+		ke := strings.Index(inner[ks:], "</key>")
+		if ke < 0 {
+			break
+		}
+		key := strings.TrimSpace(inner[ks+len("<key>") : ks+ke])
+		rest := inner[ks+ke+len("</key>"):]
+		vs := strings.Index(rest, "<string>")
+		if vs < 0 {
+			break
+		}
+		ve := strings.Index(rest[vs:], "</string>")
+		if ve < 0 {
+			break
+		}
+		out[key] = strings.TrimSpace(rest[vs+len("<string>") : vs+ve])
+		inner = rest[vs+ve+len("</string>"):]
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // launchctlProber introspects launchd for the health poll. The label

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -517,6 +517,12 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
 		c.bootout, os.Remove, pkillBinary, os.RemoveAll), nil
 }
 
+// minBinPathLen is the floor on a binary path before retirement will pkill -f
+// it. Any real disguised install path is far longer; a short value like "/"
+// (a corrupt/dead-gen ProgramArguments[0]) must never expand into a broad
+// `pkill -f /` that reaps unrelated processes.
+const minBinPathLen = 20 // shorter than any real disguised install path
+
 // retireGenerations is the seam-injected core of RetireOtherGenerations, split
 // out so the teardown ordering + the os.RemoveAll path-sanity gating are unit-
 // tested with fakes (no real launchd / FS deletion). bootout/removePlist/
@@ -548,7 +554,11 @@ func retireGenerations(
 				_ = removePlist(plistPaths[i])
 			}
 		}
-		if bin != "" {
+		// GUARD: never pkill -f a short path. A dead-generation plist whose
+		// ProgramArguments[0] is "/" (or any short root-ish path) must NOT
+		// expand into `pkill -f /` and reap unrelated processes. Real disguised
+		// install paths are far longer than minBinPathLen.
+		if len(bin) > minBinPathLen {
 			killBin(bin) // best-effort; no surviving daemon shares this path
 		}
 		// GUARD: only RemoveAll a workdir that is strictly under the mode's

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -36,8 +36,17 @@ type Generation struct {
 	PlistPaths []string
 }
 
-func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, error) {
-	return nil, ErrUnsupported
+// DeadGeneration mirrors the darwin definition (FEATURE 17 follow-up) so
+// cross-platform code that references it compiles on non-darwin.
+type DeadGeneration struct {
+	BinaryPath string
+	Workdir    string
+	Labels     []string
+	PlistPaths []string
+}
+
+func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, []DeadGeneration, error) {
+	return nil, nil, ErrUnsupported
 }
 
 // RetireOtherGenerations is a no-op on non-darwin (no launchd mesh to retire).

--- a/daemon/internal/osadapter/find_install_test.go
+++ b/daemon/internal/osadapter/find_install_test.go
@@ -35,7 +35,7 @@ func TestParsePlistReturnsArgv(t *testing.T) {
 	}
 
 	wantLabel := s.Label(RoleA)
-	label, bin, argv := parsePlist(plistPath)
+	label, bin, argv, _ := parsePlist(plistPath)
 	if label != wantLabel {
 		t.Fatalf("label = %q, want %q", label, wantLabel)
 	}

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -276,7 +276,8 @@ func contains(xs []string, want string) bool {
 
 // TestParsePlistBinaryFormat: a BINARY-format plist (the real-world hardening
 // case) is converted via plutil and parsed correctly — label, binary path, and
-// argv (including --mesh) are all recovered.
+// the FEATURE 19 EnvironmentVariables mesh marker are all recovered (the prod
+// worker plist carries the marker in env, not argv).
 func TestParsePlistBinaryFormat(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "com.apple.metadata.helper.bbbb")
@@ -296,14 +297,20 @@ func TestParsePlistBinaryFormat(t *testing.T) {
 		t.Fatal("expected a binary plist, but it still looks like XML")
 	}
 
-	label, bin, argv := parsePlist(plistPath)
+	label, bin, argv, env := parsePlist(plistPath)
 	if label != s.Label(RoleA) {
 		t.Errorf("label = %q, want %q", label, s.Label(RoleA))
 	}
 	if bin != binPath {
 		t.Errorf("bin = %q, want %q", bin, binPath)
 	}
-	if !hasMeshFlag(argv) {
-		t.Errorf("argv must carry --mesh, got %v", argv)
+	// FEATURE 19: a prod worker carries the mesh marker in EnvironmentVariables,
+	// not argv. The binary-format parse must recover it so the union predicate
+	// still corroborates the generation.
+	if env[MeshEnvKey] != "run:a" {
+		t.Errorf("env[%s] = %q, want run:a (got env %v)", MeshEnvKey, env[MeshEnvKey], env)
+	}
+	if !isFocusdMeshWorkerPlist(env, argv) {
+		t.Errorf("binary-format worker plist must corroborate the mesh, env=%v argv=%v", env, argv)
 	}
 }

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -35,6 +35,23 @@ func writeGeneration(t *testing.T, home, laDir, tag string, roster []string) (bi
 	return binPath, wd
 }
 
+// writeDeadGeneration writes the given roles' mesh plists for a generation
+// whose binary is DELETED (never created) — the zombie left by a workdir-delete
+// recovery cycle. Returns the dangling binary path + workdir.
+func writeDeadGeneration(t *testing.T, home, laDir, tag string, roster []string, roles ...Role) (binPath, wd string) {
+	t.Helper()
+	wd = filepath.Join(home, "Library", "Application Support", "."+tag)
+	binPath = filepath.Join(wd, tag+".bin")
+	s := Spec{Mode: mode.User, SelfPath: binPath, Workdir: wd, Roster: roster}
+	for _, r := range roles {
+		pp := filepath.Join(laDir, s.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(s, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return binPath, wd
+}
+
 func laDirUnderHome(t *testing.T) (home, laDir string) {
 	t.Helper()
 	home = t.TempDir()
@@ -77,9 +94,12 @@ func TestDiscoverAllGenerationsGroupsByVerifiedBinary(t *testing.T) {
 	// Verifier accepts ONLY the two real generation binaries.
 	verify := Verifier(func(p string) (bool, error) { return p == bin1 || p == bin2, nil })
 
-	gens, err := DiscoverAllGenerations(mode.User, verify)
+	gens, dead, err := DiscoverAllGenerations(mode.User, verify)
 	if err != nil {
 		t.Fatalf("DiscoverAllGenerations: %v", err)
+	}
+	if len(dead) != 0 {
+		t.Fatalf("present binaries must not be dead generations, got %+v", dead)
 	}
 	if len(gens) != 2 {
 		t.Fatalf("want 2 generations, got %d: %+v", len(gens), gens)
@@ -125,12 +145,15 @@ func TestDiscoverAllGenerationsExcludesNonMesh(t *testing.T) {
 	}
 
 	verify := Verifier(func(p string) (bool, error) { return p == binPath, nil })
-	gens, err := DiscoverAllGenerations(mode.User, verify)
+	gens, dead, err := DiscoverAllGenerations(mode.User, verify)
 	if err != nil {
 		t.Fatalf("DiscoverAllGenerations: %v", err)
 	}
 	if len(gens) != 0 {
 		t.Fatalf("a verified-but-non-mesh generation must be excluded, got %+v", gens)
+	}
+	if len(dead) != 0 {
+		t.Fatalf("a present-binary generation must never be dead, got %+v", dead)
 	}
 }
 
@@ -139,12 +162,94 @@ func TestDiscoverAllGenerationsExcludesNonMesh(t *testing.T) {
 func TestDiscoverAllGenerationsNoLaunchDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	gens, err := DiscoverAllGenerations(mode.User, Verifier(func(string) (bool, error) { return false, nil }))
+	gens, dead, err := DiscoverAllGenerations(mode.User, Verifier(func(string) (bool, error) { return false, nil }))
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if len(gens) != 0 {
 		t.Fatalf("want zero generations, got %+v", gens)
+	}
+	if len(dead) != 0 {
+		t.Fatalf("want zero dead generations, got %+v", dead)
+	}
+}
+
+// readFileVerifier mimics sig.VerifyFile's classification for tests: a deleted
+// binary yields a wrapped ENOENT error (the "dead generation" path), a present
+// "VENDOR" file fails the signature (ok=false), and any other present file is
+// accepted. errors.Is(err, fs.ErrNotExist) holds because os.ReadFile wraps the
+// real syscall error.
+func readFileVerifier(p string) (bool, error) {
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return false, err // deleted binary → ENOENT → dead generation
+	}
+	return string(data) != "VENDOR", nil
+}
+
+// TestDiscoverAllGenerationsRecordsDeadBinary: a generation whose binary was
+// DELETED but whose plists carry the mesh worker marker is returned as a DEAD
+// generation (not silently dropped). A vendor plist (binary present, fails sig)
+// is excluded. A non-mesh dead plist (deleted binary, ensure-only, no marker)
+// is NOT treated as ours.
+func TestDiscoverAllGenerationsRecordsDeadBinary(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+
+	// A live, present generation (control: must stay live, never dead).
+	liveRoster := []string{"com.apple.metadata.helper.1", "com.google.keystone.daemon.2", "org.mozilla.updater.agent.3"}
+	liveBin, _ := writeGeneration(t, home, laDir, "live", liveRoster)
+
+	// A DEAD full-mesh generation: binary deleted, all three plists present
+	// (workers carry the mesh marker → meshSeen true). The ensure plist has no
+	// marker but shares the dangling bin path, so it is swept in.
+	deadRoster := []string{"com.docker.helper.4", "us.zoom.ZoomDaemon.svc.5", "io.tailscale.ipnextension.relay.6"}
+	deadBin, deadWd := writeDeadGeneration(t, home, laDir, "dead", deadRoster, AllRoles...)
+
+	// A non-mesh DEAD plist: binary deleted, ONLY the ensure role (no marker)
+	// under a distinct dangling bin → must NOT be treated as ours.
+	ensRoster := []string{"com.vendor.x.7", "com.vendor.y.8", "com.vendor.z.9"}
+	writeDeadGeneration(t, home, laDir, "ensonly", ensRoster, RoleEnsure)
+
+	// A vendor plist whose binary EXISTS but fails the signature.
+	vendorWd := filepath.Join(home, "Library", "Application Support", ".vendor")
+	vendorBin := filepath.Join(vendorWd, "vendor.bin")
+	if err := os.MkdirAll(vendorWd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vendorBin, []byte("VENDOR"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vs := Spec{Mode: mode.User, SelfPath: vendorBin, Workdir: vendorWd,
+		Roster: []string{"com.v.a.a", "com.v.b.b", "com.v.c.c"}}
+	for _, r := range AllRoles {
+		pp := filepath.Join(laDir, vs.Label(r)+".plist")
+		if err := os.WriteFile(pp, []byte(Plist(vs, r)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gens, dead, err := DiscoverAllGenerations(mode.User, Verifier(readFileVerifier))
+	if err != nil {
+		t.Fatalf("DiscoverAllGenerations: %v", err)
+	}
+
+	// Only the live generation is live.
+	if len(gens) != 1 || gens[0].BinaryPath != liveBin {
+		t.Fatalf("want exactly the live generation, got %+v", gens)
+	}
+	// Exactly one dead generation: the full-mesh zombie (ensure-only + vendor excluded).
+	if len(dead) != 1 {
+		t.Fatalf("want exactly 1 dead generation, got %d: %+v", len(dead), dead)
+	}
+	d := dead[0]
+	if d.BinaryPath != deadBin {
+		t.Errorf("dead binary = %q, want %q", d.BinaryPath, deadBin)
+	}
+	if d.Workdir != deadWd {
+		t.Errorf("dead workdir = %q, want %q", d.Workdir, deadWd)
+	}
+	if len(d.Labels) != 3 || len(d.PlistPaths) != 3 {
+		t.Errorf("dead generation: want 3 labels/plists (incl. swept-in ensure), got %d/%d", len(d.Labels), len(d.PlistPaths))
 	}
 }
 
@@ -196,7 +301,7 @@ func TestRetireGenerationsKeepsKeepRetiresOthers(t *testing.T) {
 	}
 
 	f := &fakeRetire{}
-	n := retireGenerations(gens, keepBin, root,
+	n := retireGenerations(gens, nil, keepBin, root,
 		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
 		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
 		func(b string) { f.killed = append(f.killed, b) },
@@ -247,7 +352,7 @@ func TestRetireGenerationsNoopOnEmptyKeep(t *testing.T) {
 		},
 	}
 	f := &fakeRetire{}
-	n := retireGenerations(gens, "", root,
+	n := retireGenerations(gens, nil, "", root,
 		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
 		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
 		func(b string) { f.killed = append(f.killed, b) },
@@ -262,6 +367,85 @@ func TestRetireGenerationsNoopOnEmptyKeep(t *testing.T) {
 	if len(f.removedPlist) != 0 || len(f.killed) != 0 || len(f.removedAll) != 0 {
 		t.Fatalf("empty keep must have zero side effects, got plist=%v killed=%v removedAll=%v",
 			f.removedPlist, f.killed, f.removedAll)
+	}
+}
+
+// TestRetireGenerationsRetiresDeadZombies: dead generations are booted out,
+// their plists removed, the dangling binary pkill'd, and their workdir
+// RemoveAll'd ONLY when path-sanity allows — counted in the retired total. The
+// keep generation is never touched.
+func TestRetireGenerationsRetiresDeadZombies(t *testing.T) {
+	mkdir := func(p string) string {
+		t.Helper()
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	root := t.TempDir()
+	keepWorkdir := mkdir(filepath.Join(root, ".keep"))
+	keepBin := filepath.Join(keepWorkdir, "keep.bin")
+
+	// Dead zombie with a SAFE workdir (still on disk, under root) → full retire
+	// including RemoveAll. A real zombie's workdir is often already gone, in
+	// which case safeToRemoveWorkdir refuses (EvalSymlinks fails) — but the
+	// bootout/rm/pkill still run; we keep it present here to exercise RemoveAll.
+	deadSafeWd := mkdir(filepath.Join(root, ".deadsafe"))
+	// Dead zombie with an UNSAFE workdir (outside root) → no RemoveAll, still torn down.
+	deadUnsafeWd := t.TempDir()
+
+	gens := []Generation{{
+		BinaryPath: keepBin, Workdir: keepWorkdir,
+		Labels:     []string{"k1", "k2", "k3"},
+		PlistPaths: []string{"/p/k1", "/p/k2", "/p/k3"},
+	}}
+	dead := []DeadGeneration{
+		{
+			BinaryPath: filepath.Join(deadSafeWd, "deadsafe.bin"),
+			Workdir:    deadSafeWd,
+			Labels:     []string{"d1a", "d1b", "d1c"},
+			PlistPaths: []string{"/p/d1a", "/p/d1b", "/p/d1c"},
+		},
+		{
+			BinaryPath: filepath.Join(deadUnsafeWd, "deadunsafe.bin"),
+			Workdir:    deadUnsafeWd,
+			Labels:     []string{"d2a"},
+			PlistPaths: []string{"/p/d2a"},
+		},
+	}
+
+	f := &fakeRetire{}
+	n := retireGenerations(gens, dead, keepBin, root,
+		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
+		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
+		func(b string) { f.killed = append(f.killed, b) },
+		func(d string) error { f.removedAll = append(f.removedAll, d); return nil },
+	)
+
+	// Only keep is live (skipped); both dead zombies retired.
+	if n != 2 {
+		t.Fatalf("retired count = %d, want 2 (both dead zombies)", n)
+	}
+	// Keep generation untouched.
+	if contains(f.bootedOut, "k1") || contains(f.removedAll, keepWorkdir) {
+		t.Fatalf("keep generation must never be retired, bootedOut=%v removedAll=%v", f.bootedOut, f.removedAll)
+	}
+	// Both dead zombies booted out + binaries killed.
+	for _, lbl := range []string{"d1a", "d1b", "d1c", "d2a"} {
+		if !contains(f.bootedOut, lbl) {
+			t.Fatalf("dead label %q must be booted out, got %v", lbl, f.bootedOut)
+		}
+	}
+	if !contains(f.killed, filepath.Join(deadSafeWd, "deadsafe.bin")) ||
+		!contains(f.killed, filepath.Join(deadUnsafeWd, "deadunsafe.bin")) {
+		t.Fatalf("dead binaries must be pkill'd, got %v", f.killed)
+	}
+	// Safe dead workdir removed; unsafe one NOT.
+	if !contains(f.removedAll, deadSafeWd) {
+		t.Fatalf("safe dead workdir must be RemoveAll'd, got %v", f.removedAll)
+	}
+	if contains(f.removedAll, deadUnsafeWd) {
+		t.Fatalf("unsafe dead workdir must NOT be RemoveAll'd, got %v", f.removedAll)
 	}
 }
 

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -449,6 +449,45 @@ func TestRetireGenerationsRetiresDeadZombies(t *testing.T) {
 	}
 }
 
+// TestRetireGenerationsSkipsPkillOnShortPath: a dead-generation plist whose
+// ProgramArguments[0] is a short root-ish path (e.g. "/") must NOT expand into
+// a broad `pkill -f /` that reaps unrelated processes. The generation is still
+// booted out + plists removed, but killBin is never called for the short path.
+func TestRetireGenerationsSkipsPkillOnShortPath(t *testing.T) {
+	root := t.TempDir()
+	keepWorkdir := filepath.Join(root, ".keep")
+	if err := os.MkdirAll(keepWorkdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keepBin := filepath.Join(keepWorkdir, "keep.bin")
+
+	dead := []DeadGeneration{{
+		BinaryPath: "/", // corrupt/dangling short path — must NOT be pkill'd
+		Workdir:    "/", // unsafe by construction → no RemoveAll either
+		Labels:     []string{"shortd"},
+		PlistPaths: []string{"/p/shortd"},
+	}}
+
+	f := &fakeRetire{}
+	n := retireGenerations(nil, dead, keepBin, root,
+		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
+		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
+		func(b string) { f.killed = append(f.killed, b) },
+		func(d string) error { f.removedAll = append(f.removedAll, d); return nil },
+	)
+
+	if n != 1 {
+		t.Fatalf("retired count = %d, want 1", n)
+	}
+	// Booted out + plist removed, but the short path was never pkill'd.
+	if !contains(f.bootedOut, "shortd") {
+		t.Fatalf("short-path dead gen must still be booted out, got %v", f.bootedOut)
+	}
+	if len(f.killed) != 0 {
+		t.Fatalf("short path %q must NOT be pkill'd, got killed=%v", "/", f.killed)
+	}
+}
+
 func contains(xs []string, want string) bool {
 	for _, x := range xs {
 		if x == want {

--- a/daemon/internal/osadapter/meshenv.go
+++ b/daemon/internal/osadapter/meshenv.go
@@ -1,0 +1,81 @@
+package osadapter
+
+import (
+	"os"
+	"strings"
+)
+
+// MeshEnvKey is the launchd EnvironmentVariables key that carries a PROD mesh
+// member's role marker (FEATURE 19). The marker moved OFF the command line —
+// where `ps` exposes argv to root — and into the plist environment, which the
+// process list does not display. The name is deliberately opaque and does NOT
+// reference focusd or "mesh": a casual `ps aux | grep mesh` (or `grep focusd`)
+// over the live process list finds nothing tied to the install.
+//
+// Values (round-tripped by encodeRole / decodeMeshEnv):
+//   - "run:a"  → worker role A → argv: run --r a --mesh
+//   - "run:b"  → worker role B → argv: run --r b --mesh
+//   - "ensure" → ensurer       → argv: ensure
+const MeshEnvKey = "APP_LAUNCH_CONTEXT"
+
+// meshEnvRunPrefix tags a WORKER role value ("run:a" / "run:b"). The ensurer
+// value ("ensure") deliberately lacks it: like the pre-19 `ensure` argv (which
+// carried no --mesh), an ensure-only plist must NOT corroborate a real
+// mesh-worker generation in DiscoverAllGenerations.
+const meshEnvRunPrefix = "run:"
+
+// encodeRole maps a role to its MeshEnvKey value. Exact inverse of
+// decodeMeshEnv (round-trip unit-tested for every role).
+func encodeRole(r Role) string {
+	if r == RoleEnsure {
+		return string(RoleEnsure) // "ensure"
+	}
+	return meshEnvRunPrefix + string(r) // "run:a" / "run:b"
+}
+
+// decodeMeshEnv reconstructs the legacy subcommand argv from a MeshEnvKey
+// value (FEATURE 19). It is the EXACT inverse of the prod argv the daemon used
+// to bake before the marker moved into the environment:
+//   - "ensure"      → ["ensure"]
+//   - "run:<role>"  → ["run", "--r", <role>, "--mesh"]
+//   - unset/garbage → nil  (caller falls through to usage(); never a partial
+//     argv that could mis-dispatch)
+//
+// CRITICAL: a nil return on a bad/missing value means the prod launchd start
+// degrades to usage()+exit, which KeepAlive then respawns into the same
+// failure. The encode/decode pair is therefore round-trip unit-tested for
+// every role so a healthy install can never land here.
+func decodeMeshEnv(val string) []string {
+	if val == string(RoleEnsure) {
+		return []string{"ensure"}
+	}
+	if role := strings.TrimPrefix(val, meshEnvRunPrefix); role != val && role != "" {
+		return []string{"run", "--r", role, "--mesh"}
+	}
+	return nil
+}
+
+// ArgvFromEnv reads MeshEnvKey from the process environment and reconstructs
+// the legacy subcommand argv (FEATURE 19). Returns nil when the var is unset or
+// malformed. Used by the daemon entrypoint when launchd starts it with an empty
+// argv (the minimized prod plist's ProgramArguments is the binary alone).
+func ArgvFromEnv() []string {
+	return decodeMeshEnv(os.Getenv(MeshEnvKey))
+}
+
+// isFocusdMeshWorkerPlist reports whether a plist is a focusd self-healing
+// WORKER — the corroborating "this verified binary is a real mesh generation"
+// signal in DiscoverAllGenerations (FEATURE 17, extended by FEATURE 19). It is
+// a UNION across the fleet transition so generation cleanup keeps working while
+// old and new plists coexist:
+//   - NEW (FEATURE 19) plists carry the worker marker in EnvironmentVariables:
+//     MeshEnvKey="run:<role>".
+//   - OLD plists carry --mesh in argv (the pre-19 marker).
+//
+// The ensure role corroborates NEITHER (its env value is "ensure", its old argv
+// has no --mesh) — preserving the pre-19 semantic that an ensure-only plist is
+// not a real mesh. The Ed25519-verified argv[0] remains the PRIMARY identity
+// key; this is only the corroborating signal.
+func isFocusdMeshWorkerPlist(env map[string]string, argv []string) bool {
+	return strings.HasPrefix(env[MeshEnvKey], meshEnvRunPrefix) || hasMeshFlag(argv)
+}

--- a/daemon/internal/osadapter/meshenv.go
+++ b/daemon/internal/osadapter/meshenv.go
@@ -50,6 +50,9 @@ func decodeMeshEnv(val string) []string {
 		return []string{"ensure"}
 	}
 	if role := strings.TrimPrefix(val, meshEnvRunPrefix); role != val && role != "" {
+		if role != string(RoleA) && role != string(RoleB) {
+			return nil
+		}
 		return []string{"run", "--r", role, "--mesh"}
 	}
 	return nil

--- a/daemon/internal/osadapter/meshenv_test.go
+++ b/daemon/internal/osadapter/meshenv_test.go
@@ -1,0 +1,46 @@
+package osadapter
+
+import "testing"
+
+// TestIsFocusdMeshWorkerPlist asserts the FEATURE 19 union predicate used by
+// DiscoverAllGenerations to corroborate a real mesh-worker generation across
+// the old/new fleet transition:
+//   - NEW worker plists carry the env marker MeshEnvKey="run:<role>" → match.
+//   - OLD worker plists carry --mesh in argv → match.
+//   - the ensure plist (env "ensure", or old `ensure` argv) → NO match
+//     (an ensure-only generation is not a real mesh, preserved from FEATURE 17).
+//   - a vendor / non-focusd plist (neither marker) → NO match.
+func TestIsFocusdMeshWorkerPlist(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		argv []string
+		want bool
+	}{
+		{"new worker A (env run:a)", map[string]string{MeshEnvKey: "run:a"}, []string{"/bin/x"}, true},
+		{"new worker B (env run:b)", map[string]string{MeshEnvKey: "run:b"}, []string{"/bin/x"}, true},
+		{"old worker (--mesh argv)", nil, []string{"/bin/x", "run", "--r", "a", "--mesh"}, true},
+		{"new ensure (env ensure)", map[string]string{MeshEnvKey: "ensure"}, []string{"/bin/x"}, false},
+		{"old ensure (ensure argv)", nil, []string{"/bin/x", "ensure"}, false},
+		{"vendor plist (neither)", map[string]string{"OTHER": "x"}, []string{"/bin/x", "--foo"}, false},
+		{"empty", nil, nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isFocusdMeshWorkerPlist(c.env, c.argv); got != c.want {
+				t.Fatalf("isFocusdMeshWorkerPlist(%v, %v) = %v, want %v", c.env, c.argv, got, c.want)
+			}
+		})
+	}
+}
+
+// TestEncodeRoleExact pins the exact env values the round-trip depends on, so a
+// rename of a role string can never silently desync encode/decode.
+func TestEncodeRoleExact(t *testing.T) {
+	want := map[Role]string{RoleA: "run:a", RoleB: "run:b", RoleEnsure: "ensure"}
+	for r, w := range want {
+		if got := encodeRole(r); got != w {
+			t.Errorf("encodeRole(%s) = %q, want %q", r, got, w)
+		}
+	}
+}

--- a/daemon/internal/osadapter/plist.go
+++ b/daemon/internal/osadapter/plist.go
@@ -6,35 +6,50 @@ import (
 	"time"
 )
 
-// args returns the daemon argv for a role. A/B run the supervised loop
-// (`run --r <role> --mesh` — reconcile platform + recreate siblings);
-// ensure runs the one-shot mesh repair (`ensure`).
+// args returns the daemon argv for a role (the strings AFTER the binary in
+// ProgramArguments).
 //
-// FEATURE 14 / ADR-0018: the PROD argv is minimized to "role + mesh
-// marker" and nothing else — none of the disguised identifiers ride on
-// the command line where `ps` exposes them to root. Specifically NOT
-// baked: the three roster labels (the `launchctl bootout` keys, the worst
-// leak), --github (a focusd-identity tell), --asset, --interval, and
-// --workdir. A relaunched survivor reconstructs everything else:
-//   - the roster from the masked workdir file (single source of truth),
-//   - the workdir from filepath.Dir(os.Executable()) — the disguised binary
-//     lives inside the workdir (argv[0] is unavoidably visible anyway),
-//   - the github channel + platform asset are derived/compiled in.
+// FEATURE 19 / ADR-0018: the PROD argv is now EMPTY — ProgramArguments is the
+// binary alone. The role/mesh marker that FEATURE 14 had minimized to
+// `run --r <role> --mesh` is moved entirely OFF the command line (where `ps`
+// exposes it to root) and INTO the plist's EnvironmentVariables (see env /
+// MeshEnvKey), which the process list does not display. So a `ps aux | grep
+// mesh` (or a grep for the role flags) against the live mesh finds nothing.
+// A relaunched member reconstructs this same legacy argv from the env via
+// ArgvFromEnv; everything downstream (parse/loop/doEnsure/isMeshRole/
+// deriveMeshWorkdir) is UNCHANGED — it gets the same argv it always did. The
+// roster (masked workdir file), workdir (filepath.Dir(os.Executable())), and
+// github/asset (derived/compiled in) are recovered exactly as before.
 //
-// TEST-MODE EXCEPTION: e2e installs still bake --test-mode-flag + --workdir
-// because the throwaway e2e workdir is NOT derivable from argv[0] (it is a
-// caller-provided temp dir, and the binary is not relocated inside it). No
-// prod identifiers are ever baked.
+// TEST-MODE EXCEPTION: e2e installs still bake the FULL argv (`run --r <role>
+// --mesh` / `ensure`) + --test-mode-flag + --workdir, because the throwaway
+// e2e workdir is NOT derivable from argv[0] (it is a caller-provided temp dir,
+// and the binary is not relocated inside it) and e2e must stay self-contained.
+// Test mode emits NO env (see env), so the e2e flow is undisturbed.
 func args(s Spec, r Role) []string {
-	var tail []string
-	if s.isTest() {
-		tail = []string{"--test-mode-flag", "true", "--workdir", s.Workdir}
+	if !s.isTest() {
+		return nil // PROD: binary-only argv; the marker rides in env (FEATURE 19)
 	}
+	tail := []string{"--test-mode-flag", "true", "--workdir", s.Workdir}
 	if r == RoleEnsure {
 		return append([]string{"ensure"}, tail...)
 	}
 	// --mesh: only an installed worker self-heals the launchd mesh.
 	return append([]string{"run", "--r", string(r), "--mesh"}, tail...)
+}
+
+// envKV is one launchd EnvironmentVariables entry.
+type envKV struct{ Key, Value string }
+
+// env returns the launchd EnvironmentVariables entries for a role (FEATURE 19).
+// PROD emits exactly ONE: MeshEnvKey=<encoded role> — the mesh marker the prod
+// argv no longer carries. TEST mode emits NONE (nil): e2e keeps the full argv,
+// so the environment stays clean and the e2e flow is undisturbed.
+func env(s Spec, r Role) []envKV {
+	if s.isTest() {
+		return nil
+	}
+	return []envKV{{Key: MeshEnvKey, Value: encodeRole(r)}}
 }
 
 // EnsureBackstopInterval is the default ensurer StartInterval (FEATURE 10
@@ -75,6 +90,16 @@ func Plist(s Spec, r Role) string {
 		fmt.Fprintf(&sb, "    <string>%s</string>\n", a)
 	}
 	sb.WriteString("  </array>\n")
+	// FEATURE 19: the role/mesh marker rides in EnvironmentVariables (PROD),
+	// not argv — off the command line where `ps` would expose it. Emitted only
+	// when non-empty (test mode keeps the full argv and emits no env).
+	if kvs := env(s, r); len(kvs) > 0 {
+		sb.WriteString("  <key>EnvironmentVariables</key><dict>\n")
+		for _, kv := range kvs {
+			fmt.Fprintf(&sb, "    <key>%s</key><string>%s</string>\n", kv.Key, kv.Value)
+		}
+		sb.WriteString("  </dict>\n")
+	}
 	sb.WriteString("  <key>RunAtLoad</key><true/>\n")
 	if r == RoleEnsure {
 		fmt.Fprintf(&sb, "  <key>StartInterval</key><integer>%d</integer>\n", intervalSeconds(s))

--- a/daemon/internal/osadapter/plist_test.go
+++ b/daemon/internal/osadapter/plist_test.go
@@ -146,13 +146,11 @@ func TestArgvFromEnvRoundTrip(t *testing.T) {
 // caller then falls through to usage() rather than respawning into a wrong
 // subcommand.
 func TestDecodeMeshEnvSafeOnGarbage(t *testing.T) {
-	for _, v := range []string{"", "run:", "run", "ensur", "garbage", "RUN:A", ":a", "run:a:b"} {
+	// Strict inverse of encodeRole: only "ensure" / "run:a" / "run:b" decode.
+	// Any unknown role ("run:a:b", "run:zzz") yields nil so a bad value can
+	// never synthesize a partial argv that mis-dispatches into a crash-loop.
+	for _, v := range []string{"", "run:", "run", "ensur", "garbage", "RUN:A", ":a", "run:a:b", "run:zzz"} {
 		if got := decodeMeshEnv(v); got != nil {
-			// "run:a:b" is intentionally allowed to pass role="a:b" → a wrong but
-			// well-formed argv; guard the genuinely-empty cases here.
-			if v == "run:a:b" {
-				continue
-			}
 			t.Errorf("decodeMeshEnv(%q) = %v, want nil", v, got)
 		}
 	}

--- a/daemon/internal/osadapter/plist_test.go
+++ b/daemon/internal/osadapter/plist_test.go
@@ -21,16 +21,28 @@ func TestPlistWorkerVsEnsurer(t *testing.T) {
 	if !strings.Contains(a, "<key>KeepAlive</key><true/>") {
 		t.Fatal("worker must have KeepAlive")
 	}
-	if !strings.Contains(a, "<string>run</string>") || !strings.Contains(a, "<string>--mesh</string>") {
-		t.Fatal("worker args must include run + --mesh")
+	// FEATURE 19: the PROD worker carries NO run/--mesh in argv — the marker
+	// rides in EnvironmentVariables (MeshEnvKey="run:a"), hidden from `ps`.
+	if strings.Contains(a, "<string>run</string>") || strings.Contains(a, "<string>--mesh</string>") {
+		t.Fatalf("worker argv must NOT carry run/--mesh (FEATURE 19):\n%s", a)
+	}
+	if !strings.Contains(a, "<key>EnvironmentVariables</key><dict>") ||
+		!strings.Contains(a, "<key>"+MeshEnvKey+"</key><string>run:a</string>") {
+		t.Fatalf("worker must carry the mesh marker in env (MeshEnvKey=run:a):\n%s", a)
 	}
 	if strings.Contains(a, "StartInterval") {
 		t.Fatal("worker must NOT have StartInterval")
 	}
 
 	e := Plist(s, RoleEnsure)
-	if !strings.Contains(e, "<string>ensure</string>") {
-		t.Fatal("ensurer must run the ensure subcommand")
+	// FEATURE 19: the ensurer subcommand also moves into env (MeshEnvKey=ensure);
+	// argv is the binary alone. Scope the argv check to ProgramArguments — the
+	// env dict legitimately holds the value "ensure".
+	if strings.Contains(programArgsBlock(t, e), "<string>ensure</string>") {
+		t.Fatalf("ensurer argv must NOT carry the ensure subcommand (FEATURE 19):\n%s", e)
+	}
+	if !strings.Contains(e, "<key>"+MeshEnvKey+"</key><string>ensure</string>") {
+		t.Fatalf("ensurer must carry the ensure marker in env:\n%s", e)
 	}
 	if !strings.Contains(e, "<key>StartInterval</key><integer>30</integer>") {
 		t.Fatalf("ensurer StartInterval wrong:\n%s", e)
@@ -40,12 +52,14 @@ func TestPlistWorkerVsEnsurer(t *testing.T) {
 	}
 }
 
-// TestPlistProdArgvMinimized asserts FEATURE 14 / ADR-0018: a PROD mesh
-// plist's argv is reduced to role + mesh marker and NONE of the disguised
-// identifiers (the three roster labels — the bootout keys — plus --github,
-// --asset, --interval, --workdir, --test-mode-flag). The masked workdir
-// file, not argv, is the single source of truth for the labels.
-func TestPlistProdArgvMinimized(t *testing.T) {
+// TestPlistProdArgvEmptyMarkerInEnv asserts FEATURE 19 / ADR-0018: a PROD mesh
+// plist's argv is now EMPTY (the binary alone) — even the role/mesh marker
+// FEATURE 14 had kept (`run --r <role> --mesh` / `ensure`) is gone from the
+// command line. The marker rides in EnvironmentVariables (MeshEnvKey), and NONE
+// of the disguised identifiers (the roster labels, --github/--asset/--interval/
+// --workdir/--test-mode-flag) appear in argv. So `ps aux | grep mesh` finds
+// nothing for the live mesh.
+func TestPlistProdArgvEmptyMarkerInEnv(t *testing.T) {
 	roster := []string{
 		"com.apple.metadata.helper.7f3a2c11ab",
 		"com.google.keystone.daemon.8c1f4e9d22",
@@ -55,40 +69,105 @@ func TestPlistProdArgvMinimized(t *testing.T) {
 		Github: "o/r", Asset: "platform-darwin-arm64",
 		Interval: 10 * time.Second, Roster: roster}
 
-	// Forbidden tokens: the leak FEATURE 14 closes. The three labels are
-	// the worst (bootout keys); the rest each narrow the search. We scan the
-	// ProgramArguments (what `ps` shows), NOT the plist Label key — the
-	// launchd Label legitimately carries the disguised name on disk (that is
-	// FEATURE 10's masked-roster concern, not this feature's argv concern).
-	forbidden := []string{
-		"--roster", "--github", "--asset", "--interval",
-		"--workdir", "--test-mode-flag", "/wd", "o/r",
-		"platform-darwin-arm64",
-	}
-	forbidden = append(forbidden, roster...)
-
+	// PROD argv (the strings after the binary) must be EMPTY for every role —
+	// no run/--mesh/ensure marker, no disguised identifiers at all.
 	for _, r := range AllRoles {
-		argv := args(s, r)
-		for _, tok := range forbidden {
-			for _, a := range argv {
-				if a == tok {
-					t.Errorf("%s prod argv leaks %q: %v", r, tok, argv)
-				}
+		if got := args(s, r); len(got) != 0 {
+			t.Errorf("%s prod argv must be empty (FEATURE 19), got %v", r, got)
+		}
+	}
+
+	// The marker moved into env: workers → run:<role>, ensurer → ensure.
+	wantEnv := map[Role]string{RoleA: "run:a", RoleB: "run:b", RoleEnsure: "ensure"}
+	for r, want := range wantEnv {
+		kvs := env(s, r)
+		if len(kvs) != 1 || kvs[0].Key != MeshEnvKey || kvs[0].Value != want {
+			t.Errorf("%s env = %v, want [{%s %s}]", r, kvs, MeshEnvKey, want)
+		}
+	}
+
+	// And `ps` (the ProgramArguments array — NOT the env dict, which ps does
+	// not display) shows no mesh tell. Scope the scan to the ProgramArguments
+	// block: the env VALUE "ensure"/"run:a" legitimately lives in the env dict.
+	for _, r := range AllRoles {
+		pa := programArgsBlock(t, Plist(s, r))
+		for _, tok := range []string{"--mesh", "<string>run</string>", "<string>ensure</string>"} {
+			if strings.Contains(pa, tok) {
+				t.Errorf("%s ProgramArguments leaks %q (FEATURE 19):\n%s", r, tok, pa)
 			}
 		}
 	}
+}
 
-	// Workers carry exactly: run --r <role> --mesh.
-	for _, r := range []Role{RoleA, RoleB} {
-		got := args(s, r)
-		want := []string{"run", "--r", string(r), "--mesh"}
-		if !equalArgs(got, want) {
-			t.Errorf("%s worker argv = %v, want %v", r, got, want)
+// programArgsBlock returns the <key>ProgramArguments</key><array>…</array>
+// substring of a rendered plist — what `ps` would surface — so a test can scan
+// argv without matching the EnvironmentVariables dict.
+func programArgsBlock(t *testing.T, plist string) string {
+	t.Helper()
+	const head = "<key>ProgramArguments</key><array>"
+	i := strings.Index(plist, head)
+	if i < 0 {
+		t.Fatalf("plist has no ProgramArguments:\n%s", plist)
+	}
+	rest := plist[i:]
+	end := strings.Index(rest, "</array>")
+	if end < 0 {
+		t.Fatalf("plist ProgramArguments not closed:\n%s", plist)
+	}
+	return rest[:end]
+}
+
+// TestArgvFromEnvRoundTrip asserts the CRITICAL invariant: the env value env()
+// bakes for each role decodes EXACTLY back to the legacy subcommand argv the
+// daemon's dispatch expects. A mismatch would mean a prod launchd start (which
+// reconstructs argv from env) mis-dispatches or falls through to usage() and
+// crash-loops under KeepAlive.
+func TestArgvFromEnvRoundTrip(t *testing.T) {
+	s := Spec{Mode: mode.User, SelfPath: "/d/daemon", Workdir: "/wd", Roster: []string{"x", "y", "z"}}
+	want := map[Role][]string{
+		RoleA:      {"run", "--r", "a", "--mesh"},
+		RoleB:      {"run", "--r", "b", "--mesh"},
+		RoleEnsure: {"ensure"},
+	}
+	for _, r := range AllRoles {
+		kvs := env(s, r)
+		if len(kvs) != 1 {
+			t.Fatalf("%s: want exactly one env entry, got %v", r, kvs)
+		}
+		got := decodeMeshEnv(kvs[0].Value)
+		if !equalArgs(got, want[r]) {
+			t.Errorf("%s round-trip: decodeMeshEnv(%q) = %v, want %v", r, kvs[0].Value, got, want[r])
 		}
 	}
-	// Ensurer carries exactly: ensure.
-	if got := args(s, RoleEnsure); !equalArgs(got, []string{"ensure"}) {
-		t.Errorf("ensurer argv = %v, want [ensure]", got)
+}
+
+// TestDecodeMeshEnvSafeOnGarbage asserts a bad/missing env value yields NO
+// synthesized argv (nil) — never a partial argv that could mis-dispatch. The
+// caller then falls through to usage() rather than respawning into a wrong
+// subcommand.
+func TestDecodeMeshEnvSafeOnGarbage(t *testing.T) {
+	for _, v := range []string{"", "run:", "run", "ensur", "garbage", "RUN:A", ":a", "run:a:b"} {
+		if got := decodeMeshEnv(v); got != nil {
+			// "run:a:b" is intentionally allowed to pass role="a:b" → a wrong but
+			// well-formed argv; guard the genuinely-empty cases here.
+			if v == "run:a:b" {
+				continue
+			}
+			t.Errorf("decodeMeshEnv(%q) = %v, want nil", v, got)
+		}
+	}
+}
+
+// TestArgvFromEnvReadsProcessEnv exercises the os.Getenv path used by the prod
+// entrypoint when launchd starts the binary with an empty argv.
+func TestArgvFromEnvReadsProcessEnv(t *testing.T) {
+	t.Setenv(MeshEnvKey, "run:b")
+	if got := ArgvFromEnv(); !equalArgs(got, []string{"run", "--r", "b", "--mesh"}) {
+		t.Fatalf("ArgvFromEnv = %v, want [run --r b --mesh]", got)
+	}
+	t.Setenv(MeshEnvKey, "")
+	if got := ArgvFromEnv(); got != nil {
+		t.Fatalf("ArgvFromEnv with empty var = %v, want nil", got)
 	}
 }
 

--- a/daemon/internal/relocate/relocate.go
+++ b/daemon/internal/relocate/relocate.go
@@ -224,9 +224,9 @@ func pick(s []string) string {
 // family returns the org/vendor segment of a launchd-label prefix: the
 // first two dot-separated components (e.g. "com.apple", "com.google",
 // "org.mozilla", "us.zoom", "io.tailscale", "notion.id"). Entries with
-// fewer than two segments are returned whole. This is the grouping key
-// FEATURE 10 uses to draw the three mesh labels from DISTINCT vendors so
-// they don't visually cluster under one developer to a casual reader.
+// fewer than two segments are returned whole. Used to assert the prefixes
+// pool spans enough distinct vendors (see relocate tests); the FEATURE 19
+// roster styles draw from their own pools (roster_styles.go).
 func family(prefix string) string {
 	i := strings.IndexByte(prefix, '.')
 	if i < 0 {
@@ -255,63 +255,19 @@ func RandomBase() string {
 	return fmt.Sprintf("%s.%s.%s", pick(prefixes), pick(suffixes), randHex(randomTailBytes))
 }
 
-// GenerateRoster produces the three independent mesh labels (FEATURE 10 /
-// ADR-0014). Each label is a fully random "<prefix>.<suffix>.<10-hex>"
-// drawn from the existing disguise pool, with NO shared base, NO
-// role-revealing token (.a/.b/.ensure), and — critically — each from a
-// DISTINCT vendor family so the three read as unrelated third-party
-// agents (acceptance #1). The returned slice is positional, aligned with
-// osadapter.AllRoles (index 0 → RoleA, 1 → RoleB, 2 → RoleEnsure).
-//
-// Families are sampled WITHOUT replacement so no two labels share a
-// prefix/stem; the suffix and 10-hex tail are then drawn independently
-// per label. All randomness uses crypto/rand (via pick/randHex).
+// GenerateRoster produces the three mesh labels (FEATURE 10 → FEATURE 19). Each
+// role gets a STRUCTURALLY DISTINCT naming style from its own pools, so the
+// three entries never read as a matching set (the owner's "3 look very similar"
+// tell): role A is a dotted reverse-DNS bundle id (no hex tail), role B is a
+// CamelCase agent (no dots), the ensurer is a lowercase unix-daemon name. None
+// carry a role-revealing token (.a/.b/.ensure) or the "focusd" string. The
+// returned slice is positional, aligned with osadapter.AllRoles (index 0 →
+// RoleA, 1 → RoleB, 2 → RoleEnsure). All randomness uses crypto/rand (pick).
 func GenerateRoster() []string {
-	const meshSize = 3
-	// Group the prefix pool by vendor family.
-	byFamily := map[string][]string{}
-	var fams []string
-	for _, p := range prefixes {
-		f := family(p)
-		if _, ok := byFamily[f]; !ok {
-			fams = append(fams, f)
-		}
-		byFamily[f] = append(byFamily[f], p)
-	}
-	// Sample meshSize DISTINCT families without replacement (Fisher–Yates
-	// partial shuffle over the family list, crypto/rand driven).
-	for i := 0; i < meshSize && i < len(fams); i++ {
-		j := i + randIntn(len(fams)-i)
-		fams[i], fams[j] = fams[j], fams[i]
-	}
-	out := make([]string, 0, meshSize)
-	for i := 0; i < meshSize; i++ {
-		f := fams[i]
-		prefix := pickFrom(byFamily[f])
-		out = append(out, fmt.Sprintf("%s.%s.%s", prefix, pick(suffixes), randHex(randomTailBytes)))
-	}
-	return out
-}
-
-// pickFrom returns a crypto/rand-chosen element of s (s must be
-// non-empty; every family bucket has at least one prefix).
-func pickFrom(s []string) string { return s[randIntn(len(s))] }
-
-// randIntn returns a crypto/rand integer in [0,n) for n>0 (0 for n<=0).
-// Uses rejection sampling over a single byte's range to avoid the modulo
-// bias pick() tolerates — the family pool is small enough that one byte
-// always suffices.
-func randIntn(n int) int {
-	if n <= 0 {
-		return 0
-	}
-	limit := 256 - (256 % n) // largest multiple of n that fits in a byte
-	b := make([]byte, 1)
-	for {
-		_, _ = rand.Read(b)
-		if int(b[0]) < limit {
-			return int(b[0]) % n
-		}
+	return []string{
+		styleReverseDNS(), // RoleA
+		styleCamelCase(),  // RoleB
+		styleDaemon(),     // RoleEnsure
 	}
 }
 
@@ -323,16 +279,18 @@ func HiddenWorkdir(supportRoot string) string {
 	return filepath.Join(supportRoot, "."+pick(prefixes)+"."+randHex(6))
 }
 
-// RandomBinaryName is the disguised basename pattern used for the
-// daemon binary inside its hidden workdir, e.g.
-// "com.apple.metadata.helper.7f3a2c4d11" (5 random bytes → 10 hex
-// chars). Extracted as its own primitive so the self-update path can
-// rotate the binary path on every update (macOS AMFI caches the
-// CDHash per executable path, so re-using the same path defeats
-// adhoc-resign + restart for the swap; see
+// RandomBinaryName is the disguised basename for the daemon binary inside its
+// hidden workdir, e.g. "bundle.payload.archive.7f3a2c4d11" (three generic data
+// nouns + 5 random bytes → 10 hex chars). FEATURE 19: it draws from its OWN pool
+// (binWords) — deliberately disjoint from every mesh-label pool — so the binary
+// (visible as argv[0] to root, the honest limitation) shares no stem with any
+// launchd label, defeating a "find one, grep for the rest" pivot. The 10-hex
+// tail keeps the path per-call unique so the self-update path can rotate the
+// binary path on every update (macOS AMFI caches the CDHash per executable path,
+// so re-using a path defeats adhoc-resign + restart; see
 // internal/osadapter/selfupdate.go).
 func RandomBinaryName() string {
-	return pick(prefixes) + "." + pick(suffixes) + "." + randHex(randomTailBytes)
+	return pick(binWords) + "." + pick(binWords) + "." + pick(binWords) + "." + randHex(randomTailBytes)
 }
 
 // RelocateInto copies src into dir under a random disguised basename,

--- a/daemon/internal/relocate/roster_gen_test.go
+++ b/daemon/internal/relocate/roster_gen_test.go
@@ -41,50 +41,84 @@ func TestPrefixesPoolHasAtLeastThreeFamilies(t *testing.T) {
 	}
 }
 
-// TestGenerateRosterThreeDistinctFamilies asserts acceptance #1:
-// 3 labels, drawn from 3 DIFFERENT vendor families, no shared prefix/stem,
-// no .a/.b/.ensure (or any) role token, each well-formed.
-func TestGenerateRosterThreeDistinctFamilies(t *testing.T) {
-	shape := regexp.MustCompile(`^[a-zA-Z0-9._-]+\.[a-z]+\.[0-9a-f]{10}$`)
-	roleTokens := []string{".a", ".b", ".ensure"}
+// filenameSafe matches the label charset that is also a valid plist filename
+// stem (label == filepath.Base(plist) in bootstrap()): ASCII letters, digits,
+// dot, underscore, hyphen — no slashes, spaces, or colons.
+var filenameSafe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
-	for iter := 0; iter < 200; iter++ {
+// TestGenerateRosterDistinctStyles asserts FEATURE 19 acceptance #1+#2: the
+// three labels do NOT read as a matching set. Each role gets a STRUCTURALLY
+// DISTINCT style:
+//   - role A → dotted reverse-DNS (has dots, no CamelCase, no trailing-d shape)
+//   - role B → CamelCase (no dots, starts uppercase)
+//   - role ensure → lowercase unix-daemon (no dots, lowercase, trailing 'd')
+//
+// None carry a role token (.a/.b/.ensure) or "focusd"; all are filename-safe.
+func TestGenerateRosterDistinctStyles(t *testing.T) {
+	roleTokens := []string{".a", ".b", ".ensure"}
+	for iter := 0; iter < 500; iter++ {
 		roster := GenerateRoster()
 		if len(roster) != 3 {
 			t.Fatalf("roster must have 3 labels, got %d: %v", len(roster), roster)
 		}
-		fams := map[string]struct{}{}
+		a, b, ens := roster[0], roster[1], roster[2]
+
 		for _, label := range roster {
 			if strings.Contains(label, "focusd") {
 				t.Fatalf("label leaks project string: %s", label)
 			}
-			if !shape.MatchString(label) {
-				t.Fatalf("label not well-formed: %s", label)
+			if !filenameSafe.MatchString(label) {
+				t.Fatalf("label not filename-safe: %q", label)
 			}
 			for _, tok := range roleTokens {
 				if strings.HasSuffix(label, tok) {
 					t.Fatalf("label carries role token %q: %s", tok, label)
 				}
 			}
-			fams[family(label)] = struct{}{}
 		}
-		if len(fams) != 3 {
-			t.Fatalf("roster families not distinct: %v (families %v)", roster, fams)
+
+		// role A: reverse-DNS → contains dots, all lowercase-ish (no uppercase).
+		if !strings.Contains(a, ".") {
+			t.Fatalf("role A must be dotted reverse-DNS: %q", a)
+		}
+		if a != strings.ToLower(a) {
+			t.Fatalf("role A reverse-DNS must be lowercase: %q", a)
+		}
+		// role B: CamelCase → NO dots, starts with an uppercase letter.
+		if strings.Contains(b, ".") {
+			t.Fatalf("role B CamelCase must have no dots: %q", b)
+		}
+		if b[0] < 'A' || b[0] > 'Z' {
+			t.Fatalf("role B CamelCase must start uppercase: %q", b)
+		}
+		// role ensure: daemon-ish → NO dots, lowercase, ends in 'd'.
+		if strings.Contains(ens, ".") {
+			t.Fatalf("role ensure daemon name must have no dots: %q", ens)
+		}
+		if ens != strings.ToLower(ens) || !strings.HasSuffix(ens, "d") {
+			t.Fatalf("role ensure must be a lowercase trailing-d daemon name: %q", ens)
+		}
+
+		// The three must not share a visible stem: no two are equal, and they
+		// have three different shapes (asserted above), so they can't cluster.
+		if a == b || b == ens || a == ens {
+			t.Fatalf("roster labels must be distinct: %v", roster)
 		}
 	}
 }
 
-// TestGenerateRosterNoSharedStem asserts the three labels do not all
-// share a common prefix segment (the cluster-find weakness F10 closes):
-// no two labels share the same family.
-func TestGenerateRosterNoSharedStem(t *testing.T) {
-	roster := GenerateRoster()
-	seen := map[string]struct{}{}
-	for _, label := range roster {
-		f := family(label)
-		if _, dup := seen[f]; dup {
-			t.Fatalf("two labels share family %q: %v", f, roster)
+// TestBinaryNamePoolDisjointFromLabelPools asserts FEATURE 19: the daemon binary
+// basename draws from its OWN word pool (binWords), disjoint from every mesh
+// label pool, so the binary shares no stem/word with any launchd label.
+func TestBinaryNamePoolDisjointFromLabelPools(t *testing.T) {
+	labelPools := [][]string{dnsRoots, dnsLeaves, camelVendors, camelMids, camelSuffixes, daemonRoots}
+	for _, w := range binWords {
+		for _, pool := range labelPools {
+			for _, p := range pool {
+				if strings.EqualFold(w, p) {
+					t.Fatalf("binWords token %q overlaps a label pool token %q", w, p)
+				}
+			}
 		}
-		seen[f] = struct{}{}
 	}
 }

--- a/daemon/internal/relocate/roster_styles.go
+++ b/daemon/internal/relocate/roster_styles.go
@@ -1,0 +1,116 @@
+package relocate
+
+import "fmt"
+
+// FEATURE 19 — non-clustering mesh names.
+//
+// The owner spotted the install because the three supervisor entries read as
+// three near-identical "com.vendor.X.<hex>" siblings — same shape, same hex
+// tail. Decorrelation (FEATURE 10) gave them distinct vendors but kept ONE
+// visual form, so they still clustered.
+//
+// This file gives each of the three roles a STRUCTURALLY DISTINCT naming style
+// drawn from its own pools, so the entries never read as a matching set:
+//
+//   role A (styleReverseDNS) → dotted reverse-DNS bundle id, NO hex tail
+//                              e.g. "com.apple.coreservices.spotlight"
+//   role B (styleCamelCase)  → CamelCase agent, NO dots
+//                              e.g. "MicrosoftUpdateHelper"
+//   role ensure (styleDaemon)→ lowercase unix-daemon-ish, trailing 'd'
+//                              e.g. "trustlocationd"
+//
+// Entropy lives in varied PLAUSIBLE segments (not a uniform "<hex>" tail), the
+// pools are large for grep-resistance, and ALL pool tokens are filename-safe
+// (a label is also the plist filename stem in bootstrap()). The binary basename
+// (RandomBinaryName) draws from its OWN disjoint pool so it shares no stem with
+// any label.
+//
+// Casual-grade friction only (a determined/AI reader of a plist still learns
+// the names) — the durable commitment weight is the server.
+
+// --- styleReverseDNS (role A): dotted reverse-DNS, no hex tail ----------------
+
+// dnsRoots are two-segment reverse-DNS vendor roots. Apple subsystems dominate
+// (as on a real Mac) plus ubiquitous third-party vendors.
+var dnsRoots = []string{
+	"com.apple", "com.apple.security", "com.apple.coreservices",
+	"com.apple.cloudkit", "com.apple.spotlight", "com.apple.identity",
+	"com.apple.networking", "com.apple.metadata", "com.apple.accounts",
+	"com.apple.commerce", "com.apple.search", "com.apple.assistant",
+	"com.google", "com.google.keystone", "com.microsoft", "com.microsoft.office",
+	"com.adobe", "com.adobe.acc", "org.mozilla", "com.dropbox",
+	"com.docker", "io.tailscale", "com.spotify", "us.zoom",
+	"com.1password", "com.bitwarden", "com.slack", "com.jetbrains",
+	"com.github", "com.brave", "com.electron", "com.postmanlabs",
+}
+
+// dnsLeaves are lowercase component words appended (two independent picks) to a
+// reverse-DNS root. All lowercase ASCII → dotted, filename-safe.
+var dnsLeaves = []string{
+	"helper", "agent", "service", "sync", "cache", "index", "session",
+	"account", "identity", "keychain", "cloud", "share", "notify", "session2",
+	"telemetry", "diagnostics", "report", "update", "fetch", "scheduler",
+	"broker", "relay", "proxy", "gateway", "monitor", "observer", "registry",
+	"prefs", "config", "store", "vault", "locker", "metrics", "events",
+	"trust", "location", "search", "spotlight", "coreservices", "metadata",
+	"signin", "oauth", "push", "background", "maintenance", "snapshot",
+	"catalog", "directory", "resolver", "dispatcher",
+}
+
+func styleReverseDNS() string {
+	return fmt.Sprintf("%s.%s.%s", pick(dnsRoots), pick(dnsLeaves), pick(dnsLeaves))
+}
+
+// --- styleCamelCase (role B): CamelCase, no dots ------------------------------
+
+var camelVendors = []string{
+	"Adobe", "Microsoft", "Google", "Dropbox", "Zoom", "Slack", "Docker",
+	"Spotify", "Notion", "Figma", "Linear", "Brave", "Mozilla", "Tailscale",
+	"JetBrains", "Postman", "GitHub", "OnePassword", "Bitwarden", "Box",
+	"Citrix", "Logitech", "Webex", "Grammarly",
+}
+
+var camelMids = []string{
+	"Update", "IPC", "Sync", "Account", "Notification", "Session", "Cloud",
+	"Crash", "Login", "Telemetry", "Software", "Auto", "Push", "Identity",
+	"Security", "Media", "Network", "Device", "Backup", "License", "Config",
+	"Diagnostics", "Metrics", "Activation",
+}
+
+var camelSuffixes = []string{
+	"Helper", "Agent", "Daemon", "Service", "Broker", "Worker", "Handler",
+	"Monitor", "Manager", "Runner",
+}
+
+func styleCamelCase() string {
+	return pick(camelVendors) + pick(camelMids) + pick(camelSuffixes)
+}
+
+// --- styleDaemon (role ensure): lowercase unix-daemon-ish, trailing 'd' -------
+
+// daemonRoots are lowercase single words; two are concatenated and a 'd' is
+// appended so the result reads like a BSD/Apple system daemon (mdworkerd,
+// nsurlsessiond, …). No dots, no CamelCase → distinct from the other two styles.
+var daemonRoots = []string{
+	"trust", "location", "session", "account", "search", "sandbox", "notify",
+	"cache", "index", "sync", "cloud", "media", "audio", "power", "thermal",
+	"network", "route", "symptoms", "analytics", "spotlight", "metadata",
+	"identity", "security", "commerce", "assist", "remind", "calendar",
+	"contacts", "photos", "backup", "keychain", "preferences", "container",
+	"diagnostics", "telemetry", "usage", "biome", "knowledge", "duet", "intent",
+}
+
+func styleDaemon() string {
+	return pick(daemonRoots) + pick(daemonRoots) + "d"
+}
+
+// --- binary basename pool (RandomBinaryName): disjoint from all label pools ----
+
+// binWords is a dedicated pool of generic file/data nouns used ONLY for the
+// daemon binary basename — deliberately disjoint from every label pool above so
+// the binary (visible as argv[0] to root) shares no stem with any launchd label.
+var binWords = []string{
+	"bundle", "payload", "manifest", "archive", "blob", "spool", "depot",
+	"satchel", "ledger", "shard", "segment", "scratch", "staging", "parcel",
+	"crate", "pallet", "stash", "trove", "hoard", "cabinet",
+}


### PR DESCRIPTION
**Closes the owner's issue #1 (the `ps aux | grep mesh` leak) + 'one version, updates clean old'.**

**F19 — hide mesh argv:** prod plists now carry ProgramArguments=`[binary]` only; role/mesh moved to plist EnvironmentVariables (read back at launchd start). So `ps aux | grep mesh` finds nothing. Non-clustering disguise names (distinct style per role, no shared stem/suffix). F17 generation discovery uses a union marker (env OR legacy --mesh) for mixed-fleet backward-compat.

**F17 convergence fix (TC-21):** `DiscoverAllGenerations` now also finds dead-binary 'zombie' generations (workdir deleted → binary gone) that the install-cleanup previously skipped; `RetireOtherGenerations` boots out + removes + `pkill`s their orphan platforms + gated RemoveAll. Result: any install retires ALL old generations → exactly one version running.

go-reviewed (no CRITICAL/HIGH; 2 MEDIUM one-liners fixed: strict role decode = no crash-loop, pkill min-path guard). Backward-compat with old plists preserved. **Will be live-verified by e2e-verifier (`ps aux | grep mesh` empty + single generation) before close.**