### PR TITLE
fix(daemon): reach "good" on split install — v0.19.0 platform-start regression

### DIFF
--- a/daemon/internal/core/store.go
+++ b/daemon/internal/core/store.go
@@ -55,14 +55,19 @@ func (s *Store) platformRoot() string {
 const VersionFile = "version.json"
 
 // PlatformStateDBName is the platform engine's state-database basename inside
-// the SHARED workdir. The daemon starts the platform with `--workdir <dir>`;
-// the platform derives its state DB as `<dir>/state.db` (its cmd default). The
-// daemon treats the PRESENCE of this file as the marker that the workdir is
-// intact and the platform has initialised it — so its ABSENCE while a platform
-// process still claims to be running is the signature of a wiped workdir (the
-// platform limping off a now-unlinked inode). This is a workdir-layout contract
-// between daemon and platform, not plugin knowledge (the daemon stays
-// plugin-agnostic).
+// the disposable PLATFORM-WORKDIR (platformRoot, NOT the daemon-home). The
+// platform self-derives its workdir from its own disguised binary location
+// (<platform-workdir>/bin/<base> → two dirs up) and writes state.db there; on
+// the legacy layout the daemon passes the same dir via `--workdir`. The daemon
+// treats the PRESENCE of this file as the marker that the workdir is intact and
+// the platform has initialised it — so its ABSENCE while a platform process
+// still claims to be running is the signature of a wiped workdir (the platform
+// limping off a now-unlinked inode). This is a workdir-layout contract between
+// daemon and platform, not plugin knowledge (the daemon stays plugin-agnostic).
+//
+// FEATURE 21 (HF1) split state.db out of the daemon-home into the separate
+// platform-workdir; stateDBPath/WorkdirIntact therefore key off platformRoot(),
+// not Dir — see stateDBPath.
 const PlatformStateDBName = "state.db"
 
 // RosterFile is the LEGACY fixed basename of the masked mesh-label roster
@@ -169,17 +174,34 @@ func (s *Store) badName(v string) string {
 func (s *Store) versionPath() string { return filepath.Join(s.Dir, VersionFile) }
 func (s *Store) goodPath() string    { return filepath.Join(s.Dir, "good") }
 func (s *Store) badDir() string      { return filepath.Join(s.Dir, "bad") }
-func (s *Store) stateDBPath() string { return filepath.Join(s.Dir, PlatformStateDBName) }
+// stateDBPath is where the platform engine's state.db lives: the disposable
+// PLATFORM-WORKDIR (platformRoot), NOT the daemon-home. FEATURE 21 (HF1) split
+// the two roots — the platform derives its workdir from its own binary location
+// (or is handed it via --workdir) and writes state.db under platformRoot — so
+// this MUST key off platformRoot(), not Dir. Keying it off Dir made
+// WorkdirIntact stat a state.db that never exists in a split install, so the
+// proactive workdir-wipe heal fired on EVERY tick and restart-looped a healthy
+// platform (it never survived to be promoted to good). platformRoot() falls
+// back to Dir on the legacy single-root layout, so unit/e2e stays unchanged.
+func (s *Store) stateDBPath() string {
+	return filepath.Join(s.platformRoot(), PlatformStateDBName)
+}
 
-// WorkdirIntact reports whether the shared workdir is present on disk AND
-// initialised: the workdir directory exists and the platform's state DB is
-// present inside it. A false result while a platform process still claims to be
-// running means the workdir was wiped (rm -rf) and the running platform is
+// WorkdirIntact reports whether the PLATFORM-workdir is present on disk AND
+// initialised: the platform-workdir directory exists and the platform's state DB
+// is present inside it. A false result while a platform process still claims to
+// be running means the workdir was wiped (rm -rf) and the running platform is
 // limping off a now-unlinked inode — the reconcile loop uses this to trigger a
 // proactive restart+rebuild rather than wait (blind) for the platform to
 // eventually crash on its own.
+//
+// Both checks key off platformRoot() (the disposable platform-workdir where
+// state.db lives), NOT the daemon-home: FEATURE 21 (HF1) split them, and the
+// daemon-home always exists (the daemon runs from it), so statting Dir here
+// would mask a wiped platform-workdir. platformRoot() falls back to Dir on the
+// legacy single-root layout.
 func (s *Store) WorkdirIntact() bool {
-	if fi, err := os.Stat(s.Dir); err != nil || !fi.IsDir() {
+	if fi, err := os.Stat(s.platformRoot()); err != nil || !fi.IsDir() {
 		return false
 	}
 	if fi, err := os.Stat(s.stateDBPath()); err != nil || fi.IsDir() {

--- a/daemon/internal/core/store.go
+++ b/daemon/internal/core/store.go
@@ -174,6 +174,7 @@ func (s *Store) badName(v string) string {
 func (s *Store) versionPath() string { return filepath.Join(s.Dir, VersionFile) }
 func (s *Store) goodPath() string    { return filepath.Join(s.Dir, "good") }
 func (s *Store) badDir() string      { return filepath.Join(s.Dir, "bad") }
+
 // stateDBPath is where the platform engine's state.db lives: the disposable
 // PLATFORM-WORKDIR (platformRoot), NOT the daemon-home. FEATURE 21 (HF1) split
 // the two roots — the platform derives its workdir from its own binary location

--- a/daemon/internal/core/store_test.go
+++ b/daemon/internal/core/store_test.go
@@ -142,6 +142,46 @@ func TestStoreWorkdirIntact(t *testing.T) {
 	}
 }
 
+// TestStoreWorkdirIntactHonorsPlatformDir is the v0.19.0 regression guard.
+// FEATURE 21 (HF1) split the daemon-home (Dir) from the disposable
+// platform-workdir (PlatformDir); the platform writes state.db under
+// PlatformDir, not Dir. WorkdirIntact MUST therefore key off the platform-workdir
+// — otherwise it stats a state.db under the daemon-home that never exists in a
+// split install, always reads "wiped", and the proactive workdir-wipe heal
+// restart-loops a HEALTHY platform (it never survives to be promoted to good:
+// the exact `platform process down / good=none` regression).
+func TestStoreWorkdirIntactHonorsPlatformDir(t *testing.T) {
+	daemonHome := t.TempDir()
+	platformWorkdir := t.TempDir()
+	s := &Store{Dir: daemonHome, PlatformDir: platformWorkdir}
+
+	// state.db present in the PLATFORM-workdir (where the platform actually
+	// writes it) → intact — even though the daemon-home has NO state.db.
+	if err := os.WriteFile(filepath.Join(platformWorkdir, PlatformStateDBName), []byte("db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !s.WorkdirIntact() {
+		t.Fatal("split install: state.db in the platform-workdir must read as intact")
+	}
+
+	// Guard against a regression to the daemon-home: a state.db that exists ONLY
+	// in the daemon-home (never in the platform-workdir) must NOT read as intact.
+	dhOnly := &Store{Dir: t.TempDir(), PlatformDir: t.TempDir()}
+	if err := os.WriteFile(filepath.Join(dhOnly.Dir, PlatformStateDBName), []byte("db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if dhOnly.WorkdirIntact() {
+		t.Fatal("split install: state.db only in the daemon-home must NOT read as intact")
+	}
+
+	// A wiped platform-workdir (dir gone) reads as broken even though the
+	// daemon-home still exists (the daemon runs from it).
+	wiped := &Store{Dir: t.TempDir(), PlatformDir: filepath.Join(t.TempDir(), "gone")}
+	if wiped.WorkdirIntact() {
+		t.Fatal("split install: absent platform-workdir must not read as intact")
+	}
+}
+
 func TestAtomicWriteCreatesDirs(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "a", "b", "f")
 	if err := atomicWrite(p, []byte("x")); err != nil {


### PR DESCRIPTION
## Summary

v0.19.0 deployed live but the **platform never reached `good`** (`platform down / good=none` for 3+ min); rolled back to v0.18.0. Root-caused + fixed here.

### Root cause
v0.19.0 bundled the HF1 **daemon-home ↔ platform-workdir split** together with the new **proactive "workdir wiped → heal"** behavior. The platform self-derives its workdir from its disguised binary location, so on a real split install `state.db` lives under `platformRoot()` (the disposable platform-workdir) — but the daemon's `WorkdirIntact()` / `stateDBPath()` still statted the daemon-home (`s.Dir`), while `BinPath()` correctly used `platformRoot()`.

Result: `WorkdirIntact()` read **false on every tick** → the proactive heal `Stop`+rebuilt a perfectly healthy platform every ~6s → it never survived long enough for the `HealthyFor` promotion → `good=none` forever.

CI/unit stayed green because the store tests use a single-root `Store` (`platformRoot()==Dir`), which never exercises the split.

### Fix (daemon-only, 2 functional lines)
`stateDBPath()` and the `WorkdirIntact()` directory check now key off `platformRoot()` (falls back to `Dir` on the legacy single-root layout, so existing installs/tests are unchanged).

### Proof (the sandbox start-check that was missing before deploy)
Disguised sandbox driving the real `Executor → ProcSvc → platform` handoff with a real (jobs-neutralized) platform binary:
- **Before:** `workdir_intact=false` every tick, `good=""` for 24s, 3 kill-rebuild events → FAIL
- **After:** `workdir_intact=true` from t=2s, `good="v0.19.0"` by t=6s, stays good, 0 kill events → PASS

Added `TestStoreWorkdirIntactHonorsPlatformDir` as the permanent regression guard (fails on the old `s.Dir` check, passes on `platformRoot()`).

## Test plan
- [x] `go build ./...` / `go vet ./...` green (daemon + platform)
- [x] `go test ./internal/core/...` green incl. new regression test
- [x] Disguised-sandbox e2e: platform reaches `good` and stays up, 0 kill-rebuild events
- [ ] Live redeploy v0.19.1 → platform reaches `good` on the real machine