### PR TITLE
fix(daemon): 1-min companion recovery + lock the no-argv-leak invariant on the rebuild path (TC-23)

### DIFF
--- a/daemon/cmd/daemon/watchdog_test.go
+++ b/daemon/cmd/daemon/watchdog_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
@@ -153,6 +154,61 @@ func TestRunWatchdogIncompleteMeshRebuilds(t *testing.T) {
 	if !installed {
 		t.Fatalf("install was NOT called for an incomplete mesh; want called")
 	}
+}
+
+// TestRunWatchdogRebuildSpecIsProdPlist locks TC-23: the watchdog's LOCAL
+// rebuild must render FEATURE-19 PROD plists — the role/mesh marker rides in
+// EnvironmentVariables, NOT argv — so a watchdog/companion-driven rebuild can
+// never re-leak `run --r <role> --mesh` into `ps` (the leak TC-23 caught). The
+// watchdog resolves a REAL deployment mode (user/system, never test) via
+// mode.Resolve, so Spec.isTest() is false and args() is nil. We capture the
+// EXACT spec the watchdog hands to installMesh and assert the rendered plist's
+// ProgramArguments is the binary ALONE for every role (the env marker, which
+// `ps` does not display, carries the role). Both real modes are covered: the
+// companion runs the watchdog as the user (LaunchAgent) or as root (LaunchDaemon).
+func TestRunWatchdogRebuildSpecIsProdPlist(t *testing.T) {
+	for _, m := range []mode.Mode{mode.User, mode.System} {
+		t.Run(string(m), func(t *testing.T) {
+			var gotSpec *osadapter.Spec
+			runWatchdog("/copy/bin", m, "v1.2.3",
+				okVerify,
+				func() (osadapter.CurInstall, error) { return osadapter.CurInstall{}, nil },
+				func(s *osadapter.Spec) error { gotSpec = s; return nil },
+			)
+			if gotSpec == nil {
+				t.Fatal("watchdog did not call install for an absent mesh")
+			}
+			if gotSpec.Mode == mode.Test {
+				t.Fatalf("watchdog rebuild spec is test mode → would re-leak full argv")
+			}
+			for _, r := range osadapter.AllRoles {
+				pa := progArgsBlock(t, osadapter.Plist(*gotSpec, r))
+				for _, leak := range []string{"--mesh", "<string>run</string>", "<string>ensure</string>"} {
+					if strings.Contains(pa, leak) {
+						t.Fatalf("%s ProgramArguments leaks %q (TC-23 regression):\n%s", r, leak, pa)
+					}
+				}
+			}
+		})
+	}
+}
+
+// progArgsBlock extracts the <key>ProgramArguments</key><array>…</array>
+// substring — what `ps` surfaces — so a leak scan ignores the env dict (whose
+// value legitimately holds "run:a"/"ensure").
+func progArgsBlock(t *testing.T, plist string) string {
+	t.Helper()
+	const head = "<key>ProgramArguments</key><array>"
+	i := strings.Index(plist, head)
+	if i < 0 {
+		t.Fatalf("plist has no ProgramArguments:\n%s", plist)
+	}
+	rest := plist[i:]
+	end := strings.Index(rest, "</array>")
+	if end < 0 {
+		t.Fatalf("plist ProgramArguments not closed:\n%s", plist)
+	}
+	return rest[:end]
 }
 
 // TestRunWatchdogRebuildFailureNonZero: a failed local rebuild surfaces a

--- a/daemon/internal/companion/companion.go
+++ b/daemon/internal/companion/companion.go
@@ -23,14 +23,17 @@ import (
 )
 
 // StaleThreshold is how long the daemon heartbeat may go untouched before the
-// companion treats the daemon as DOWN and restores it. Deliberately generous
-// (minutes, not seconds): the daemon touches the heartbeat every reconcile tick
-// (~2s), so a brief self-update bounce — where the mesh restarts and the
-// heartbeat pauses for a few seconds — must NEVER trip a false recovery. A false
-// positive is harmless anyway: recovery routes through the idempotent
-// `daemon watchdog`, which no-ops on a complete mesh, so it costs at most one
-// harmless run. We bias toward NOT fighting a healthy install.
-const StaleThreshold = 3 * time.Minute
+// companion treats the daemon as DOWN and restores it. 30s gives a ~1-minute
+// worst-case recovery (this threshold + one ~30s companion StartInterval pass)
+// instead of the old ~3-4 minutes. It stays well above the daemon's ~2s
+// heartbeat cadence, so a brief self-update bounce — where the mesh restarts and
+// the heartbeat pauses for a few seconds — still does NOT trip a false recovery.
+// A false positive is harmless regardless: recovery routes through the
+// idempotent `daemon watchdog`, which no-ops on a complete mesh (its meshComplete
+// check is the authority), so even during a slow self-update a false trigger
+// costs at most one harmless run. We still bias toward NOT fighting a healthy
+// install.
+const StaleThreshold = 30 * time.Second
 
 // DecideStale reports whether the heartbeat (last touched at mtime) is stale as
 // of now — the daemon has not checked in within StaleThreshold. A zero/old mtime

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -27,12 +27,15 @@ import (
 // NOT mesh-signed, so it is invisible to FindCurrentInstall + DiscoverAllGenerations
 // and can never be retired/swept by FEATURE 17/19 cleanup (see CompanionPlist).
 
-// companionInterval is the companion launchd StartInterval (seconds). ~60s: the
-// companion is a slow BACKSTOP, not a fast self-heal — the daemon's in-mesh
+// companionInterval is the companion launchd StartInterval (seconds). ~30s: the
+// companion is still a BACKSTOP, not a fast self-heal — the daemon's in-mesh
 // reconcile already heals fast; the companion only matters once the whole daemon
-// mesh is DOWN, where minutes-scale recovery is acceptable. RunAtLoad +
-// StartInterval (a one-shot pass per interval), NOT KeepAlive.
-const companionInterval = 60
+// mesh is DOWN. Paired with the 30s StaleThreshold this gives a ~1-minute
+// worst-case recovery (was ~3-4 min). Restore routes through the idempotent
+// `daemon watchdog`, which no-ops a healthy mesh, so the tighter cadence cannot
+// fight a slow self-update. RunAtLoad + StartInterval (a one-shot pass per
+// interval), NOT KeepAlive.
+const companionInterval = 30
 
 // companionMinBytes is the floor on the embedded companion binary before it is
 // written + loaded. The in-repo embed is a tiny PLACEHOLDER (see


### PR DESCRIPTION
**Companion recovers in ~1 min** (was ~3-4): StaleThreshold 3m→30s, companion StartInterval 60→30s. Anti-fight backstop unchanged (restore routes through idempotent `daemon watchdog`, which no-ops a healthy mesh, so a false trigger during a slow self-update is harmless).

**TC-23 — honest correction:** the watchdog/companion rebuild path does NOT leak `--mesh` in current source. `runWatchdog` builds its spec from `mode.Resolve()` (only ever User/System, never Test), so `plist.args()` returns nil → F19 env-based ProgramArguments (binary-only). The live `--mesh` observed earlier was a stale/pre-F19 backup artifact from the session's install churn, not a code bug. Added `TestRunWatchdogRebuildSpecIsProdPlist` (user + system) to lock the no-leak invariant so it can never regress. Independent e2e will re-confirm live with a fresh F19 backup.