### PR TITLE
fix(platform): enable WAL so daemon status doesn't flip 'no runs yet' / OVERALL UNKNOWN

### DIFF
--- a/platform/internal/core/state/runs_race_test.go
+++ b/platform/internal/core/state/runs_race_test.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHistory_NeverEmptyUnderConcurrentWrites reproduces the status-flip bug:
+// a read-only connection (the `status` reader) must NEVER read back 0 rows for
+// a job that has already recorded at least one run, even while a separate
+// read-write connection (the scheduler) is continuously inserting runs.
+//
+// On origin/master (rollback-journal mode) this fails: the read-only
+// connection transiently observes an empty result, which the status reader
+// maps to "no runs yet" → UNKNOWN, flipping the overall verdict.
+func TestHistory_NeverEmptyUnderConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	rw, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rw.Close()
+
+	const jobID = "kill-steam-kill"
+	// Seed: after this, the job has >=1 run forever.
+	id, err := rw.Runs.Start(jobID, "kill-steam", "1.0.0", "test")
+	if err != nil {
+		t.Fatalf("seed Start: %v", err)
+	}
+	if err := rw.Runs.Finish(JobRun{ID: id, Status: "ok"}); err != nil {
+		t.Fatalf("seed Finish: %v", err)
+	}
+
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer ro.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+
+	// Writer: mimic the scheduler hammering Start/Finish for this job.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			rid, werr := rw.Runs.Start(jobID, "kill-steam", "1.0.0", "scheduler")
+			if werr != nil {
+				continue
+			}
+			_ = rw.Runs.Finish(JobRun{ID: rid, Status: "ok"})
+		}
+	}()
+
+	// Reader: mimic `status` calling History(jobID, 1) repeatedly.
+	var emptyReads, totalReads atomic.Int64
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			runs, rerr := ro.Runs.History(jobID, 1)
+			if rerr != nil {
+				t.Errorf("History error: %v", rerr)
+				continue
+			}
+			totalReads.Add(1)
+			if len(runs) == 0 {
+				emptyReads.Add(1)
+			}
+		}
+		stop.Store(true)
+	}()
+
+	wg.Wait()
+
+	t.Logf("reads=%d empty=%d", totalReads.Load(), emptyReads.Load())
+	if n := emptyReads.Load(); n != 0 {
+		t.Fatalf("read 0 rows %d times for a job with >=1 recorded run — status would flip to 'no runs yet'", n)
+	}
+}
+
+// TestOpen_UsesWAL pins the root-cause fix: the writer DB must be in WAL mode
+// so the read-only status snapshot never contends with the scheduler. A
+// regression to rollback-journal mode reintroduces the status flip.
+func TestOpen_UsesWAL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	var mode string
+	if err := db.sql.QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", mode)
+	}
+}

--- a/platform/internal/core/state/state.go
+++ b/platform/internal/core/state/state.go
@@ -35,9 +35,17 @@ func Open(path string) (*DB, error) {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return nil, fmt.Errorf("create state dir: %w", err)
 		}
-		// _busy_timeout avoids spurious "database is locked" under the
-		// scheduler; foreign_keys on for integrity.
-		dsn = "file:" + path + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)"
+		// WAL mode is the fix for the `status` flip: in the default
+		// rollback-journal mode a writer holds an EXCLUSIVE lock during
+		// commit, so the separate read-only `status` process contends with
+		// the scheduler and its History query can hit SQLITE_BUSY. The status
+		// reader maps that error to found=false → "no runs yet" → the OVERALL
+		// verdict flips HEALTHY↔UNKNOWN. WAL lets a reader take a consistent
+		// committed snapshot without ever blocking (or being blocked by) the
+		// writer, so a job with >=1 recorded run is always read back as such.
+		// busy_timeout still backs the rare writer-vs-checkpointer contention;
+		// foreign_keys on for integrity.
+		dsn = "file:" + path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
 	}
 
 	sqldb, err := sql.Open("sqlite", dsn)


### PR DESCRIPTION
**Root cause (with empirical proof):** the platform's state.db was opened in SQLite default rollback-journal mode (no WAL). The scheduler writes job runs constantly; the separate `daemon status` read-only process calling `Runs.History(jobID,1)` exceeds its busy_timeout under writer lock contention → SQLITE_BUSY, which the reader collapses with 'zero rows' into `found=false` → 'no runs yet' → OVERALL flips to UNKNOWN. (Master: 141 reads/2.26s lock-blocked; with WAL: 1569 reads/2s, zero empty/error.)

**Fix:** add `journal_mode(WAL)` to the DB DSN (one line) so readers get a consistent committed snapshot that never blocks. Status reader unchanged (no blind retry). Tests: `History` never reads empty under concurrent writes; WAL pinned. Found live via the owner's teardown testing (the flickering kill-steam/OVERALL).