### PR TITLE
fix(daemon): sweep orphaned generation workdirs on install (TC-21 — one clean generation)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -706,6 +706,19 @@ func installMesh(self string, spec *osadapter.Spec, desired string) error {
 	} else if n > 0 {
 		fmt.Printf("retired %d prior generation(s)\n", n)
 	}
+	// FEATURE 17 follow-up (TC-21): retirement only catches generations still
+	// visible to a plist scan. A teardown/recovery/re-install cycle can also
+	// leave ORPHANED generation workdirs on disk — hidden-dot dirs with a stale
+	// state.db but NO plist/process backing them — invisible to retirement.
+	// Sweep them now (keep = the new install's workdir = Dir(relocated binary))
+	// so exactly ONE state.db survives and status reads a single source. Best-
+	// effort: a sweep failure must NOT fail an otherwise-successful install, and
+	// the swept paths are never surfaced.
+	if n, serr := osadapter.SweepOrphanWorkdirs(spec.Mode, filepath.Dir(spec.SelfPath)); serr != nil {
+		fmt.Fprintln(os.Stderr, "install: sweep orphan workdirs (best-effort) failed")
+	} else if n > 0 {
+		fmt.Printf("swept %d orphan workdir(s)\n", n)
+	}
 	return nil
 }
 

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -517,6 +517,73 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath string) (int, error) {
 		c.bootout, os.Remove, pkillBinary, os.RemoveAll), nil
 }
 
+// stateDBFile is the SQLite state file a platform writes into its generation
+// workdir (see platform: filepath.Join(workdir, "state.db")). A hidden-dot
+// directory directly under the support root that contains this file is the
+// generation-workdir signature SweepOrphanWorkdirs keys on. The out-of-band
+// watchdog copy dir (also a hidden-dot sibling) holds only the relocated binary
+// and NO state.db, so it is excluded by construction.
+const stateDBFile = "state.db"
+
+// SweepOrphanWorkdirs deletes generation workdirs that survive on disk with NO
+// loaded plist or running process backing them — the residual a teardown /
+// recovery / re-install cycle leaves behind (FEATURE 17 follow-up, TC-21).
+// RetireOtherGenerations only catches generations still visible to a plist scan
+// (live "other" + dead-binary "zombie" generations); a generation whose plist
+// was already removed leaves ONLY orphaned files on disk, invisible to that
+// scan. Those stale state.db copies clutter disk and confuse status reads
+// (multiple state sources). This sweep is the disk-side complement: after any
+// install exactly ONE generation workdir (the keep) survives.
+//
+// It scans the IMMEDIATE children of the mode's support root and removes each
+// hidden-dot directory that contains a state.db file (the generation signature)
+// and is NOT the keepWorkdir. Every removal is GATED by safeToRemoveWorkdir
+// (absolute, strictly under the support root, not the keep, not an ancestor of
+// the keep) — the same belt RetireOtherGenerations uses. The watchdog copy dir
+// has no state.db so it is never a candidate. Best-effort throughout: it returns
+// only the count of removed workdirs (never the disguised paths) and never errors
+// out the install — a failed remove is skipped, a scan failure returns the count
+// so far with the error for optional logging.
+//
+// keepWorkdir is the new install's workdir (Dir of the relocated binary).
+func SweepOrphanWorkdirs(m mode.Mode, keepWorkdir string) (removed int, err error) {
+	home, _ := os.UserHomeDir()
+	root := mode.SupportRoot(m, home)
+	entries, rerr := os.ReadDir(root)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return 0, nil
+		}
+		return 0, rerr
+	}
+	keep := filepath.Clean(keepWorkdir)
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), ".") {
+			continue // only hidden-dot directories are generation workdirs
+		}
+		dir := filepath.Join(root, e.Name())
+		if filepath.Clean(dir) == keep {
+			continue // the surviving generation — never sweep it
+		}
+		// The generation signature: a state.db file. The watchdog copy dir (a
+		// hidden-dot sibling) has none, so it is naturally excluded; a legit
+		// third-party Application Support dir is not hidden-dot and lacks our
+		// state.db, so it can never match.
+		if st, serr := os.Stat(filepath.Join(dir, stateDBFile)); serr != nil || st.IsDir() {
+			continue
+		}
+		// GUARD: only RemoveAll a dir strictly under the support root that is
+		// neither the keep nor an ancestor of it (the same belt the generation
+		// retirement uses). Best-effort: a remove failure is skipped, not fatal.
+		if safeToRemoveWorkdir(dir, root, keepWorkdir) {
+			if rmErr := os.RemoveAll(dir); rmErr == nil {
+				removed++
+			}
+		}
+	}
+	return removed, nil
+}
+
 // minBinPathLen is the floor on a binary path before retirement will pkill -f
 // it. Any real disguised install path is far longer; a short value like "/"
 // (a corrupt/dead-gen ProgramArguments[0]) must never expand into a broad

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -53,6 +53,11 @@ func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, []DeadGeneration
 // It returns (0, nil) so the cross-platform install path treats it as "nothing
 // to do" rather than surfacing ErrUnsupported on every install.
 func RetireOtherGenerations(mode.Mode, string) (int, error) { return 0, nil }
+
+// SweepOrphanWorkdirs is a no-op on non-darwin (no launchd mesh / generation
+// workdirs to sweep). Returns (0, nil) so the cross-platform install path treats
+// it as "nothing to do" rather than surfacing ErrUnsupported on every install.
+func SweepOrphanWorkdirs(mode.Mode, string) (int, error) { return 0, nil }
 func MeshStatus(mode.Mode) (loaded, total int, found bool, err error) {
 	return 0, 0, false, ErrUnsupported
 }

--- a/daemon/internal/osadapter/sweep_test.go
+++ b/daemon/internal/osadapter/sweep_test.go
@@ -1,0 +1,165 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// mkWorkdir creates a hidden-dot directory under root and, when withDB is set,
+// drops a state.db file inside it (the generation-workdir signature). Returns
+// the dir path.
+func mkWorkdir(t *testing.T, root, name string, withDB bool) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if withDB {
+		if err := os.WriteFile(filepath.Join(dir, stateDBFile), []byte("FAKE-DB"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// supportRootUnderHome points SupportRoot(User, …) at a t.TempDir() by setting
+// HOME, and returns (home, supportRoot). User mode → ~/Library/Application
+// Support.
+func supportRootUnderHome(t *testing.T) (home, root string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	root = mode.SupportRoot(mode.User, home)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return home, root
+}
+
+// TestSweepOrphanWorkdirsRemovesOrphanKeepsKeep: an orphan generation workdir
+// (hidden-dot + state.db, != keep) is removed; the keep workdir is preserved.
+func TestSweepOrphanWorkdirsRemovesOrphanKeepsKeep(t *testing.T) {
+	_, root := supportRootUnderHome(t)
+
+	keep := mkWorkdir(t, root, ".keep.gen", true)
+	orphan := mkWorkdir(t, root, ".orphan.gen", true)
+
+	removed, err := SweepOrphanWorkdirs(mode.User, keep)
+	if err != nil {
+		t.Fatalf("SweepOrphanWorkdirs: unexpected error %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan workdir should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("keep workdir should survive, stat err = %v", err)
+	}
+}
+
+// TestSweepOrphanWorkdirsSkipsNonSignatureDirs: dirs that are NOT the generation
+// signature are left alone — a hidden-dot dir WITHOUT state.db (the watchdog
+// copy dir), and a non-hidden dir WITH state.db (a legit app dir is never
+// hidden-dot). Only the true orphan is removed.
+func TestSweepOrphanWorkdirsSkipsNonSignatureDirs(t *testing.T) {
+	_, root := supportRootUnderHome(t)
+
+	keep := mkWorkdir(t, root, ".keep.gen", true)
+	watchdog := mkWorkdir(t, root, ".watchdog.copy", false) // hidden-dot, NO state.db
+	plainApp := mkWorkdir(t, root, "SomeVendorApp", true)   // state.db but not hidden-dot
+	orphan := mkWorkdir(t, root, ".orphan.gen", true)
+
+	removed, err := SweepOrphanWorkdirs(mode.User, keep)
+	if err != nil {
+		t.Fatalf("SweepOrphanWorkdirs: unexpected error %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (only the orphan)", removed)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan should be removed, stat err = %v", err)
+	}
+	for name, dir := range map[string]string{"keep": keep, "watchdog": watchdog, "plainApp": plainApp} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("%s dir should survive, stat err = %v", name, err)
+		}
+	}
+}
+
+// TestSweepOrphanWorkdirsNoSupportRoot: a missing support root is not an error
+// (nothing installed yet) — returns (0, nil).
+func TestSweepOrphanWorkdirsNoSupportRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Do NOT create ~/Library/Application Support.
+
+	removed, err := SweepOrphanWorkdirs(mode.User, filepath.Join(mode.SupportRoot(mode.User, home), ".keep"))
+	if err != nil {
+		t.Fatalf("missing support root should be (0,nil), got err %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+}
+
+// TestSweepOrphanWorkdirsGateBlocksKeep: even if the keep path were somehow a
+// candidate, the keep-exclusion + safeToRemoveWorkdir belt prevents deleting it.
+// Here we sweep with an EMPTY keep + a state.db-bearing dir whose path is the
+// support root's only child; safeToRemoveWorkdir still permits a strictly-nested
+// orphan, so it is removed — confirming the gate allows legitimate targets while
+// the prior tests confirm it blocks the keep.
+func TestSweepOrphanWorkdirsGateAllowsNestedOrphan(t *testing.T) {
+	_, root := supportRootUnderHome(t)
+	orphan := mkWorkdir(t, root, ".lonely.orphan", true)
+
+	// keepWorkdir under root but a different dir → orphan is strictly-nested,
+	// not the keep, not an ancestor → safeToRemoveWorkdir permits removal.
+	keep := filepath.Join(root, ".keep.gen")
+
+	removed, err := SweepOrphanWorkdirs(mode.User, keep)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("nested orphan should be removed, stat err = %v", err)
+	}
+}
+
+// TestSafeToRemoveWorkdirBlocksBadTargets pins the safety belt SweepOrphanWorkdirs
+// relies on: outside-root, the root itself, and an ancestor of keep are all
+// refused; a strictly-nested non-keep dir is allowed.
+func TestSafeToRemoveWorkdirBlocksBadTargets(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	keep := filepath.Join(root, "keepgen")
+	if err := os.MkdirAll(keep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orphan := filepath.Join(root, "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if safeToRemoveWorkdir(outside, root, keep) {
+		t.Fatal("outside-root dir must be refused")
+	}
+	if safeToRemoveWorkdir(root, root, keep) {
+		t.Fatal("the support root itself must be refused")
+	}
+	if safeToRemoveWorkdir(keep, root, keep) {
+		t.Fatal("the keep workdir must be refused")
+	}
+	if !safeToRemoveWorkdir(orphan, root, keep) {
+		t.Fatal("a strictly-nested non-keep dir must be allowed")
+	}
+}


### PR DESCRIPTION
**Closes the TC-21 stale-on-disk residual (owner reqs 3 & 7).** After teardown/recovery + re-install cycles, orphaned generation workdirs pile up on disk (hidden-dot dirs with `state.db`, no live plist/proc) — invisible to the plist-scan cleanup, and they made `daemon status` read stale data.

New `SweepOrphanWorkdirs(mode, keepWorkdir)` runs in `installMesh` right after `RetireOtherGenerations`: scans immediate hidden-dot children of SupportRoot containing `state.db`, removes every one that isn't the keep workdir — gated by the (already-reviewed) `safeToRemoveWorkdir` belt (absolute, symlink-resolved, strictly under SupportRoot, not keep/ancestor). Watchdog dir excluded (no state.db). Net: after any install, exactly ONE generation workdir survives → no stale state.db → status reads one source. Tests cover orphan-removed / keep-preserved / watchdog-skipped / vendor-skipped / gate-blocks-bad-targets.