### PR TITLE
ci: embed real companion into daemon release (F18)

### DIFF
--- a/.github/workflows/daemon-release.yml
+++ b/.github/workflows/daemon-release.yml
@@ -47,6 +47,11 @@ jobs:
           for t in $targets; do
             os=${t%/*}; arch=${t#*/}; ext=""
             [ "$os" = windows ] && ext=".exe"
+            # FEATURE 18 / ADR-0020: stage the REAL companion at the daemon's
+            # //go:embed path for THIS os/arch BEFORE the daemon build (in-repo
+            # that path is a tiny placeholder). The companion is deliberately
+            # NOT mesh-signed, so it stays invisible to mesh discovery.
+            COMPANION_GOOS=$os COMPANION_GOARCH=$arch bash ../scripts/build-companion.sh
             CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
               go build -trimpath -ldflags "-s -w -X main.version=$V" \
               -o /tmp/daemon-$os-$arch$ext ./cmd/daemon


### PR DESCRIPTION
F18's companion is embedded via go:embed; in-repo that path is a placeholder. This stages the real `cmd/companion` binary (per os/arch) via build-companion.sh before each daemon build in the release workflow, so a tagged daemon release actually carries a functional companion. Companion stays NOT mesh-signed (invisible to discovery, per the F18 invariant).