### PR TITLE
fix(platform): kickstart jobs on scheduler start — close network-block 30m cold-start blind window

### DIFF
--- a/platform/internal/core/scheduler/scheduler.go
+++ b/platform/internal/core/scheduler/scheduler.go
@@ -37,6 +37,15 @@ type Scheduler struct {
 	mu         sync.Mutex
 	triggered  map[string]int  // jobID -> trigger count (test/observability)
 	skipLogged map[string]bool // jobID -> Info-logged "first run_as skip"
+
+	// kickstart holds one fire-once trigger per registered job. Start runs
+	// each ONCE immediately (then the cron interval takes over) so every
+	// protection layer engages right after a (re)start instead of waiting a
+	// full interval — closing the cold-start blind window a long-interval job
+	// (e.g. network-block @every 30m) would otherwise leave. kickWG tracks
+	// those in-flight runs so Stop drains them alongside cron-dispatched ones.
+	kickstart []func()
+	kickWG    sync.WaitGroup
 }
 
 // New builds a scheduler. The runner and DB must be ready. mode is the
@@ -140,15 +149,17 @@ func (s *Scheduler) Register(jobs []config.Job, plugins map[string]plugin.Discov
 
 		job := j // capture
 		disc := p
-		_, err := s.cron.AddFunc(job.Schedule, func() {
-			s.trigger(job, disc)
-		})
+		fire := func() { s.trigger(job, disc) }
+		_, err := s.cron.AddFunc(job.Schedule, fire)
 		if err != nil {
 			reason := fmt.Sprintf("invalid schedule %q for job %q: %v", job.Schedule, job.ID, err)
 			s.event(state.SeverityError, "bad_schedule", reason, job.ID)
 			s.log.Error("bad schedule", "job", job.ID, "err", err)
 			continue
 		}
+		// Same closure Start fires once immediately (kickstart), so the job's
+		// first run is at t=0 rather than t=schedule.
+		s.kickstart = append(s.kickstart, fire)
 		registered++
 		s.log.Info("job registered", "job", job.ID, "plugin", job.Plugin, "schedule", job.Schedule)
 	}
@@ -303,11 +314,45 @@ func (s *Scheduler) event(sev, typ, msg, jobID string) {
 	_ = s.db.Events.Record(sev, typ, msg, string(details))
 }
 
-// Start begins the cron loop (non-blocking).
-func (s *Scheduler) Start() { s.cron.Start() }
+// Start begins the cron loop (non-blocking) and KICKSTARTS every registered
+// job once, immediately. robfig/cron's @every schedules the FIRST tick at
+// now+interval, so without a kickstart a job on a long interval leaves its
+// protection layer absent — and its status reading "never" — for up to that
+// interval after each platform (re)start. network-block (@every 30m) is the
+// acute case: a 30-minute cold-start window where the pf packet-filter layer
+// is down after every restart/deploy. Firing once here engages every layer
+// within seconds and lets status reflect reality promptly; the cron interval
+// then takes over for steady-state reconciliation.
+//
+// Each kickstart runs in its own goroutine (mirroring cron's per-entry
+// dispatch) so Start stays non-blocking. no-overlap job_locks make a kickstart
+// run and the first cron tick coexist safely (whichever loses the lock records
+// a benign skip). Stop drains these via kickWG.
+func (s *Scheduler) Start() {
+	s.cron.Start()
+	for _, fire := range s.kickstart {
+		s.kickWG.Add(1)
+		go func() {
+			defer s.kickWG.Done()
+			fire()
+		}()
+	}
+}
 
-// Stop halts scheduling and waits for in-flight jobs to finish.
-func (s *Scheduler) Stop() context.Context { return s.cron.Stop() }
+// Stop halts scheduling and waits for in-flight jobs to finish — both the
+// cron-dispatched runs (drained by cron.Stop's context) and any still-running
+// kickstart runs (drained via kickWG). The returned context is Done only once
+// BOTH have settled, so callers get one honest "fully drained" signal.
+func (s *Scheduler) Stop() context.Context {
+	cronCtx := s.cron.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-cronCtx.Done()
+		s.kickWG.Wait()
+		cancel()
+	}()
+	return ctx
+}
 
 // TriggerCount reports how many times a job has been triggered (test
 // and observability aid).

--- a/platform/internal/core/scheduler/scheduler.go
+++ b/platform/internal/core/scheduler/scheduler.go
@@ -328,9 +328,17 @@ func (s *Scheduler) event(sev, typ, msg, jobID string) {
 // dispatch) so Start stays non-blocking. no-overlap job_locks make a kickstart
 // run and the first cron tick coexist safely (whichever loses the lock records
 // a benign skip). Stop drains these via kickWG.
+//
+// Lifecycle contract: Register must fully return before Start; Start is called
+// exactly once and is NOT safe to call concurrently with Stop or Register (the
+// s.kickstart slice is built lock-free by Register, and a second Start would
+// re-kickstart every job). The sole production caller (App.BuildScheduler then
+// cmd/platform run) honors this — register once, Start once, Stop once, all on
+// one goroutine. A future reload path must add its own synchronization.
 func (s *Scheduler) Start() {
 	s.cron.Start()
 	for _, fire := range s.kickstart {
+		fire := fire // per-iteration copy (redundant under Go 1.22+ loop semantics; kept explicit)
 		s.kickWG.Add(1)
 		go func() {
 			defer s.kickWG.Done()

--- a/platform/internal/core/scheduler/scheduler_test.go
+++ b/platform/internal/core/scheduler/scheduler_test.go
@@ -250,3 +250,38 @@ func TestStartStopLifecycle(t *testing.T) {
 		t.Error("Stop did not drain in time")
 	}
 }
+
+// TestStartKickstartsRegisteredJobsImmediately proves the cold-start fix:
+// a job on a long interval (whose first cron tick is an hour out) still runs
+// once promptly because Start kickstarts every registered job. Without the
+// kickstart this job would show status=none/never for an hour after start —
+// the exact network-block (@every 30m) blind window this closes.
+func TestStartKickstartsRegisteredJobsImmediately(t *testing.T) {
+	s, db := newSched(t)
+	p := testutil.ScriptPlugin(t, "ok", `echo '{"status":"ok"}'`)
+	s.Register([]config.Job{{ID: "j1", Plugin: "ok", Enabled: true,
+		Schedule: "@every 1h", Timeout: dur(5 * time.Second)}},
+		map[string]plugin.Discovered{"ok": p})
+
+	s.Start()
+	t.Cleanup(func() { <-s.Stop().Done() })
+
+	// The kickstart fires in a goroutine; wait for the run to actually RECORD
+	// (TriggerCount increments before the run completes, so poll the DB row).
+	deadline := time.After(3 * time.Second)
+	for {
+		if _, err := db.Runs.LastByStatus("j1", state.RunStatusOK); err == nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("job not kickstarted within 3s (trigger count = %d)", s.TriggerCount("j1"))
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	// Kickstart fires each job exactly once; the 1h cron tick is far away, so
+	// the count must stay at 1 (no accidental double-fire).
+	if got := s.TriggerCount("j1"); got != 1 {
+		t.Errorf("kickstart trigger count = %d, want exactly 1", got)
+	}
+}

--- a/platform/internal/core/scheduler/scheduler_test.go
+++ b/platform/internal/core/scheduler/scheduler_test.go
@@ -264,7 +264,15 @@ func TestStartKickstartsRegisteredJobsImmediately(t *testing.T) {
 		map[string]plugin.Discovered{"ok": p})
 
 	s.Start()
-	t.Cleanup(func() { <-s.Stop().Done() })
+	t.Cleanup(func() {
+		// Bounded so a regressed/hung Stop surfaces fast instead of deadlocking
+		// the package until the global test timeout.
+		select {
+		case <-s.Stop().Done():
+		case <-time.After(2 * time.Second):
+			t.Error("Stop did not drain in time")
+		}
+	})
 
 	// The kickstart fires in a goroutine; wait for the run to actually RECORD
 	// (TriggerCount increments before the run completes, so poll the DB row).


### PR DESCRIPTION
## Problem

On live v0.19.x, `network-block-reconcile` is scheduled `@every 30m` while every other job is `@every 10s`/`5m`. The concern: after each platform (re)start the pf packet-filter layer is absent for up to 30 minutes, and the job shows `status=none, age=never` for that window.

## Root cause (confirmed by reading the code, not guessing)

**Real gap — cold-start blind window.** The scheduler registers jobs via `robfig/cron`'s `AddFunc` and calls `cron.Start()`. `@every` uses `ConstantDelaySchedule.Next(t) = t + delay`, and `cron.run()` sets `entry.Next = Schedule.Next(now)` — so the FIRST tick of every `@every` job fires at `now + interval`, **never on start**. For 10s/5m jobs this is invisible; for network-block (`@every 30m`) it means the pf defense-in-depth layer is **down for up to 30 minutes after every platform restart/deploy**, and the job reads `none/never` that whole time.

**Not a bug — the status verdict.** A never-run job is already handled correctly:
- `platform/internal/status/status.go`: no run yet → `Unknown` (warming), and `overall()` folds worst-wins where `Unknown` ranks above `Healthy` → platform overall `UNKNOWN`, exit 0.
- `daemon/internal/status`: `PlatformDetail.Verdict()` maps `UNKNOWN`→`Unknown`; `Combine` folds → OVERALL `UNKNOWN` → exit 0.

So a never-run network-block reads **UNKNOWN/exit-0, not DEGRADED** — there was **no false-DEGRADED to fix in the verdict path**. (A live DEGRADED attributable to network-block comes from its first run *failing* when the manual pf prereqs — anchor+table in `/etc/pf.conf`, sudoers — are absent: exit 1 → `failed` → Degraded. That is a true signal, and this change surfaces it at t=0 instead of after a 30m `never` window.)

## Fix (KISS, scheduler-only)

`Scheduler.Start()` now fires each registered job **once immediately** (kickstart), each in its own goroutine, then the cron interval takes over. Every protection layer engages within seconds of a (re)start and status reflects reality promptly — this helps **every** job, not just network-block. `no-overlap` job_locks make the kickstart run and the first cron tick coexist safely. `Stop()` now drains in-flight kickstart runs (via a `WaitGroup`) alongside cron-dispatched runs before its context reports done; the existing 30s drain budget in `main` bounds it.

Steady-state cadence left at `@every 30m` by design (documented DoH/pfctl cost). No verdict-logic change (already correct).

## Verification

- **network-block actually works (proven live, then cleaned up):** ran the real plugin binary against a **disposable sandbox pf anchor** (`focusd_netblock_selftest`, not the real focusd anchor). Live Cloudflare DoH resolve returned Steam IPs, the reconciler added them to the pf table and removed a stale seed entry → `{"status":"ok","message":"added=3 removed=1"}` exit 0; idempotent re-run → `added=0 removed=0` exit 0; sandbox table flushed+killed afterward (zero residue). Also confirmed the controlled-failure path: missing table → `Table does not exist` → exit 1 / valid JSON, no mutation.
- **New test** `TestStartKickstartsRegisteredJobsImmediately`: a job on `@every 1h` still records exactly one run promptly after `Start` (would be `none/never` for an hour without the kickstart). Passes 3× and under `-race`.
- `go build ./...`, `go vet ./...` clean. Platform + daemon suites green (the pre-existing `runner/TestPrepareDropPathsMakesBinaryUserReachable` chmod-TMPDIR failure is environmental and reproduces on unmodified master; two daemon e2e timeouts were parallel-load contention — green when run sequentially, and the daemon module is byte-identical since only the platform scheduler changed).

Not merged, not deployed.