### PR TITLE
feat(daemon): FEATURE 18 — out-of-band companion (offline daemon recovery, launchd no-FDA)

### DIFF
--- a/daemon/cmd/companion/main.go
+++ b/daemon/cmd/companion/main.go
@@ -1,0 +1,58 @@
+// Command companion is the focusd out-of-band recovery rail (FEATURE 18 /
+// ADR-0020). It is a SEPARATE, minimal binary living in its own fixed disguised
+// folder (NOT the daemon binary, NOT under the daemon's workdir), run by launchd
+// on a StartInterval. Each run performs one recovery pass: if the daemon's
+// heartbeat has gone stale, it promotes its own signature-verified offline copy
+// of the daemon and hands off to the daemon's idempotent `watchdog` rebuild —
+// restoring protection with NO network. Then it exits; launchd re-runs it.
+//
+// Minimal by design (ADR-0020): few reasons to change, so the rail stays stable
+// and out of the way. Its dependencies are deliberately tiny — mode, sig, and
+// internal/companion — and it does NOT import the daemon's osadapter install
+// code. launchd, not cron, so it can be established + repaired in an automated
+// context WITHOUT Full Disk Access (the failure ADR-0020 reverses).
+package main
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/companion"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
+)
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	m := mode.Resolve()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// No resolvable home → the companion folder path would be relative;
+		// refuse rather than touch the wrong place. launchd re-runs us next
+		// interval. PATH-FREE: print nothing identifying.
+		os.Stderr.WriteString("companion: cannot resolve home directory\n")
+		return 1
+	}
+	dir := companion.For(m, home)
+	if rerr := recover(dir, time.Now(), sig.VerifyFile, execWatchdog); rerr != nil {
+		// PATH-FREE: never print the disguised companion/daemon paths a
+		// weak-moment self would need. Keep it abstract; launchd captures this
+		// to the companion log.
+		os.Stderr.WriteString("companion: recovery pass did not complete\n")
+		return 1
+	}
+	return 0
+}
+
+// execWatchdog runs the promoted daemon binary's idempotent watchdog rebuild:
+//
+//	<bin> watchdog -v <desired>
+//
+// The watchdog no-ops when the mesh is already complete (the anti-fight guard),
+// so a false-positive staleness costs at most one harmless run. A child run +
+// wait is enough; launchd re-runs the companion on the next interval.
+func execWatchdog(bin, desired string) error {
+	return exec.Command(bin, "watchdog", "-v", desired).Run()
+}

--- a/daemon/cmd/companion/recover.go
+++ b/daemon/cmd/companion/recover.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/companion"
+)
+
+// recover is the companion's single recovery pass (FEATURE 18 / ADR-0020),
+// injectable for unit testing. verify is the signature check (sig.VerifyFile in
+// production); execDaemon runs the promoted daemon binary's idempotent
+// `watchdog` subcommand.
+//
+// Steps:
+//  1. Heartbeat fresh (< StaleThreshold) → the daemon is alive → no-op.
+//  2. Stale (or heartbeat missing) → read the pinned desired version (reject if
+//     not valid semver), signature-verify the offline backup; an invalid/
+//     tampered backup is REFUSED WITHOUT promoting (path-free error).
+//  3. Atomically place the verified backup at the promote path (0755), then
+//     hand off to `daemon watchdog -v <desired>`.
+//
+// ANTI-FIGHT (critical): restoration goes through the daemon's IDEMPOTENT
+// watchdog, which no-ops when the mesh is already complete
+// (FindCurrentInstall/meshComplete). The heartbeat is ONLY an optimization — the
+// daemon's meshComplete is the authority — so a false "stale" costs exactly one
+// harmless watchdog run and creates ZERO new generations on a healthy install.
+func recover(
+	dir companion.Dir, now time.Time,
+	verify func(path string) (bool, error),
+	execDaemon func(bin, desired string) error,
+) error {
+	// 1. Heartbeat fresh → daemon alive → no-op. A missing heartbeat (Stat
+	//    error) falls through to the restore path (treated as stale).
+	if fi, err := os.Stat(dir.Heartbeat()); err == nil {
+		if !companion.DecideStale(fi.ModTime(), now) {
+			return nil
+		}
+	}
+
+	// 2. Stale (or missing): restore. The watchdog needs an explicit -v and
+	//    refuses garbage, so validate the pinned version up front.
+	desired, derr := readTrimmed(dir.Desired())
+	if derr != nil || !companion.IsValidVersion(desired) {
+		return fmt.Errorf("companion: missing/invalid desired version; refusing to restore")
+	}
+	// Signature-verify the offline backup BEFORE it can be promoted + exec'd as
+	// root. A genuine backup is a signed daemon binary and verifies; a tampered/
+	// poisoned copy fails → refuse WITHOUT promoting. PATH-FREE message.
+	if ok, verr := verify(dir.Backup()); verr != nil || !ok {
+		return fmt.Errorf("companion: offline backup failed signature verification; refusing to promote")
+	}
+
+	// 3. Atomically place the verified backup, then hand off to the idempotent
+	//    watchdog rebuild.
+	if err := placeExecutable(dir.Backup(), dir.Promote()); err != nil {
+		return fmt.Errorf("companion: place backup failed")
+	}
+	return execDaemon(dir.Promote(), desired)
+}
+
+// readTrimmed reads a small file and trims surrounding whitespace.
+func readTrimmed(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// placeExecutable copies src to dst atomically (temp + rename, same dir → same
+// filesystem) with 0755, so a crash mid-copy can't leave a half-written binary
+// that exec would run.
+func placeExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dst)
+}

--- a/daemon/cmd/companion/recover_test.go
+++ b/daemon/cmd/companion/recover_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/companion"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// companionDir builds a real companion.Dir rooted under a temp HOME and creates
+// the folder so tests can drop heartbeat/desired/backup files into it.
+func companionTestDir(t *testing.T) companion.Dir {
+	t.Helper()
+	home := t.TempDir()
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// recorder captures the seam calls so a test asserts exactly what recover did.
+type recorder struct {
+	verified    []string
+	execBin     string
+	execDesired string
+	execCalls   int
+}
+
+const goodDesired = "v0.16.3"
+
+// TestRecoverFreshHeartbeatNoOp: a fresh heartbeat means the daemon is alive —
+// recover must be a pure no-op: it never verifies the backup and never execs.
+func TestRecoverFreshHeartbeatNoOp(t *testing.T) {
+	dir := companionTestDir(t)
+	writeFile(t, dir.Heartbeat(), "")        // just touched (mtime = now)
+	writeFile(t, dir.Desired(), goodDesired) // present but must NOT be consulted
+	writeFile(t, dir.Backup(), "SIGNED-DAEMON")
+
+	rec := &recorder{}
+	err := recover(dir, time.Now(),
+		func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+		func(bin, desired string) error { rec.execCalls++; return nil },
+	)
+	if err != nil {
+		t.Fatalf("recover (fresh) = %v, want nil", err)
+	}
+	if len(rec.verified) != 0 {
+		t.Fatalf("verify ran on a fresh heartbeat; want 0, got %v", rec.verified)
+	}
+	if rec.execCalls != 0 {
+		t.Fatalf("execDaemon ran on a fresh heartbeat; want 0, got %d", rec.execCalls)
+	}
+}
+
+// TestRecoverStaleValidBackupExecs: a stale heartbeat + valid desired + a
+// signature-verifying backup → recover promotes the backup and hands off to the
+// idempotent watchdog (execDaemon) with the promote path + pinned version.
+//
+// ANTI-FIGHT (invariant #3): the handoff target is the daemon's `watchdog`,
+// which no-ops a complete mesh (see runWatchdog tests in cmd/daemon) — so even
+// this stale-but-actually-healthy path creates ZERO new generations.
+func TestRecoverStaleValidBackupExecs(t *testing.T) {
+	dir := companionTestDir(t)
+	writeFile(t, dir.Heartbeat(), "")
+	staleMtime := time.Now().Add(-companion.StaleThreshold - time.Minute)
+	if err := os.Chtimes(dir.Heartbeat(), staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir.Desired(), goodDesired)
+	writeFile(t, dir.Backup(), "SIGNED-DAEMON-BYTES")
+
+	rec := &recorder{}
+	err := recover(dir, time.Now(),
+		func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+		func(bin, desired string) error {
+			rec.execCalls++
+			rec.execBin = bin
+			rec.execDesired = desired
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("recover (stale+valid) = %v, want nil", err)
+	}
+	if len(rec.verified) != 1 || rec.verified[0] != dir.Backup() {
+		t.Fatalf("verify calls = %v, want [%s]", rec.verified, dir.Backup())
+	}
+	if rec.execCalls != 1 {
+		t.Fatalf("execDaemon calls = %d, want 1", rec.execCalls)
+	}
+	if rec.execBin != dir.Promote() {
+		t.Fatalf("execDaemon bin = %q, want promote path %q", rec.execBin, dir.Promote())
+	}
+	if rec.execDesired != goodDesired {
+		t.Fatalf("execDaemon desired = %q, want %q", rec.execDesired, goodDesired)
+	}
+	// The verified backup was atomically placed at the promote path.
+	if _, statErr := os.Stat(dir.Promote()); statErr != nil {
+		t.Fatalf("promote path not placed: %v", statErr)
+	}
+}
+
+// TestRecoverStaleBadBackupNoPromote: a stale heartbeat but a backup that FAILS
+// signature verification → recover must NOT promote and must NOT exec; it
+// returns an error. Closes the poisoned-offline-restore hole (acceptance #4).
+func TestRecoverStaleBadBackupNoPromote(t *testing.T) {
+	dir := companionTestDir(t)
+	staleMtime := time.Now().Add(-companion.StaleThreshold - time.Minute)
+	writeFile(t, dir.Heartbeat(), "")
+	if err := os.Chtimes(dir.Heartbeat(), staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir.Desired(), goodDesired)
+	writeFile(t, dir.Backup(), "TAMPERED")
+
+	rec := &recorder{}
+	err := recover(dir, time.Now(),
+		func(p string) (bool, error) { rec.verified = append(rec.verified, p); return false, nil }, // reject
+		func(bin, desired string) error { rec.execCalls++; return nil },
+	)
+	if err == nil {
+		t.Fatalf("recover (stale+bad backup) = nil, want error")
+	}
+	if rec.execCalls != 0 {
+		t.Fatalf("execDaemon ran with an unverified backup; want 0, got %d", rec.execCalls)
+	}
+	if _, statErr := os.Stat(dir.Promote()); statErr == nil {
+		t.Fatalf("backup was promoted despite failing verification")
+	}
+}
+
+// TestRecoverStaleInvalidDesiredNoVerify: a stale heartbeat with a missing/
+// garbage desired version is refused BEFORE the backup is even verified — the
+// watchdog can't rebuild without a valid -v, so we never promote.
+func TestRecoverStaleInvalidDesiredNoVerify(t *testing.T) {
+	for _, desired := range []string{"", "latest", "garbage"} {
+		t.Run("desired="+desired, func(t *testing.T) {
+			dir := companionTestDir(t)
+			staleMtime := time.Now().Add(-companion.StaleThreshold - time.Minute)
+			writeFile(t, dir.Heartbeat(), "")
+			if err := os.Chtimes(dir.Heartbeat(), staleMtime, staleMtime); err != nil {
+				t.Fatal(err)
+			}
+			if desired != "" {
+				writeFile(t, dir.Desired(), desired)
+			}
+			writeFile(t, dir.Backup(), "SIGNED-DAEMON")
+
+			rec := &recorder{}
+			err := recover(dir, time.Now(),
+				func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+				func(bin, desired string) error { rec.execCalls++; return nil },
+			)
+			if err == nil {
+				t.Fatalf("recover with invalid desired %q = nil, want error", desired)
+			}
+			if len(rec.verified) != 0 {
+				t.Fatalf("verify ran before rejecting invalid desired %q: %v", desired, rec.verified)
+			}
+			if rec.execCalls != 0 {
+				t.Fatalf("execDaemon ran with invalid desired %q", desired)
+			}
+		})
+	}
+}
+
+// TestRecoverMissingHeartbeatTreatedStale: with NO heartbeat file at all (a
+// freshly-wiped state), recover treats the daemon as down and restores.
+func TestRecoverMissingHeartbeatTreatedStale(t *testing.T) {
+	dir := companionTestDir(t)
+	// No heartbeat file.
+	writeFile(t, dir.Desired(), goodDesired)
+	writeFile(t, dir.Backup(), "SIGNED-DAEMON")
+
+	rec := &recorder{}
+	err := recover(dir, time.Now(),
+		func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+		func(bin, desired string) error { rec.execCalls++; return nil },
+	)
+	if err != nil {
+		t.Fatalf("recover (missing heartbeat) = %v, want nil", err)
+	}
+	if rec.execCalls != 1 {
+		t.Fatalf("execDaemon calls = %d, want 1 (missing heartbeat ⇒ stale)", rec.execCalls)
+	}
+}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -396,13 +396,18 @@ func loop(args []string, once bool) int {
 			} else if len(rec) > 0 {
 				log.Info("mesh recreated", "roles", rec)
 			}
-			// FEATURE 12 / ADR-0016: mutual guarding — the mesh's own
-			// reconcile also keeps the out-of-band watchdog rail up. Pass an
-			// empty copy path: EnsureWatchdog's darwin impl recovers the copy
-			// from the existing cron line, or places a fresh one if the rail
-			// was removed (place-if-missing). Best-effort; never fails a tick.
-			if werr := osadapter.EnsureWatchdog(spec.Mode, "", (&core.Store{Dir: o.workdir}).Desired()); werr != nil {
-				log.Warn("ensure-watchdog", "err", werr)
+			// FEATURE 18 / ADR-0020: out-of-band COMPANION mutual guarding — the
+			// mesh's own reconcile keeps the companion rail up (idempotent) AND
+			// refreshes the daemon heartbeat the companion watches, so a healthy
+			// daemon is never falsely "recovered". Best-effort; never fails a
+			// tick. (Supersedes the FEATURE 12 cron watchdog rail.)
+			if desired := (&core.Store{Dir: o.workdir}).Desired(); desired != "" {
+				if cerr := osadapter.EnsureCompanion(spec.Mode, self, desired); cerr != nil {
+					log.Warn("ensure-companion", "err", cerr)
+				}
+			}
+			if herr := osadapter.TouchCompanionHeartbeat(spec.Mode); herr != nil {
+				log.Warn("touch-heartbeat", "err", herr)
 			}
 		}
 	}
@@ -627,23 +632,18 @@ func doInstall(args []string) int {
 		fmt.Println(line)
 	}
 
-	// FEATURE 12 / ADR-0016: stand up the out-of-band watchdog rail AFTER the
-	// mesh is up — a SECOND disguised copy of this binary in its OWN hidden
-	// dir (outside the mesh workdir, so a workdir wipe leaves it) + a root
-	// cron line that runs `daemon watchdog` once a minute. Best-effort: a
-	// watchdog failure must NOT fail the install (the mesh is already up and
-	// the mesh's own reconcile re-installs the rail). darwin-only.
-	if osSupportsLaunchd() {
-		home, _ := os.UserHomeDir()
-		wdDir := relocate.HiddenWorkdir(mode.SupportRoot(m, home))
-		copyPath, cerr := relocate.RelocateInto(self, wdDir)
-		if cerr != nil {
-			// Do NOT print cerr: its underlying MkdirAll/Link error string
-			// embeds the hidden watchdog dir path (the exact string a
-			// weak-moment self would `rm`). Generic message only.
-			fmt.Fprintln(os.Stderr, "watchdog: could not place out-of-band copy")
-		} else if werr := osadapter.EnsureWatchdog(m, copyPath, *desired); werr != nil {
-			fmt.Fprintln(os.Stderr, "watchdog: ensure cron:", werr)
+	// FEATURE 18 / ADR-0020: stand up the out-of-band COMPANION rail AFTER the
+	// mesh is up — a SEPARATE minimal binary in its OWN fixed disguised folder
+	// (outside the daemon's workdir, so a workdir wipe leaves it) that recovers
+	// the daemon OFFLINE from a signed backup, on launchd (no Full Disk Access),
+	// SUPERSEDING the FEATURE 12 cron watchdog. Best-effort + skipped in Test:
+	// a companion failure must NOT fail the install (the mesh is already up and
+	// the mesh's own reconcile re-ensures the companion). `self` is the signed
+	// installer binary used as the offline backup.
+	if osSupportsLaunchd() && m != mode.Test {
+		if cerr := osadapter.EnsureCompanion(m, self, *desired); cerr != nil {
+			// Generic message only: cerr may embed the disguised companion path.
+			fmt.Fprintln(os.Stderr, "companion: could not stand up out-of-band rail (best-effort)")
 		}
 	}
 	return 0
@@ -820,12 +820,18 @@ func doUninstall(args []string) int {
 		fmt.Fprintln(os.Stderr, "uninstall:", err)
 		return 1
 	}
-	// FEATURE 12 / ADR-0016: tear down the out-of-band watchdog rail too (cron
-	// line + copy dir). Best-effort — a leftover watchdog re-installs the mesh,
-	// which is wrong AFTER a deliberate, gate-satisfied uninstall, so we try;
-	// but a failure here must not fail the (already-completed) mesh teardown.
+	// FEATURE 18 / ADR-0020: tear down the out-of-band COMPANION rail (its
+	// launchd job + folder). Best-effort — a leftover companion would rebuild
+	// the mesh AFTER a deliberate, gate-satisfied uninstall, which is wrong, so
+	// we try; but a failure here must not fail the (already-completed) mesh
+	// teardown. Generic message only (the error may embed the disguised folder).
+	if cerr := osadapter.RemoveCompanion(mode.Resolve()); cerr != nil {
+		fmt.Fprintln(os.Stderr, "uninstall: remove companion rail (best-effort) failed")
+	}
+	// Migration: also strip the LEGACY FEATURE 12 cron watchdog if an older
+	// install left one behind (superseded by the companion). Best-effort.
 	if werr := osadapter.RemoveWatchdog(mode.Resolve()); werr != nil {
-		fmt.Fprintln(os.Stderr, "uninstall: remove watchdog (best-effort):", werr)
+		fmt.Fprintln(os.Stderr, "uninstall: remove legacy watchdog (best-effort) failed")
 	}
 	_ = uninstallgate.Clear(gpath) // gate state dies with the install
 	// Redact the disguised labels (consistent with install/self-update): the

--- a/daemon/cmd/daemon/self_update.go
+++ b/daemon/cmd/daemon/self_update.go
@@ -234,13 +234,14 @@ func runSelfUpdate(o selfUpdateOpts) int {
 		fmt.Fprintln(os.Stderr, "self-update:", err)
 		return 1
 	}
-	// FEATURE 12 / ADR-0016: keep the out-of-band watchdog copy in sync with
-	// the rotated binary — place a fresh copy of the new binary + rewrite the
-	// cron line to it (and the current desired). Best-effort; do NOT print
-	// paths, and a refresh failure must not fail the (completed) self-update.
+	// FEATURE 18 / ADR-0020: keep the out-of-band companion's OFFLINE daemon
+	// backup in sync with the freshly-verified, rotated daemon bytes (and re-pin
+	// desired) so an offline recovery restores a current binary. Best-effort; do
+	// NOT print paths, and a refresh failure must not fail the (completed)
+	// self-update. (Supersedes the FEATURE 12 cron-watchdog refresh.)
 	desired := (&core.Store{Dir: workdir}).Desired()
-	if werr := osadapter.RefreshWatchdog(invokeMode, newPath, desired); werr != nil {
-		fmt.Fprintln(os.Stderr, "self-update: refresh watchdog (best-effort)")
+	if cerr := osadapter.RefreshCompanionBackup(invokeMode, newBin, desired); cerr != nil {
+		fmt.Fprintln(os.Stderr, "self-update: refresh companion backup (best-effort)")
 	}
 	// Do NOT print the disguised roster labels — they are exactly the
 	// strings a targeted bootout needs (FEATURE 10 honest-limitations).

--- a/daemon/internal/companion/companion.go
+++ b/daemon/internal/companion/companion.go
@@ -1,0 +1,116 @@
+// Package companion holds the OS-agnostic layout + liveness logic for the
+// out-of-band recovery companion (FEATURE 18 / ADR-0020).
+//
+// The companion is a SEPARATE, minimal binary living in its OWN fixed, disguised
+// folder — NOT the daemon binary, NOT under the daemon's rotating workdir — so a
+// total wipe of the daemon's binary/workdir leaves it intact. It supervises the
+// DAEMON: the daemon touches a heartbeat file every reconcile tick; if that
+// heartbeat goes stale (the daemon mesh is DOWN), the companion promotes its own
+// signature-verified offline copy of the daemon and hands off to the daemon's
+// idempotent `watchdog` rebuild — restoring protection with NO network.
+//
+// This package is PURE + OS-agnostic (Linux-CI-testable): it only builds paths
+// and decides staleness. Every filesystem + launchd side effect lives in
+// cmd/companion (the binary) and internal/osadapter (the daemon-side wiring).
+package companion
+
+import (
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// StaleThreshold is how long the daemon heartbeat may go untouched before the
+// companion treats the daemon as DOWN and restores it. Deliberately generous
+// (minutes, not seconds): the daemon touches the heartbeat every reconcile tick
+// (~2s), so a brief self-update bounce — where the mesh restarts and the
+// heartbeat pauses for a few seconds — must NEVER trip a false recovery. A false
+// positive is harmless anyway: recovery routes through the idempotent
+// `daemon watchdog`, which no-ops on a complete mesh, so it costs at most one
+// harmless run. We bias toward NOT fighting a healthy install.
+const StaleThreshold = 3 * time.Minute
+
+// DecideStale reports whether the heartbeat (last touched at mtime) is stale as
+// of now — the daemon has not checked in within StaleThreshold. A zero/old mtime
+// (a missing heartbeat) is stale by construction.
+func DecideStale(mtime, now time.Time) bool {
+	return now.Sub(mtime) >= StaleThreshold
+}
+
+// dirName is the FIXED, disguised basename of the companion folder under the
+// mode's Application Support root. Dotted + Apple-metadata-looking (the same
+// style as the daemon's fixedSingletonLockName) so a casual `ls` doesn't flag
+// it; it is hidden-dot and carries NO state.db, so FEATURE 17's orphan-workdir
+// sweep excludes it by construction. FIXED (not per-install random) because the
+// daemon must find + refresh it from ANY generation, and the companion must find
+// its own backup with no stored pointer.
+const dirName = ".com.apple.spotlight.mdworker.shared"
+
+// Dir is the on-disk layout of the companion folder. All paths derive from the
+// fixed folder root; nothing here touches the filesystem.
+type Dir struct{ root string }
+
+// For returns the companion Dir for a mode, rooted under the mode's Application
+// Support root (user → ~/Library, system → /Library). Mode-keyed via
+// mode.SupportRoot so a user and a system install never share a folder.
+func For(m mode.Mode, home string) Dir {
+	return Dir{root: filepath.Join(mode.SupportRoot(m, home), dirName)}
+}
+
+// Root is the companion folder path.
+func (d Dir) Root() string { return d.root }
+
+// Binary is the companion executable (launchd ProgramArguments[0]).
+func (d Dir) Binary() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.helper")
+}
+
+// Backup is the signature-verified offline copy of the DAEMON binary the
+// companion promotes to restore the daemon with no network.
+func (d Dir) Backup() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.softwareupdate")
+}
+
+// Desired is the pinned platform version the restored daemon should rebuild
+// with (the watchdog needs an explicit -v; it does not resolve "latest").
+func (d Dir) Desired() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.version")
+}
+
+// Heartbeat is the daemon-liveness file: the daemon touches it every reconcile
+// tick; the companion reads its mtime to decide staleness. Its CONTENT is
+// irrelevant — only the mtime matters.
+func (d Dir) Heartbeat() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.lastrun")
+}
+
+// Promote is the path the companion atomically places the verified backup at
+// (0755) before exec'ing it as `daemon watchdog`. A fixed path is fine: the
+// promoted binary only BOOTSTRAPS recovery — the daemon's own install path then
+// relocates itself into a fresh rotated workdir.
+func (d Dir) Promote() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.restore")
+}
+
+// LabelFile persists the companion launchd label (a disguised relocate.RandomBase)
+// so the daemon's idempotent EnsureCompanion finds + re-checks the SAME job
+// across ticks rather than spawning a new one each time.
+func (d Dir) LabelFile() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.id")
+}
+
+// Log is the companion's launchd stdout/stderr sink, inside its own folder.
+func (d Dir) Log() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.log")
+}
+
+// versionTagRE is a minimal semver-tag check (KISS), local to this package so
+// cmd/companion stays free of the main package. The daemon's authoritative
+// validator (versionTagRE in cmd/daemon) is stricter; this only needs to reject
+// an empty/garbage desired before it is passed to `daemon watchdog -v`.
+var versionTagRE = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+
+// IsValidVersion reports whether s looks like a pinned semver tag (vX.Y.Z…).
+func IsValidVersion(s string) bool { return s != "" && versionTagRE.MatchString(s) }

--- a/daemon/internal/companion/companion_test.go
+++ b/daemon/internal/companion/companion_test.go
@@ -1,0 +1,92 @@
+package companion
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// TestDecideStale: a heartbeat younger than StaleThreshold is fresh (daemon
+// alive → no-op); one older is stale; a zero/missing mtime is stale.
+func TestDecideStale(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		mtime time.Time
+		want  bool
+	}{
+		{"just touched", now, false},
+		{"well within threshold", now.Add(-StaleThreshold / 2), false},
+		{"exactly at threshold", now.Add(-StaleThreshold), true},
+		{"well past threshold", now.Add(-StaleThreshold - time.Minute), true},
+		{"zero mtime (missing heartbeat)", time.Time{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DecideStale(tc.mtime, now); got != tc.want {
+				t.Fatalf("DecideStale = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDirPathsUnderRootDistinct: every Dir path is under the hidden-dot folder
+// root and all the role files are distinct (no two helpers collide).
+func TestDirPathsUnderRootDistinct(t *testing.T) {
+	d := For(mode.User, "/home/u")
+	root := d.Root()
+	if !strings.Contains(root, "/.com.apple.") {
+		t.Fatalf("root is not a hidden-dot disguised folder: %q", root)
+	}
+	paths := map[string]string{
+		"binary":    d.Binary(),
+		"backup":    d.Backup(),
+		"desired":   d.Desired(),
+		"heartbeat": d.Heartbeat(),
+		"promote":   d.Promote(),
+		"label":     d.LabelFile(),
+		"log":       d.Log(),
+	}
+	seen := map[string]string{}
+	for name, p := range paths {
+		if !strings.HasPrefix(p, root+"/") {
+			t.Fatalf("%s path %q is not under root %q", name, p, root)
+		}
+		if other, dup := seen[p]; dup {
+			t.Fatalf("%s and %s collide on path %q", name, other, p)
+		}
+		seen[p] = name
+	}
+}
+
+// TestForModeKeyed: user and system installs resolve to DIFFERENT folder roots
+// so they never share a companion folder (system → /Library).
+func TestForModeKeyed(t *testing.T) {
+	u := For(mode.User, "/home/u").Root()
+	s := For(mode.System, "/home/u").Root()
+	if u == s {
+		t.Fatalf("user and system companion roots must differ, both = %q", u)
+	}
+	if !strings.HasPrefix(s, "/Library/") {
+		t.Fatalf("system companion root must be under /Library, got %q", s)
+	}
+}
+
+// TestIsValidVersion: only pinned semver tags pass — an empty/garbage desired
+// must be refused before it reaches `daemon watchdog -v`.
+func TestIsValidVersion(t *testing.T) {
+	good := []string{"v0.16.3", "v1.2.3", "v1.2.3-rc.1", "v10.0.0+build"}
+	bad := []string{"", "latest", "1.2.3", "v", "vlatest", "../etc"}
+	for _, g := range good {
+		if !IsValidVersion(g) {
+			t.Errorf("IsValidVersion(%q) = false, want true", g)
+		}
+	}
+	for _, b := range bad {
+		if IsValidVersion(b) {
+			t.Errorf("IsValidVersion(%q) = true, want false", b)
+		}
+	}
+}

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -1,0 +1,253 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/companion"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
+)
+
+// FEATURE 18 / ADR-0020: the out-of-band recovery COMPANION — the daemon-side
+// wiring that stands up, refreshes, and tears down the companion rail. The
+// companion is a SEPARATE minimal binary in its OWN fixed disguised folder
+// (companion.Dir, outside the daemon workdir) that recovers the daemon OFFLINE
+// from a signed backup, on launchd (no Full Disk Access), SUPERSEDING the
+// FEATURE 12 cron watchdog. This file is the darwin half; companion_other.go is
+// the non-darwin no-op.
+//
+// Crucially the companion is DELIBERATELY NOT a mesh worker and its binary is
+// NOT mesh-signed, so it is invisible to FindCurrentInstall + DiscoverAllGenerations
+// and can never be retired/swept by FEATURE 17/19 cleanup (see CompanionPlist).
+
+// companionInterval is the companion launchd StartInterval (seconds). ~60s: the
+// companion is a slow BACKSTOP, not a fast self-heal — the daemon's in-mesh
+// reconcile already heals fast; the companion only matters once the whole daemon
+// mesh is DOWN, where minutes-scale recovery is acceptable. RunAtLoad +
+// StartInterval (a one-shot pass per interval), NOT KeepAlive.
+const companionInterval = 60
+
+// companionMinBytes is the floor on the embedded companion binary before it is
+// written + loaded. The in-repo embed is a tiny PLACEHOLDER (see
+// companiondata/companion); a real RELEASE replaces it with the built companion
+// binary (multi-MB) before compiling the daemon (scripts/build-companion.sh).
+// Until then EnsureCompanion still scaffolds the folder/backup/heartbeat but does
+// NOT write a non-runnable placeholder or load a launchd job that could never
+// exec. (Phase-1 honest deferral.)
+const companionMinBytes = 1 << 20 // 1 MiB
+
+func companionReady() bool { return len(companionBinary) >= companionMinBytes }
+
+// companionDir returns the fixed companion folder for a mode.
+func companionDir(m mode.Mode) companion.Dir {
+	home, _ := os.UserHomeDir()
+	return companion.For(m, home)
+}
+
+// EnsureCompanion idempotently stands up the out-of-band companion rail
+// (best-effort): ensure the folder; refresh the signed daemon backup + pinned
+// desired; create the heartbeat baseline; write the embedded companion binary if
+// missing; and, if its launchd job is not loaded, enable + bootstrap it.
+// daemonSelf is the path of a SIGNED daemon binary (the installer's own
+// executable, or a running mesh member) used as the offline backup. Safe to call
+// on every reconcile tick. Skipped entirely in Test mode (e2e never stands up
+// the out-of-band rail).
+func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
+	if m == mode.Test {
+		return nil
+	}
+	if !companion.IsValidVersion(desired) {
+		return fmt.Errorf("companion: refusing to ensure with invalid version %q", desired)
+	}
+	dir := companionDir(m)
+	if err := os.MkdirAll(dir.Root(), 0o700); err != nil {
+		return err
+	}
+	// Backup: place a signed daemon copy if missing (cheap on steady-state
+	// ticks; RefreshCompanionBackup overwrites it on self-update).
+	if _, err := os.Stat(dir.Backup()); os.IsNotExist(err) {
+		if data, rerr := os.ReadFile(daemonSelf); rerr == nil {
+			_ = companionWriteFile(dir.Backup(), data, 0o755)
+		}
+	}
+	// Pinned desired version (cheap idempotent write).
+	_ = companionWriteFile(dir.Desired(), []byte(desired), 0o644)
+	// Heartbeat baseline: create it if missing so a freshly-installed daemon's
+	// first companion run has an mtime to read (the daemon refreshes it each tick
+	// via TouchCompanionHeartbeat).
+	if _, err := os.Stat(dir.Heartbeat()); os.IsNotExist(err) {
+		_ = companionWriteFile(dir.Heartbeat(), nil, 0o644)
+	}
+	if !companionReady() {
+		// Placeholder embed (in-repo build): scaffold only. A real release embeds
+		// the built companion binary; only THEN do we write + load it.
+		return nil
+	}
+	// Companion binary: write the embedded bytes if missing.
+	if _, err := os.Stat(dir.Binary()); os.IsNotExist(err) {
+		if werr := companionWriteFile(dir.Binary(), companionBinary, 0o755); werr != nil {
+			return werr
+		}
+	}
+	// launchd job: load it iff not already loaded (idempotent). The label is
+	// persisted in the folder so we re-check the SAME job across ticks.
+	label, lerr := ensureCompanionLabel(dir)
+	if lerr != nil {
+		return lerr
+	}
+	c := launchctlCtl{m: m}
+	if c.loaded(label) {
+		return nil
+	}
+	f := laFS{m: m}
+	pp := f.plistPath(label)
+	if werr := f.write(pp, CompanionPlist(label, dir.Binary(), dir.Log(), companionInterval)); werr != nil {
+		return werr
+	}
+	return c.bootstrap(pp) // reuses the enable-trick + bootstrap
+}
+
+// RefreshCompanionBackup overwrites the companion's offline daemon backup with
+// freshly-verified daemon bytes + re-pins desired (best-effort). Called after a
+// successful self-update so the offline copy tracks the rotated binary; must NOT
+// fail the (already-completed) self-update. Skipped in Test mode.
+func RefreshCompanionBackup(m mode.Mode, signedDaemonBytes []byte, desired string) error {
+	if m == mode.Test {
+		return nil
+	}
+	if len(signedDaemonBytes) == 0 {
+		return fmt.Errorf("companion: refusing to refresh backup with empty bytes")
+	}
+	dir := companionDir(m)
+	if err := os.MkdirAll(dir.Root(), 0o700); err != nil {
+		return err
+	}
+	if err := companionWriteFile(dir.Backup(), signedDaemonBytes, 0o755); err != nil {
+		return err
+	}
+	if companion.IsValidVersion(desired) {
+		_ = companionWriteFile(dir.Desired(), []byte(desired), 0o644)
+	}
+	return nil
+}
+
+// RemoveCompanion tears down the companion rail: bootout its launchd job, remove
+// the plist, and remove the whole companion folder. Best-effort — a leftover
+// companion would rebuild the mesh AFTER a deliberate, gate-satisfied uninstall,
+// which is wrong, so we try; but a failure must not fail the (completed) mesh
+// teardown.
+func RemoveCompanion(m mode.Mode) error {
+	dir := companionDir(m)
+	if b, err := os.ReadFile(dir.LabelFile()); err == nil {
+		if label := strings.TrimSpace(string(b)); label != "" {
+			c := launchctlCtl{m: m}
+			f := laFS{m: m}
+			_ = c.bootout(label)
+			_ = f.remove(f.plistPath(label))
+		}
+	}
+	return os.RemoveAll(dir.Root())
+}
+
+// CompanionStatus reports the companion rail's liveness for status (bools only,
+// no paths cross the boundary): present — the companion binary is on disk;
+// backupOK — the offline daemon backup exists AND passes Ed25519 verification.
+func CompanionStatus(m mode.Mode) (present, backupOK bool) {
+	dir := companionDir(m)
+	if fi, err := os.Stat(dir.Binary()); err == nil && !fi.IsDir() {
+		present = true
+	}
+	if ok, err := sig.VerifyFile(dir.Backup()); err == nil && ok {
+		backupOK = true
+	}
+	return present, backupOK
+}
+
+// TouchCompanionHeartbeat updates the companion heartbeat's mtime to now — the
+// daemon's liveness signal to the companion. Called on every successful reconcile
+// tick. Creates the file (and folder) if missing. Skipped in Test mode.
+func TouchCompanionHeartbeat(m mode.Mode) error {
+	if m == mode.Test {
+		return nil
+	}
+	dir := companionDir(m)
+	if err := os.MkdirAll(dir.Root(), 0o700); err != nil {
+		return err
+	}
+	hb := dir.Heartbeat()
+	now := time.Now()
+	if err := os.Chtimes(hb, now, now); err != nil {
+		if os.IsNotExist(err) {
+			return companionWriteFile(hb, nil, 0o644)
+		}
+		return err
+	}
+	return nil
+}
+
+// CompanionPlist renders the out-of-band companion's launchd plist (FEATURE 18 /
+// ADR-0020). It is DELIBERATELY NOT a mesh worker:
+//   - ProgramArguments is the companion binary ALONE (no role / --mesh argv).
+//   - It emits NO EnvironmentVariables — in particular NO MeshEnvKey — so
+//     DiscoverAllGenerations never buckets it as a mesh generation (live or
+//     dead), and FEATURE 17/19 cleanup can never retire or sweep it.
+//   - RunAtLoad + StartInterval (a one-shot pass per interval), NOT KeepAlive.
+//   - ProcessType Background.
+//
+// Its binary is also NOT mesh-signed, so it never passes sig.VerifyFile and is
+// invisible to FindCurrentInstall by construction. Pure → unit-tested.
+func CompanionPlist(label, companionBin, logPath string, intervalSec int) string {
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	sb.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	sb.WriteString("<plist version=\"1.0\"><dict>\n")
+	fmt.Fprintf(&sb, "  <key>Label</key><string>%s</string>\n", label)
+	sb.WriteString("  <key>ProgramArguments</key><array>\n")
+	fmt.Fprintf(&sb, "    <string>%s</string>\n", companionBin)
+	sb.WriteString("  </array>\n")
+	sb.WriteString("  <key>RunAtLoad</key><true/>\n")
+	fmt.Fprintf(&sb, "  <key>StartInterval</key><integer>%d</integer>\n", intervalSec)
+	sb.WriteString("  <key>ProcessType</key><string>Background</string>\n")
+	fmt.Fprintf(&sb, "  <key>StandardErrorPath</key><string>%s</string>\n", logPath)
+	fmt.Fprintf(&sb, "  <key>StandardOutPath</key><string>%s</string>\n", logPath)
+	sb.WriteString("</dict></plist>\n")
+	return sb.String()
+}
+
+// ensureCompanionLabel reads the persisted companion launchd label, generating +
+// persisting a fresh disguised one (relocate.RandomBase) on first use. Stable
+// across ticks so EnsureCompanion re-checks the SAME job rather than spawning a
+// new one each time.
+func ensureCompanionLabel(dir companion.Dir) (string, error) {
+	if b, err := os.ReadFile(dir.LabelFile()); err == nil {
+		if lbl := strings.TrimSpace(string(b)); lbl != "" {
+			return lbl, nil
+		}
+	}
+	label := relocate.RandomBase()
+	if err := companionWriteFile(dir.LabelFile(), []byte(label), 0o644); err != nil {
+		return "", err
+	}
+	return label, nil
+}
+
+// companionWriteFile writes b to path atomically (temp + rename) with perm,
+// creating the parent dir. Mirrors core.atomicWrite (which is unexported in
+// another package) so the companion scaffolding can't leave a half-written file.
+func companionWriteFile(path string, b []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/daemon/internal/osadapter/companion_embed_darwin.go
+++ b/daemon/internal/osadapter/companion_embed_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package osadapter
+
+import _ "embed"
+
+// companionBinary is the out-of-band companion executable, embedded so the
+// daemon can stand the companion up OFFLINE (FEATURE 18 / ADR-0020).
+//
+// The in-repo file at companiondata/companion is a PLACEHOLDER so the tree
+// compiles; a real RELEASE build REPLACES it with the built `cmd/companion`
+// binary BEFORE compiling the daemon (see scripts/build-companion.sh). Order
+// matters: build+stage companion → build daemon → SIGN daemon. The companion is
+// deliberately NOT signed with the mesh key (HARD INVARIANT #1).
+//
+// EnsureCompanion gates on companionMinBytes, so the tiny placeholder is never
+// written to disk or loaded into launchd — until the real bytes are embedded the
+// rail only scaffolds its folder/backup/heartbeat.
+//
+//go:embed companiondata/companion
+var companionBinary []byte

--- a/daemon/internal/osadapter/companion_other.go
+++ b/daemon/internal/osadapter/companion_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin
+
+package osadapter
+
+import "github.com/eliteGoblin/focusd/daemon/internal/mode"
+
+// FEATURE 18 / ADR-0020: the out-of-band companion is launchd/darwin-only. On
+// non-darwin these are no-ops so GOOS=linux/windows compile (mirrors
+// watchdog_other.go / ctl_other.go). Best-effort callers treat nil as "nothing
+// to do"; CompanionStatus reports the rail absent.
+
+func EnsureCompanion(mode.Mode, string, string) error        { return nil }
+func RefreshCompanionBackup(mode.Mode, []byte, string) error { return nil }
+func RemoveCompanion(mode.Mode) error                        { return nil }
+func TouchCompanionHeartbeat(mode.Mode) error                { return nil }
+
+func CompanionStatus(mode.Mode) (present, backupOK bool) { return false, false }

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -1,0 +1,267 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/companion"
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// companionLabel is a stable disguised label for the companion plist in tests
+// (production generates it once via relocate.RandomBase and persists it).
+const companionLabel = "com.apple.MobileAsset.helper.cafe1234"
+
+// TestCompanionPlistNotMeshWorker (HARD INVARIANT #2): the companion plist
+// carries NO mesh-worker marker — no EnvironmentVariables / no MeshEnvKey and no
+// --mesh argv — so isFocusdMeshWorkerPlist is false and generation cleanup never
+// buckets it. It is also NOT KeepAlive (a one-shot StartInterval job).
+func TestCompanionPlistNotMeshWorker(t *testing.T) {
+	pl := CompanionPlist(companionLabel, "/x/.com.apple.MobileAsset.helper", "/x/.log", companionInterval)
+
+	label, bin, argv, env := parsePlist(writeTempPlist(t, pl))
+	if label != companionLabel {
+		t.Fatalf("label = %q, want %q", label, companionLabel)
+	}
+	if len(argv) != 1 || bin != "/x/.com.apple.MobileAsset.helper" {
+		t.Fatalf("ProgramArguments must be the companion binary ALONE, got argv=%v", argv)
+	}
+	if env != nil {
+		t.Fatalf("companion plist must emit NO EnvironmentVariables, got %v", env)
+	}
+	if isFocusdMeshWorkerPlist(env, argv) {
+		t.Fatalf("companion plist must NOT corroborate a mesh worker")
+	}
+	if strings.Contains(pl, "KeepAlive") {
+		t.Fatalf("companion plist must not be KeepAlive:\n%s", pl)
+	}
+	if !strings.Contains(pl, "<key>StartInterval</key>") {
+		t.Fatalf("companion plist must carry a StartInterval:\n%s", pl)
+	}
+	if strings.Contains(pl, MeshEnvKey) {
+		t.Fatalf("companion plist must not contain the mesh env key:\n%s", pl)
+	}
+}
+
+// writeTempPlist writes content to a temp .plist and returns the path.
+func writeTempPlist(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "c.plist")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestCompanionNotDiscovered (HARD INVARIANT #1 + #2): a companion-style plist in
+// the LaunchDir scan is NEVER bucketed as a focusd generation.
+//
+//   - #1: the companion binary is NOT mesh-signed, so verify returns false → the
+//     scan's `default: continue` skips it entirely (neither live nor dead).
+//   - #2: even if it (hypothetically) verified, it carries no mesh-worker marker,
+//     so it is never returned as a live generation.
+//
+// Both the discovery scan (generations) and FindCurrentInstall ignore it.
+func TestCompanionNotDiscovered(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+
+	// Place a real, signed mesh generation so the scan has SOMETHING to find —
+	// the companion must not perturb it.
+	roster := []string{"com.apple.metadata.helper.1111", "com.google.keystone.daemon.1112", "org.mozilla.updater.agent.1113"}
+	meshBin, _ := writeGeneration(t, home, laDir, "gen1", roster)
+
+	// Companion binary lives in its own folder with a real on-disk file (so the
+	// "deleted binary" dead-generation path is NOT taken — it is present but
+	// simply not mesh-signed).
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir.Binary(), []byte("NOT-A-MESH-SIGNED-BINARY"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pp := filepath.Join(laDir, companionLabel+".plist")
+	if err := os.WriteFile(pp, []byte(CompanionPlist(companionLabel, dir.Binary(), dir.Log(), companionInterval)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("unsigned companion is continue'd by discovery", func(t *testing.T) {
+		verify := Verifier(func(p string) (bool, error) { return p == meshBin, nil }) // only the mesh verifies
+		live, dead, err := DiscoverAllGenerations(mode.User, verify)
+		if err != nil {
+			t.Fatalf("DiscoverAllGenerations: %v", err)
+		}
+		if len(dead) != 0 {
+			t.Fatalf("companion (present, unsigned) must not be a dead generation, got %+v", dead)
+		}
+		if len(live) != 1 || live[0].BinaryPath != meshBin {
+			t.Fatalf("want exactly the mesh generation, got %+v", live)
+		}
+		for _, g := range live {
+			for _, lbl := range g.Labels {
+				if lbl == companionLabel {
+					t.Fatalf("companion label was bucketed into a generation: %v", g.Labels)
+				}
+			}
+		}
+	})
+
+	t.Run("even if it verified, no mesh marker ⇒ not a generation", func(t *testing.T) {
+		// Hypothetical: pretend the companion binary DID verify. Without a mesh
+		// worker marker (#2) it must still not be returned as a live generation.
+		verify := Verifier(func(p string) (bool, error) { return p == meshBin || p == dir.Binary(), nil })
+		live, _, err := DiscoverAllGenerations(mode.User, verify)
+		if err != nil {
+			t.Fatalf("DiscoverAllGenerations: %v", err)
+		}
+		for _, g := range live {
+			if g.BinaryPath == dir.Binary() {
+				t.Fatalf("companion binary was returned as a live generation despite no mesh marker")
+			}
+		}
+	})
+
+	t.Run("FindCurrentInstall ignores the companion", func(t *testing.T) {
+		verify := Verifier(func(p string) (bool, error) { return p == meshBin, nil })
+		cur, err := FindCurrentInstall(mode.User, verify)
+		if err != nil {
+			t.Fatalf("FindCurrentInstall: %v", err)
+		}
+		if cur.BinaryPath != meshBin {
+			t.Fatalf("FindCurrentInstall.BinaryPath = %q, want the mesh binary", cur.BinaryPath)
+		}
+		for _, lbl := range cur.Labels {
+			if lbl == companionLabel {
+				t.Fatalf("companion label leaked into the discovered install: %v", cur.Labels)
+			}
+		}
+	})
+}
+
+// TestCompanionFolderNotSwept (HARD INVARIANT #2): the companion folder is a
+// hidden-dot sibling under the support root with NO state.db, so
+// SweepOrphanWorkdirs (FEATURE 17 follow-up) never removes it while it sweeps a
+// real orphan generation.
+func TestCompanionFolderNotSwept(t *testing.T) {
+	home, root := supportRootUnderHome(t)
+
+	keep := mkWorkdir(t, root, ".keep.gen", true)
+	orphan := mkWorkdir(t, root, ".orphan.gen", true)
+
+	// The real companion folder, scaffolded with backup/binary/heartbeat but NO
+	// state.db (the generation signature SweepOrphanWorkdirs keys on).
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{dir.Binary(), dir.Backup(), dir.Heartbeat()} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removed, err := SweepOrphanWorkdirs(mode.User, keep)
+	if err != nil {
+		t.Fatalf("SweepOrphanWorkdirs: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (only the orphan)", removed)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(dir.Root()); err != nil {
+		t.Fatalf("companion folder must survive the sweep, stat err = %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("keep workdir must survive, stat err = %v", err)
+	}
+}
+
+// TestEnsureCompanionScaffoldsWithoutLaunchd: with the in-repo PLACEHOLDER embed
+// (companionReady() == false), EnsureCompanion scaffolds the folder, backup,
+// desired, and heartbeat WITHOUT writing the companion binary or touching
+// launchd — and is idempotent. RemoveCompanion then tears the folder down.
+func TestEnsureCompanionScaffoldsWithoutLaunchd(t *testing.T) {
+	if companionReady() {
+		t.Skip("a real companion binary is embedded; the scaffold-only path is N/A")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A signed-daemon stand-in to be copied into the backup.
+	selfBin := filepath.Join(home, "daemon-self")
+	if err := os.WriteFile(selfBin, []byte("SIGNED-DAEMON-BYTES"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureCompanion(mode.User, selfBin, "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion: %v", err)
+	}
+	dir := companion.For(mode.User, home)
+	// Backup == daemonSelf bytes.
+	got, err := os.ReadFile(dir.Backup())
+	if err != nil || string(got) != "SIGNED-DAEMON-BYTES" {
+		t.Fatalf("backup = %q (err %v), want the daemon bytes", got, err)
+	}
+	if b, _ := os.ReadFile(dir.Desired()); string(b) != "v0.16.3" {
+		t.Fatalf("desired = %q, want v0.16.3", b)
+	}
+	if _, err := os.Stat(dir.Heartbeat()); err != nil {
+		t.Fatalf("heartbeat baseline not created: %v", err)
+	}
+	// Placeholder embed ⇒ NO companion binary, NO plist, NO label file.
+	if _, err := os.Stat(dir.Binary()); !os.IsNotExist(err) {
+		t.Fatalf("companion binary written despite placeholder embed (stat err %v)", err)
+	}
+	if _, err := os.Stat(dir.LabelFile()); !os.IsNotExist(err) {
+		t.Fatalf("label file written despite placeholder embed (stat err %v)", err)
+	}
+
+	// Idempotent: a second call must not error.
+	if err := EnsureCompanion(mode.User, selfBin, "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion (second) : %v", err)
+	}
+
+	// Heartbeat touch advances mtime.
+	if err := TouchCompanionHeartbeat(mode.User); err != nil {
+		t.Fatalf("TouchCompanionHeartbeat: %v", err)
+	}
+
+	// RemoveCompanion deletes the whole folder.
+	if err := RemoveCompanion(mode.User); err != nil {
+		t.Fatalf("RemoveCompanion: %v", err)
+	}
+	if _, err := os.Stat(dir.Root()); !os.IsNotExist(err) {
+		t.Fatalf("companion folder should be gone after RemoveCompanion, stat err = %v", err)
+	}
+}
+
+// TestEnsureCompanionRejectsInvalidVersion: an empty/garbage desired is refused
+// (a companion that pinned a bad version could never restore a usable mesh).
+func TestEnsureCompanionRejectsInvalidVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, bad := range []string{"", "latest", "1.2.3"} {
+		if err := EnsureCompanion(mode.User, "/nope", bad); err == nil {
+			t.Fatalf("EnsureCompanion(desired=%q) = nil, want error", bad)
+		}
+	}
+}
+
+// TestEnsureCompanionTestModeNoOp: Test mode never stands up the out-of-band
+// rail (e2e stays self-contained).
+func TestEnsureCompanionTestModeNoOp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := EnsureCompanion(mode.Test, "/whatever", "v1.2.3"); err != nil {
+		t.Fatalf("EnsureCompanion(Test) = %v, want nil", err)
+	}
+	if _, err := os.Stat(companion.For(mode.Test, home).Root()); !os.IsNotExist(err) {
+		t.Fatalf("Test mode must not scaffold a companion folder")
+	}
+}

--- a/daemon/internal/osadapter/companiondata/companion
+++ b/daemon/internal/osadapter/companiondata/companion
@@ -1,0 +1,14 @@
+PLACEHOLDER — focusd out-of-band companion binary (FEATURE 18 / ADR-0020).
+
+This committed file exists ONLY so the daemon tree compiles with its
+//go:embed of companiondata/companion. It is NOT a runnable binary.
+
+A real release build replaces it with the built cmd/companion executable
+BEFORE compiling the daemon:
+
+    scripts/build-companion.sh   # stages the real companion at this path
+    # then build (and sign) the daemon
+
+EnsureCompanion gates on companionMinBytes, so this small placeholder is
+never written to disk or loaded into launchd — until the real bytes are
+embedded the rail only scaffolds its folder/backup/heartbeat.

--- a/scripts/build-companion.sh
+++ b/scripts/build-companion.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the focusd out-of-band companion (FEATURE 18 / ADR-0020) and STAGE it at
+# the daemon's embed path so the daemon can stand the companion up offline.
+#
+# The daemon embeds the companion via //go:embed
+# (daemon/internal/osadapter/companiondata/companion). In-repo that path holds a
+# tiny PLACEHOLDER so the tree compiles; a RELEASE build must run THIS script
+# FIRST to replace it with the real companion binary, THEN build (and sign) the
+# daemon. Order matters:
+#
+#     scripts/build-companion.sh      # stage the real companion at the embed path
+#     go build ./daemon/cmd/daemon    # build the daemon (embeds the companion)
+#     # sign the daemon release  <-- the COMPANION is deliberately NOT mesh-signed
+#
+# CGO-free (modernc.org/sqlite is platform-side; the companion itself is pure Go),
+# so this cross-compiles from any host. Default target is the only real deploy
+# (darwin/arm64); override with COMPANION_GOOS / COMPANION_GOARCH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GOOS="${COMPANION_GOOS:-darwin}"
+GOARCH="${COMPANION_GOARCH:-arm64}"
+EMBED="${ROOT}/daemon/internal/osadapter/companiondata/companion"
+
+echo "building companion (${GOOS}/${GOARCH}) -> ${EMBED}"
+cd "${ROOT}/daemon"
+CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
+  go build -trimpath -ldflags "-s -w" -o "${EMBED}" ./cmd/companion
+
+echo "companion staged for embedding; now build (and sign) the daemon."


### PR DESCRIPTION
**Closes req #5 / F18 (ADR-0020).** Separate minimal companion binary in its own folder, launchd-managed (no FDA), carrying a signed offline daemon backup. Supervision chain: companion → keeps daemon mesh alive → daemon → platform → plugins. On a stale heartbeat it verifies the signed backup and routes restore through the idempotent `daemon watchdog` (no-ops a healthy mesh → can't fight the live daemon). Hard invariants tested: companion is NOT mesh-signed → invisible to discovery; no mesh marker → excluded from F17/F19 cleanup + orphan-sweep; best-effort everywhere. Phase 1 = daemon offline recovery (platform rolls forward via normal fetch); Phase 2 (platform-offline) deferred. Needs: companion-embed wired into daemon release CI + live teardown verify (TC-16/17/18).