### PR TITLE
fix(platform): status reader sees committed runs cross-process (real flip fix; reverts #74 WAL)

### DIFF
--- a/platform/cmd/platform/main.go
+++ b/platform/cmd/platform/main.go
@@ -259,9 +259,24 @@ func runStatus(args []string) int {
 		if db, derr := state.OpenReadOnly(dbPath); derr == nil {
 			defer db.Close()
 			lastRun = func(jobID string) (string, time.Time, bool, error) {
-				runs, herr := db.Runs.History(jobID, 1)
-				if herr != nil || len(runs) == 0 {
+				// Retry on a transient read error (e.g. SQLITE_BUSY if the
+				// writer's brief commit lock outlasts busy_timeout) so a
+				// momentary lock is never mistaken for history. Crucially we do
+				// NOT conflate the two failure shapes:
+				//   - herr != nil  → a transient READ error. Return it as an
+				//     error (found=false) so the job reads UNKNOWN for THIS tick
+				//     only; it is not a definitive "never ran" claim and the
+				//     next status read recovers. Previously an error and an
+				//     empty result were collapsed into the same found=false,
+				//     so a transient query error rolled OVERALL to UNKNOWN
+				//     identically to a genuine fresh install.
+				//   - herr == nil && len(runs) == 0 → a GENUINE "no run yet".
+				runs, herr := historyWithRetry(db.Runs.History, jobID)
+				if herr != nil {
 					return "", time.Time{}, false, herr
+				}
+				if len(runs) == 0 {
+					return "", time.Time{}, false, nil
 				}
 				// A malformed/corrupt StartedAt parses to the year-0 zero time,
 				// which would mis-bucket age as ">1h" and lie about staleness
@@ -295,6 +310,34 @@ func runStatus(args []string) int {
 		return 0
 	}
 	return 1
+}
+
+// historyReadAttempts / historyReadBackoff bound the status reader's retry on
+// a transient History error. With a 5s busy_timeout already absorbing the
+// writer's sub-millisecond commit lock, a couple of short retries is ample;
+// the goal is to avoid surfacing a momentary SQLITE_BUSY as missing history,
+// not to mask a genuinely broken DB.
+const (
+	historyReadAttempts = 3
+	historyReadBackoff  = 25 * time.Millisecond
+)
+
+// historyWithRetry calls the run-history query, retrying only on a transient
+// ERROR. A successful read — including a genuine empty result — returns
+// immediately and is NEVER retried (an empty history is a real answer, not a
+// failure). Separating "error" from "empty" is what keeps a transient read
+// error from masquerading as "no runs yet". query mirrors JobRunRepo.History.
+func historyWithRetry(query func(jobID string, limit int) ([]state.JobRun, error), jobID string) ([]state.JobRun, error) {
+	var runs []state.JobRun
+	var err error
+	for attempt := 0; attempt < historyReadAttempts; attempt++ {
+		runs, err = query(jobID, 1)
+		if err == nil {
+			return runs, nil
+		}
+		time.Sleep(historyReadBackoff)
+	}
+	return runs, err
 }
 
 func runRun(args []string) int {

--- a/platform/cmd/platform/main_test.go
+++ b/platform/cmd/platform/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/platform/internal/core/state"
+)
+
+// TestHistoryWithRetry_SeparatesErrorFromEmpty is the bug-#2 guard: the status
+// reader must NOT conflate a transient read ERROR with a genuine empty history.
+func TestHistoryWithRetry_SeparatesErrorFromEmpty(t *testing.T) {
+	seeded := []state.JobRun{{JobID: "kill-steam-kill", Status: "ok"}}
+
+	t.Run("retries past a transient error then succeeds", func(t *testing.T) {
+		calls := 0
+		query := func(string, int) ([]state.JobRun, error) {
+			calls++
+			if calls < historyReadAttempts {
+				return nil, errors.New("database is locked (SQLITE_BUSY)")
+			}
+			return seeded, nil
+		}
+		runs, err := historyWithRetry(query, "kill-steam-kill")
+		if err != nil {
+			t.Fatalf("err = %v, want nil after retry recovered", err)
+		}
+		if len(runs) != 1 {
+			t.Fatalf("runs = %d, want 1 — a transient error must not surface as missing history", len(runs))
+		}
+		if calls != historyReadAttempts {
+			t.Fatalf("calls = %d, want %d (should retry until success)", calls, historyReadAttempts)
+		}
+	})
+
+	t.Run("a genuine empty result is returned immediately, not retried", func(t *testing.T) {
+		calls := 0
+		query := func(string, int) ([]state.JobRun, error) {
+			calls++
+			return nil, nil // no error, no rows: a real "never ran"
+		}
+		runs, err := historyWithRetry(query, "kill-steam-kill")
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if len(runs) != 0 {
+			t.Fatalf("runs = %d, want 0", len(runs))
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1 — an empty result is a real answer and must not be retried", calls)
+		}
+	})
+
+	t.Run("a persistent error is returned as an error, never as empty history", func(t *testing.T) {
+		wantErr := errors.New("disk I/O error")
+		query := func(string, int) ([]state.JobRun, error) {
+			return nil, wantErr
+		}
+		runs, err := historyWithRetry(query, "kill-steam-kill")
+		if err == nil {
+			t.Fatal("err = nil, want the read error — a persistent read error must be reported, not masked as 'no runs'")
+		}
+		if len(runs) != 0 {
+			t.Fatalf("runs = %d, want 0 on error", len(runs))
+		}
+	})
+}

--- a/platform/internal/core/state/runs_crossproc_test.go
+++ b/platform/internal/core/state/runs_crossproc_test.go
@@ -1,0 +1,163 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Env handshake for the re-exec child reader. When set, TestStatusReader_child
+// becomes the reader subprocess; otherwise it skips (it is driven only by the
+// parent test below).
+const (
+	envCrossProcDB  = "FOCUSD_TEST_RO_DB"
+	envCrossProcDur = "FOCUSD_TEST_RO_DUR_MS"
+	crossProcJobID  = "kill-steam-kill"
+)
+
+var childResultRe = regexp.MustCompile(`CHILD_RESULT reads=(\d+) empty=(\d+) errs=(\d+) minrows=(\d+)`)
+
+// TestStatusReader_CrossProcess_SeesCommittedRuns is the decisive reproduction
+// of the live status flip. A SEPARATE OS PROCESS (re-exec of the test binary)
+// opens the DB read-only — exactly like `daemon status` — and polls
+// Runs.History(jobID, 1) while THIS process continuously commits runs. Once a
+// run is committed, the cross-process reader must observe >=1 row within a
+// bounded time and must NEVER spuriously read 0 or error.
+//
+// This is the gap the earlier WAL fix (#74) missed: its test used a same-uid,
+// same-process read-only connection, which can attach the WAL's -shm and so
+// always saw committed runs — passing in test while the live cross-process
+// reader, unable to attach a hot -wal, read the stale main file and flipped the
+// verdict. In rollback-journal mode the commit lands in the main file, so a
+// separate process always sees it.
+func TestStatusReader_CrossProcess_SeesCommittedRuns(t *testing.T) {
+	if os.Getenv(envCrossProcDB) != "" {
+		t.Skip("running as the re-exec child reader")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.db")
+
+	rw, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rw.Close()
+
+	// Seed: after this commit the job has >=1 run forever. Any subsequent
+	// cross-process read of 0 rows is a currency bug.
+	id, err := rw.Runs.Start(crossProcJobID, "kill-steam", "1.0.0", "test")
+	if err != nil {
+		t.Fatalf("seed Start: %v", err)
+	}
+	if err := rw.Runs.Finish(JobRun{ID: id, Status: "ok"}); err != nil {
+		t.Fatalf("seed Finish: %v", err)
+	}
+
+	// Writer goroutine in THIS process: mimic the scheduler committing runs
+	// while the separate reader process polls.
+	const durMS = 2000
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			rid, werr := rw.Runs.Start(crossProcJobID, "kill-steam", "1.0.0", "scheduler")
+			if werr != nil {
+				continue
+			}
+			_ = rw.Runs.Finish(JobRun{ID: rid, Status: "ok"})
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	// Re-exec ourselves as the reader subprocess.
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestStatusReader_child$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		envCrossProcDB+"="+path,
+		envCrossProcDur+"="+strconv.Itoa(durMS),
+	)
+	out, runErr := cmd.CombinedOutput()
+	stop.Store(true)
+	wg.Wait()
+
+	if runErr != nil {
+		t.Fatalf("reader subprocess failed: %v\n%s", runErr, out)
+	}
+
+	m := childResultRe.FindStringSubmatch(string(out))
+	if m == nil {
+		t.Fatalf("could not parse child result from output:\n%s", out)
+	}
+	reads, _ := strconv.Atoi(m[1])
+	empty, _ := strconv.Atoi(m[2])
+	errs, _ := strconv.Atoi(m[3])
+	minrows, _ := strconv.Atoi(m[4])
+	t.Logf("cross-process reader: reads=%d empty=%d errs=%d minrows=%d", reads, empty, errs, minrows)
+
+	if reads == 0 {
+		t.Fatalf("reader made no reads")
+	}
+	if errs != 0 {
+		t.Fatalf("cross-process reader hit %d read errors — a transient read must not surface as missing history", errs)
+	}
+	if empty != 0 {
+		t.Fatalf("cross-process reader read 0 rows %d times for a job with >=1 committed run — status would flip to 'no runs yet'", empty)
+	}
+	if minrows < 1 {
+		t.Fatalf("cross-process reader observed minrows=%d, want >=1", minrows)
+	}
+}
+
+// TestStatusReader_child is the re-exec reader subprocess. It runs only when
+// envCrossProcDB is set (otherwise it skips, so a normal `go test` run is a
+// no-op). It opens the DB read-only exactly as the status path does and polls
+// History, reporting the worst case it observed on stdout for the parent.
+func TestStatusReader_child(t *testing.T) {
+	dbPath := os.Getenv(envCrossProcDB)
+	if dbPath == "" {
+		t.Skip("not the cross-process reader child")
+	}
+	durMS, _ := strconv.Atoi(os.Getenv(envCrossProcDur))
+	if durMS <= 0 {
+		durMS = 2000
+	}
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer ro.Close()
+
+	deadline := time.Now().Add(time.Duration(durMS) * time.Millisecond)
+	var reads, empty, errs int
+	minrows := 1 << 30
+	for time.Now().Before(deadline) {
+		runs, herr := ro.Runs.History(crossProcJobID, 1)
+		reads++
+		if herr != nil {
+			errs++
+			continue
+		}
+		if n := len(runs); n < minrows {
+			minrows = n
+		}
+		if len(runs) == 0 {
+			empty++
+		}
+	}
+	if minrows == 1<<30 {
+		minrows = 0
+	}
+	// Sentinel parsed by the parent. Use fmt (not t.Logf) so it lands on
+	// stdout verbatim regardless of test log formatting.
+	fmt.Printf("CHILD_RESULT reads=%d empty=%d errs=%d minrows=%d\n", reads, empty, errs, minrows)
+}

--- a/platform/internal/core/state/runs_race_test.go
+++ b/platform/internal/core/state/runs_race_test.go
@@ -8,14 +8,16 @@ import (
 	"time"
 )
 
-// TestHistory_NeverEmptyUnderConcurrentWrites reproduces the status-flip bug:
-// a read-only connection (the `status` reader) must NEVER read back 0 rows for
-// a job that has already recorded at least one run, even while a separate
-// read-write connection (the scheduler) is continuously inserting runs.
+// TestHistory_NeverEmptyUnderConcurrentWrites is the same-process guard for
+// the status-flip bug: a read-only connection (the `status` reader) must NEVER
+// read back 0 rows for a job that already recorded at least one run, even while
+// a separate read-write connection (the scheduler) inserts runs continuously.
 //
-// On origin/master (rollback-journal mode) this fails: the read-only
-// connection transiently observes an empty result, which the status reader
-// maps to "no runs yet" → UNKNOWN, flipping the overall verdict.
+// NOTE: this same-process variant is necessary but NOT sufficient — it passed
+// under the earlier WAL fix too, because a same-uid in-process reader CAN
+// attach the WAL's -shm and so sees committed-but-uncheckpointed runs. The live
+// flip was a CROSS-PROCESS reader that could not attach a hot WAL; see
+// TestStatusReader_CrossProcess_SeesCommittedRuns for the decisive reproduction.
 func TestHistory_NeverEmptyUnderConcurrentWrites(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.db")
 
@@ -85,10 +87,15 @@ func TestHistory_NeverEmptyUnderConcurrentWrites(t *testing.T) {
 	}
 }
 
-// TestOpen_UsesWAL pins the root-cause fix: the writer DB must be in WAL mode
-// so the read-only status snapshot never contends with the scheduler. A
-// regression to rollback-journal mode reintroduces the status flip.
-func TestOpen_UsesWAL(t *testing.T) {
+// TestOpen_UsesRollbackJournal pins the root-cause fix and guards against
+// re-introducing the earlier (failed) WAL attempt. The writer DB must use
+// rollback-journal mode (journal_mode=delete) so every commit lands in the
+// MAIN db file and is therefore visible to ANY read-only reader — including a
+// separate, possibly privilege-dropped `daemon status` process — with no
+// dependency on attaching a WAL -shm sidecar. A regression to WAL reintroduces
+// the cross-process status flip (committed runs stranded in an unattachable
+// -wal → stale 0-row reads → HEALTHY↔UNKNOWN).
+func TestOpen_UsesRollbackJournal(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.db")
 	db, err := Open(path)
 	if err != nil {
@@ -100,7 +107,12 @@ func TestOpen_UsesWAL(t *testing.T) {
 	if err := db.sql.QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
 		t.Fatalf("PRAGMA journal_mode: %v", err)
 	}
-	if mode != "wal" {
-		t.Fatalf("journal_mode = %q, want wal", mode)
+	if mode == "wal" {
+		t.Fatalf("journal_mode = %q, want a rollback-journal mode (delete) — "+
+			"WAL strands committed runs in the -wal and reintroduces the "+
+			"cross-process status flip", mode)
+	}
+	if mode != "delete" {
+		t.Fatalf("journal_mode = %q, want delete", mode)
 	}
 }

--- a/platform/internal/core/state/state.go
+++ b/platform/internal/core/state/state.go
@@ -35,17 +35,25 @@ func Open(path string) (*DB, error) {
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			return nil, fmt.Errorf("create state dir: %w", err)
 		}
-		// WAL mode is the fix for the `status` flip: in the default
-		// rollback-journal mode a writer holds an EXCLUSIVE lock during
-		// commit, so the separate read-only `status` process contends with
-		// the scheduler and its History query can hit SQLITE_BUSY. The status
-		// reader maps that error to found=false → "no runs yet" → the OVERALL
-		// verdict flips HEALTHY↔UNKNOWN. WAL lets a reader take a consistent
-		// committed snapshot without ever blocking (or being blocked by) the
-		// writer, so a job with >=1 recorded run is always read back as such.
-		// busy_timeout still backs the rare writer-vs-checkpointer contention;
-		// foreign_keys on for integrity.
-		dsn = "file:" + path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+		// Rollback-journal mode (journal_mode=DELETE) is required for the
+		// `status` flip fix. The separate `daemon status` PROCESS opens this
+		// DB read-only (OpenReadOnly, mode=ro). Under WAL, freshly committed
+		// runs live in the -wal sidecar until a checkpoint folds them into the
+		// main file; a cross-process read-only opener that cannot attach the
+		// WAL's shared-memory index (-shm) — the live case: a separate, possibly
+		// privilege-dropped reader against a hot, un-checkpointed -wal — reads
+		// the STALE main file and sees 0 rows → "no runs yet" → OVERALL flips
+		// HEALTHY↔UNKNOWN. (This is why the earlier WAL fix passed in-process
+		// but failed live.) In rollback-journal mode every commit lands in the
+		// MAIN db file and the journal is removed on commit, so ANY read-only
+		// reader — same process or separate, regardless of -shm permissions —
+		// always observes the last committed state. No sidecar, no staleness.
+		// journal_mode(DELETE) is set explicitly so a DB previously left in
+		// (persistent) WAL mode is converted back on open. The reader's
+		// contention with a writer's brief commit lock is handled by a generous
+		// busy_timeout + reader retry (see OpenReadOnly / status), never by
+		// treating SQLITE_BUSY as empty. foreign_keys on for integrity.
+		dsn = "file:" + path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(DELETE)&_pragma=foreign_keys(1)"
 	}
 
 	sqldb, err := sql.Open("sqlite", dsn)
@@ -84,7 +92,11 @@ func Open(path string) (*DB, error) {
 // expected to degrade to "history unavailable" rather than treat this as
 // fatal.
 func OpenReadOnly(path string) (*DB, error) {
-	dsn := "file:" + path + "?mode=ro&_pragma=busy_timeout(2000)"
+	// A generous busy_timeout lets a read query ride out the writer's brief
+	// per-commit EXCLUSIVE lock (rollback-journal mode) instead of erroring,
+	// so a momentary lock is never surfaced as "no runs". The caller adds a
+	// bounded retry on top for the rare timeout overrun.
+	dsn := "file:" + path + "?mode=ro&_pragma=busy_timeout(5000)"
 	sqldb, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite ro: %w", err)


### PR DESCRIPTION
**The real fix for the status flip** (#74's WAL was a misdiagnosis). Live evidence: 1 generation, 1 stable platform, yet a separate read-only sqlite query returned 0 rows for kill-steam every time while the `-wal` file sat at 4MB uncheckpointed — recent runs were stranded in the WAL, invisible to the cross-process read-only `daemon status` reader → 'no runs yet' → OVERALL UNKNOWN flicker.

**Fix:** `journal_mode=DELETE` (rollback-journal) so writes commit to the MAIN db and any read-only reader always sees committed state; generous `busy_timeout` + reader retry to ride out the writer's brief lock; and stop conflating a transient query ERROR with a definitive 'no runs yet' (a read error must not flip a healthy plugin to UNKNOWN). New `runs_crossproc_test.go` reproduces the ACTUAL symptom the #74 throughput test missed: a separate read-only connection must observe a just-committed run within bounded time and never spuriously read 0.