### PR TITLE
harden(round2): disguise footprint + in-mesh binary re-materialize (5 red-team fixes)

### DIFF
--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -298,6 +298,13 @@ func resolvePlatformWorkdir(m mode.Mode, daemonHome string) string {
 // launchd StartInterval stays the slower osadapter.EnsureBackstopInterval.
 const workerHealInterval = 2 * time.Second
 
+// companionHeartbeatInterval throttles the companion heartbeat touch (FEATURE 24
+// / HF-disguise). The reconcile loop ticks ~2s, but touching the heartbeat file
+// every tick turned it into a once-every-2s on-disk beacon. 15s stays well under
+// the companion's StaleThreshold (30s), so a killed daemon is still detected +
+// recovered within the same ~60s window — recovery timing is unchanged.
+const companionHeartbeatInterval = 15 * time.Second
+
 // platformAsset is the protection-engine release asset name for THIS
 // daemon's OS/arch. Releases are named platform-{GOOS}-{GOARCH}, so the
 // name is FULLY DETERMINED — it is DERIVED, never an operator knob.
@@ -472,18 +479,51 @@ func loop(args []string, once bool) int {
 	self, _ := os.Executable()
 	spec := o.spec(self)
 
+	// FEATURE 22 follow-up (in-mesh binary re-materialize): retain a read-only fd
+	// to our OWN binary for the process lifetime. On Unix an open fd keeps the
+	// inode alive, so pread from it returns the original release bytes even after
+	// the path is unlinked (`rm`). A surviving mesh worker uses these bytes to
+	// rewrite the deleted binary within one tick — closing the rm=permanent-kill
+	// hole without waiting on the ~60s companion backstop. Best-effort: if the
+	// open fails, selfFD stays nil and the companion remains the LAST line.
+	// Deliberately NEVER closed — it lives for the whole process lifetime.
+	selfFD, ferr := os.Open(self)
+	if ferr != nil {
+		log.Warn("retain self fd", "err", ferr)
+		selfFD = nil
+	}
+
+	// lastHeartbeat throttles the companion heartbeat touch (see
+	// companionHeartbeatInterval). Zero value ⇒ the first tick touches immediately.
+	var lastHeartbeat time.Time
+
 	tick := func() {
-		a, err := e.Tick(ctx)
-		if err != nil {
+		// Steady-state ticks no longer emit a per-tick "tick" beacon (FEATURE 24 /
+		// HF-disguise): non-steady actions are already logged by the executor, and
+		// the mesh/companion calls below log only on change/error — so real events
+		// stay recorded while the daemon log falls silent at rest. Errors are still
+		// logged.
+		if _, err := e.Tick(ctx); err != nil {
 			log.Error("tick error", "err", err)
-		} else {
-			log.Info("tick", "role", o.role, "action", string(a.Kind),
-				"target", a.Target, "note", a.Note)
 		}
 		// Mesh self-heal: only when launched as part of an installed
 		// mesh (--mesh, set solely by the installer). A plain
 		// `daemon run` (e2e/foreground) never touches launchd.
 		if o.mesh {
+			// FEATURE 22 follow-up: a surviving worker re-materializes its own
+			// binary FILE if it was deleted (`rm` = permanent-kill). The helper
+			// self-gates — to the single platform-lock HOLDER (so A and B don't
+			// both place), to non-test mode, and to the actually-missing case (one
+			// cheap stat at rest). On a real re-materialize it returns the fresh
+			// disguised path, which we adopt so the NEXT tick stats the new file
+			// (no heal loop) and EnsureAll/EnsureCompanion below use it.
+			if newSelf, changed, berr := osadapter.EnsureBinaryPresent(spec, e.HoldsPlatformLock(), selfFD); berr != nil {
+				log.Warn("ensure-binary-present", "err", berr)
+			} else if changed {
+				self = newSelf
+				spec.SelfPath = newSelf
+				log.Info("daemon binary re-materialized") // no path (redaction-safe)
+			}
 			if rec, eerr := osadapter.EnsureAll(spec); eerr != nil {
 				log.Warn("ensure-all", "err", eerr)
 			} else if len(rec) > 0 {
@@ -499,8 +539,15 @@ func loop(args []string, once bool) int {
 					log.Warn("ensure-companion", "err", cerr)
 				}
 			}
-			if herr := osadapter.TouchCompanionHeartbeat(spec.Mode); herr != nil {
-				log.Warn("touch-heartbeat", "err", herr)
+			// Throttled heartbeat (FEATURE 24 / HF-disguise): touch at most once per
+			// companionHeartbeatInterval so the file stops being a ~2s disk beacon.
+			// Test mode is a no-op inside TouchCompanionHeartbeat.
+			if now := time.Now(); now.Sub(lastHeartbeat) >= companionHeartbeatInterval {
+				if herr := osadapter.TouchCompanionHeartbeat(spec.Mode); herr != nil {
+					log.Warn("touch-heartbeat", "err", herr)
+				} else {
+					lastHeartbeat = now
+				}
 			}
 		}
 	}

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -152,6 +152,13 @@ const fetchRetryCooldown = 30 * time.Second
 // never itself MarkBad the only version.
 const platformSettleWindow = 5 * time.Second
 
+// HoldsPlatformLock reports whether this executor won the cross-generation
+// platform singleton lock (FEATURE 17, Item 2). The reconcile loop uses it to
+// gate single-writer work to exactly one mesh worker — e.g. the in-mesh binary
+// re-materialize (FEATURE 22 follow-up), so roles A and B don't both place a
+// fresh binary when the file is deleted. Read-only accessor over holdsLock.
+func (e *Executor) HoldsPlatformLock() bool { return e.holdsLock }
+
 // nowOrDefault returns the executor clock (time.Now unless a test injected
 // a fake), tolerating zero-valued executors built without NewExecutor.
 func (e *Executor) nowOrDefault() time.Time {

--- a/daemon/internal/osadapter/binpresent.go
+++ b/daemon/internal/osadapter/binpresent.go
@@ -1,0 +1,167 @@
+package osadapter
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// binPresentDeps are the injectable seams for ensureBinaryPresent so the
+// decision + placement guards are unit-tested on Linux CI without launchd, a
+// real self-delete, or the offline signing key. Production wiring lives in the
+// darwin EnsureBinaryPresent.
+type binPresentDeps struct {
+	// selfExists reports whether the daemon binary FILE is present. It returns
+	// (false, nil) for a clean ENOENT (the re-materialize trigger) and a non-nil
+	// err only for an ambiguous stat failure (permission, I/O) — which aborts
+	// rather than guessing the file is gone.
+	selfExists func(path string) (bool, error)
+	// readSelfBytes returns the retained-fd bytes of the ORIGINAL binary (still
+	// readable after the path is unlinked). An error or empty result ⇒ no in-mesh
+	// source; the out-of-band companion backstop still applies.
+	readSelfBytes func() ([]byte, error)
+	// verify reports whether the read bytes are a genuine, Ed25519-signed release
+	// (program image ++ 64-byte trailer). Checked BEFORE anything is written —
+	// refuse-then-place — so a corrupted retained image is never re-materialized.
+	verify func(signedImage []byte) (bool, error)
+	// randName is the fresh disguised basename generator (relocate.RandomBinaryName):
+	// a new path each call also satisfies AMFI per-path CDHash rotation.
+	randName func() string
+	// place writes bytes to a NEW path atomically (temp+rename, 0755). CREATE-ONLY:
+	// it never removes a directory.
+	place func(bytes []byte, dst string) error
+	// reinstall re-renders the three mesh plists at newSpec.SelfPath and
+	// re-bootstraps them (installAll). Repointing SelfPath repoints all three by
+	// construction.
+	reinstall func(newSpec Spec) error
+	// supportRoot is the containment root: the fresh binary path must sit directly
+	// in spec.Workdir, which must itself be strictly under supportRoot.
+	supportRoot string
+}
+
+// The refuse sentinels are surfaced (best-effort) so a heal that cannot proceed
+// safely is logged, never silently placing an unverified or out-of-containment
+// binary.
+var (
+	errNoSelfSource     = errors.New("osadapter: no retained-fd bytes to re-materialize the daemon binary")
+	errUnverifiedSelf   = errors.New("osadapter: refusing to place a daemon binary that failed signature verification")
+	errUnsafeCreatePath = errors.New("osadapter: refusing to place a daemon binary outside the contained workdir")
+)
+
+// ensureBinaryPresent is the seam-injected core of the in-mesh binary
+// re-materialize fast path (FEATURE 22 follow-up). If our own binary FILE was
+// deleted while this worker survives (`rm` = permanent-kill, since launchd can no
+// longer exec the mesh), it verifies the retained-fd bytes and re-places them at
+// a FRESH disguised path under the workdir, then repoints the three mesh plists —
+// all within one reconcile tick, so the heartbeat keeps advancing and the ~30s
+// companion staleness never trips. It is the FAST first line (partial kill:
+// binary rm'd while A/B alive); the companion remains the LAST line (total kill /
+// reboot).
+//
+// It is strictly CREATE-ONLY: it deletes NOTHING (no os.RemoveAll anywhere), so
+// it can never degrade into the RemoveAll-class blast bug. The old (already
+// ENOENT) path is left alone.
+//
+// Returns (newSelfPath, changed=true, err) when it (attempted to) re-materialize,
+// and ("", false, nil) for every no-op gate (test mode, not the lock holder,
+// binary still present). A non-nil err with changed=false is a refusal BEFORE any
+// write; changed=true with a non-nil err means the binary WAS placed but the
+// plist re-bootstrap failed (still progress — the caller adopts newSelfPath and
+// the next tick's EnsureAll retries the launchd side).
+func ensureBinaryPresent(d binPresentDeps, spec Spec, holdsLock bool) (newSelfPath string, changed bool, err error) {
+	if spec.Mode == mode.Test { // test mode: never touch a real launchd mesh
+		return "", false, nil
+	}
+	if !holdsLock { // only the single platform-lock holder re-materializes
+		return "", false, nil
+	}
+	present, serr := d.selfExists(spec.SelfPath) // one cheap stat in steady state
+	if serr != nil {
+		return "", false, serr // ambiguous stat failure — do NOT assume deleted
+	}
+	if present { // steady state: the file is there, nothing to do
+		return "", false, nil
+	}
+
+	// The binary FILE is gone. Re-materialize it from the retained-fd bytes.
+	raw, rerr := d.readSelfBytes()
+	if rerr != nil {
+		return "", false, rerr
+	}
+	if len(raw) == 0 {
+		return "", false, errNoSelfSource
+	}
+	ok, verr := d.verify(raw) // VERIFY BEFORE PLACE
+	if verr != nil {
+		return "", false, verr
+	}
+	if !ok {
+		return "", false, errUnverifiedSelf
+	}
+
+	newPath := filepath.Join(spec.Workdir, d.randName()) // fresh disguised path
+	if !safeToCreateUnder(newPath, spec.Workdir, d.supportRoot) {
+		return "", false, errUnsafeCreatePath
+	}
+	if perr := d.place(raw, newPath); perr != nil { // atomic create-only, 0755
+		return "", false, perr
+	}
+
+	// Repoint the three mesh plists at the fresh binary and re-bootstrap them.
+	newSpec := spec
+	newSpec.SelfPath = newPath
+	if ierr := d.reinstall(newSpec); ierr != nil {
+		// The binary IS placed; report the new path so the caller adopts it even
+		// though the launchd rebuild failed (the next tick's EnsureAll retries).
+		return newPath, true, ierr
+	}
+	return newPath, true, nil
+}
+
+// safeToCreateUnder reports whether newPath is a safe CREATE target for the
+// re-materialized binary: an absolute path sitting DIRECTLY in workdir, where
+// workdir is itself strictly nested under supportRoot. It is the create-side
+// mirror of safeToRemoveWorkdir — belt-and-suspenders against a corrupted
+// spec.Workdir ever widening where we write. newPath does not exist yet, so we
+// resolve its PARENT (== workdir, which does exist) instead of the file itself.
+// Pure → unit-tested on Linux CI.
+func safeToCreateUnder(newPath, workdir, supportRoot string) bool {
+	if newPath == "" || workdir == "" || supportRoot == "" {
+		return false
+	}
+	if !filepath.IsAbs(newPath) || !filepath.IsAbs(workdir) || !filepath.IsAbs(supportRoot) {
+		return false
+	}
+	// The base must be a real single path element — never a traversal that could
+	// climb out of the workdir.
+	base := filepath.Base(newPath)
+	if base == "." || base == ".." || strings.ContainsRune(base, filepath.Separator) {
+		return false
+	}
+	// workdir must be strictly under supportRoot. Resolve symlinks on both (they
+	// exist) so this guard and the real write agree on the true paths — a
+	// symlinked intermediate must not let the write escape supportRoot.
+	rwd, err := filepath.EvalSymlinks(workdir)
+	if err != nil {
+		return false
+	}
+	rroot, err := filepath.EvalSymlinks(supportRoot)
+	if err != nil {
+		return false
+	}
+	wd := filepath.Clean(rwd)
+	root := filepath.Clean(rroot)
+	rel, err := filepath.Rel(root, wd)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	// newPath's PARENT must resolve to exactly workdir (no symlinked escape via a
+	// component of the parent).
+	rparent, err := filepath.EvalSymlinks(filepath.Dir(newPath))
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(rparent) == wd
+}

--- a/daemon/internal/osadapter/binpresent_darwin.go
+++ b/daemon/internal/osadapter/binpresent_darwin.go
@@ -4,6 +4,7 @@ package osadapter
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -26,7 +27,21 @@ import (
 // (Executor.HoldsPlatformLock) — only the lock holder re-materializes, so mesh
 // roles A and B never both place.
 func EnsureBinaryPresent(spec Spec, holdsLock bool, retained *os.File) (newSelf string, changed bool, err error) {
-	home, _ := os.UserHomeDir()
+	// Cheap no-op gates hoisted from the core so a non-participant skips the home
+	// resolution + fd work below (and never logs a spurious home error every tick).
+	// The core re-checks both, so its unit-tested guards remain authoritative.
+	if spec.Mode == mode.Test || !holdsLock {
+		return "", false, nil
+	}
+	home, herr := os.UserHomeDir()
+	// System mode's SupportRoot is a fixed absolute path (home-independent); every
+	// other mode roots the containment under home. If home can't be resolved for a
+	// home-dependent mode, supportRoot would be RELATIVE and safeToCreateUnder
+	// would refuse with a misleading errUnsafeCreatePath — surface the real cause
+	// instead. Best-effort: the out-of-band companion remains the backstop.
+	if herr != nil && spec.Mode != mode.System {
+		return "", false, fmt.Errorf("osadapter: re-materialize: resolve home: %w", herr)
+	}
 	d := binPresentDeps{
 		selfExists:    fileExists,
 		readSelfBytes: func() ([]byte, error) { return readAllFromFD(retained) },
@@ -73,8 +88,10 @@ func fileExists(path string) (bool, error) {
 // readAllFromFD reads the entire file behind an open fd via pread (ReadAt through
 // io.SectionReader), which works even after the path has been unlinked — the
 // inode stays alive while the fd is open, so the original release bytes remain
-// readable. It uses fstat (f.Stat) for the size, which also works on an unlinked
-// inode. Returns an error for a nil fd (the retain open failed at startup).
+// readable. It uses fstat (f.Stat) for the size bound, which also works on an
+// unlinked inode. Reading through a size-bounded SectionReader with io.ReadAll
+// avoids a manual make([]byte, int64) allocation. Returns an error for a nil fd
+// (the retain open failed at startup).
 func readAllFromFD(f *os.File) ([]byte, error) {
 	if f == nil {
 		return nil, errors.New("osadapter: no retained daemon-binary fd")
@@ -83,9 +100,5 @@ func readAllFromFD(f *os.File) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, fi.Size())
-	if _, err := io.ReadFull(io.NewSectionReader(f, 0, fi.Size()), buf); err != nil {
-		return nil, err
-	}
-	return buf, nil
+	return io.ReadAll(io.NewSectionReader(f, 0, fi.Size()))
 }

--- a/daemon/internal/osadapter/binpresent_darwin.go
+++ b/daemon/internal/osadapter/binpresent_darwin.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
+	"github.com/eliteGoblin/focusd/daemon/internal/sig"
+)
+
+// EnsureBinaryPresent is the darwin entry point for the in-mesh binary
+// re-materialize fast path (FEATURE 22 follow-up). It wires the real seams
+// (fstat-based read of the retained fd, Ed25519 verify, atomic create-only
+// placer, installAll re-bootstrap) into the pure ensureBinaryPresent core and
+// returns its result unchanged.
+//
+// retained is a read-only fd to the daemon's OWN binary, held open for the
+// process lifetime (loop() opens it once). It may be nil (the retain open failed
+// at startup); then a re-materialize cannot proceed in-mesh and the companion
+// remains the backstop. holdsLock is the caller's platform-singleton-lock state
+// (Executor.HoldsPlatformLock) — only the lock holder re-materializes, so mesh
+// roles A and B never both place.
+func EnsureBinaryPresent(spec Spec, holdsLock bool, retained *os.File) (newSelf string, changed bool, err error) {
+	home, _ := os.UserHomeDir()
+	d := binPresentDeps{
+		selfExists:    fileExists,
+		readSelfBytes: func() ([]byte, error) { return readAllFromFD(retained) },
+		verify:        verifySignedBytes,
+		randName:      relocate.RandomBinaryName,
+		place:         binPlacerFS{}.place,
+		reinstall: func(ns Spec) error {
+			var rs rosterIO
+			if ns.Workdir != "" {
+				rs = newWorkdirRoster(ns.Workdir)
+			}
+			return installAll(ns, launchctlCtl{m: ns.Mode}, laFS{m: ns.Mode}, rs)
+		},
+		supportRoot: mode.SupportRoot(spec.Mode, home),
+	}
+	return ensureBinaryPresent(d, spec, holdsLock)
+}
+
+// verifySignedBytes splits a signed-release image (program ++ 64-byte trailer)
+// and verifies it against the embedded Ed25519 key — the same trust root the
+// daemon uses for peer binaries on disk. It refuses (ok=false) a truncated or
+// unsigned image rather than trusting the bytes.
+func verifySignedBytes(b []byte) (bool, error) {
+	program, signature, serr := sig.SplitTrailer(b)
+	if serr != nil {
+		return false, serr
+	}
+	return sig.Verify(program, signature)
+}
+
+// fileExists reports whether path is present. A clean ENOENT ⇒ (false, nil); any
+// other stat error is surfaced so an ambiguous failure never masquerades as "the
+// binary was deleted" (which would trigger an unwarranted re-materialize).
+func fileExists(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// readAllFromFD reads the entire file behind an open fd via pread (ReadAt through
+// io.SectionReader), which works even after the path has been unlinked — the
+// inode stays alive while the fd is open, so the original release bytes remain
+// readable. It uses fstat (f.Stat) for the size, which also works on an unlinked
+// inode. Returns an error for a nil fd (the retain open failed at startup).
+func readAllFromFD(f *os.File) ([]byte, error) {
+	if f == nil {
+		return nil, errors.New("osadapter: no retained daemon-binary fd")
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, fi.Size())
+	if _, err := io.ReadFull(io.NewSectionReader(f, 0, fi.Size()), buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/daemon/internal/osadapter/binpresent_test.go
+++ b/daemon/internal/osadapter/binpresent_test.go
@@ -1,0 +1,301 @@
+package osadapter
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// testBinPresentDeps returns a default deps set whose seams describe the common
+// re-materialize scenario: a MISSING self, valid retained bytes, a passing verify,
+// a deterministic fresh name, a real create-only placer (os.WriteFile), and a
+// no-op reinstall. The workdir is a real dir strictly under a real supportRoot so
+// safeToCreateUnder (which resolves symlinks) passes. Individual tests override
+// only the seam under test.
+func testBinPresentDeps(t *testing.T) (binPresentDeps, Spec, string) {
+	t.Helper()
+	supportRoot := t.TempDir()
+	workdir := filepath.Join(supportRoot, "hidden-workdir")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	spec := Spec{
+		Mode:     mode.User,
+		SelfPath: filepath.Join(workdir, "old-binary"),
+		Workdir:  workdir,
+	}
+	d := binPresentDeps{
+		selfExists:    func(string) (bool, error) { return false, nil }, // gone by default
+		readSelfBytes: func() ([]byte, error) { return []byte("SIGNED-DAEMON-BYTES"), nil },
+		verify:        func([]byte) (bool, error) { return true, nil },
+		randName:      func() string { return "fresh.disguised.name.deadbeef01" },
+		place:         func(b []byte, dst string) error { return os.WriteFile(dst, b, 0o755) },
+		reinstall:     func(Spec) error { return nil },
+		supportRoot:   supportRoot,
+	}
+	return d, spec, workdir
+}
+
+// (a) A deleted self is re-materialized at a FRESH path directly inside the
+// workdir, and the bytes are actually written.
+func TestEnsureBinaryPresent_MissingSelfPlacesFreshBinary(t *testing.T) {
+	d, spec, workdir := testBinPresentDeps(t)
+	var placedDst string
+	var placedBytes []byte
+	d.place = func(b []byte, dst string) error {
+		placedDst, placedBytes = dst, b
+		return os.WriteFile(dst, b, 0o755)
+	}
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed || newSelf == "" {
+		t.Fatalf("want a re-materialize, got changed=%v newSelf=%q", changed, newSelf)
+	}
+	if filepath.Dir(newSelf) != workdir {
+		t.Errorf("fresh binary %q is not directly in workdir %q", newSelf, workdir)
+	}
+	if newSelf == spec.SelfPath {
+		t.Error("fresh path must differ from the deleted (old) path")
+	}
+	if placedDst != newSelf {
+		t.Errorf("placed at %q but returned %q", placedDst, newSelf)
+	}
+	if string(placedBytes) != "SIGNED-DAEMON-BYTES" {
+		t.Errorf("placed the wrong bytes: %q", placedBytes)
+	}
+	if _, statErr := os.Stat(newSelf); statErr != nil {
+		t.Errorf("fresh binary not on disk: %v", statErr)
+	}
+}
+
+// (b) When self is still present it is a cheap no-op — nothing placed, no
+// reinstall.
+func TestEnsureBinaryPresent_PresentSelfNoOp(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	d.selfExists = func(string) (bool, error) { return true, nil }
+	placeCalled, reinstallCalled := false, false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+	d.reinstall = func(Spec) error { reinstallCalled = true; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || changed || newSelf != "" {
+		t.Fatalf("want no-op, got (%q, %v, %v)", newSelf, changed, err)
+	}
+	if placeCalled || reinstallCalled {
+		t.Error("steady-state path must not place or reinstall")
+	}
+}
+
+// (c) Bytes that fail verification are REFUSED before any write.
+func TestEnsureBinaryPresent_VerifyFailRefuses(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	d.verify = func([]byte) (bool, error) { return false, nil }
+	placeCalled := false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if !errors.Is(err, errUnverifiedSelf) {
+		t.Fatalf("want errUnverifiedSelf, got %v", err)
+	}
+	if changed || newSelf != "" {
+		t.Error("a refusal must not report a change")
+	}
+	if placeCalled {
+		t.Error("must NOT place bytes that failed verification")
+	}
+}
+
+// (d) All three mesh plists are repointed at the fresh binary (via the reinstall
+// spec's SelfPath), rendered through the real Plist template.
+func TestEnsureBinaryPresent_AllThreePlistsRepointed(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	// A populated roster makes Plist emit the prod Program=<SelfPath> shape.
+	spec.Roster = []string{"com.vendor.alpha", "com.vendor.bravo", "com.vendor.charlie"}
+	var gotSpec Spec
+	d.reinstall = func(ns Spec) error { gotSpec = ns; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || !changed {
+		t.Fatalf("want a re-materialize, got changed=%v err=%v", changed, err)
+	}
+	if gotSpec.SelfPath != newSelf {
+		t.Fatalf("reinstall spec.SelfPath = %q, want the fresh path %q", gotSpec.SelfPath, newSelf)
+	}
+	for _, r := range AllRoles {
+		pl := Plist(gotSpec, r)
+		if !strings.Contains(pl, newSelf) {
+			t.Errorf("role %s plist does not point at the fresh binary %q", r, newSelf)
+		}
+	}
+}
+
+// (e) The heal is strictly CREATE-ONLY: unrelated workdir contents (a state.db
+// file and a plugins dir) survive — proving no RemoveAll-class blast. The deps
+// struct has no delete seam at all; this asserts that against a real FS.
+func TestEnsureBinaryPresent_CreateOnlyNoCollateralDelete(t *testing.T) {
+	d, spec, workdir := testBinPresentDeps(t)
+	sentinelFile := filepath.Join(workdir, "state.db")
+	if err := os.WriteFile(sentinelFile, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sentinelDir := filepath.Join(workdir, "plugins")
+	if err := os.MkdirAll(sentinelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || !changed {
+		t.Fatalf("want a re-materialize, got changed=%v err=%v", changed, err)
+	}
+	if _, e := os.Stat(sentinelFile); e != nil {
+		t.Errorf("sentinel state.db was deleted by the heal: %v", e)
+	}
+	if _, e := os.Stat(sentinelDir); e != nil {
+		t.Errorf("sentinel plugins/ dir was deleted by the heal: %v", e)
+	}
+}
+
+// (f) Containment: if the workdir is not strictly under supportRoot, the placement
+// is refused (belt-and-suspenders against a corrupted spec.Workdir).
+func TestEnsureBinaryPresent_RefusesWhenWorkdirOutsideSupportRoot(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	d.supportRoot = t.TempDir() // unrelated tree — workdir is no longer nested under it
+	placeCalled := false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if !errors.Is(err, errUnsafeCreatePath) {
+		t.Fatalf("want errUnsafeCreatePath, got %v", err)
+	}
+	if changed || newSelf != "" || placeCalled {
+		t.Error("must refuse to place outside containment")
+	}
+}
+
+// (g) A worker that does NOT hold the platform singleton lock is a no-op — it does
+// not even stat self (so roles A and B don't both act).
+func TestEnsureBinaryPresent_NonLockHolderNoOp(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	statCalled := false
+	d.selfExists = func(string) (bool, error) { statCalled = true; return false, nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, false)
+	if err != nil || changed || newSelf != "" {
+		t.Fatalf("want no-op, got (%q, %v, %v)", newSelf, changed, err)
+	}
+	if statCalled {
+		t.Error("non-holder must short-circuit BEFORE stat'ing self")
+	}
+}
+
+// (h) Test mode never touches a real launchd mesh — no-op, not even a stat.
+func TestEnsureBinaryPresent_TestModeNoOp(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	spec.Mode = mode.Test
+	statCalled := false
+	d.selfExists = func(string) (bool, error) { statCalled = true; return false, nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || changed || newSelf != "" {
+		t.Fatalf("want no-op, got (%q, %v, %v)", newSelf, changed, err)
+	}
+	if statCalled {
+		t.Error("test mode must short-circuit BEFORE stat'ing self")
+	}
+}
+
+// An ambiguous stat failure (not a clean ENOENT) must NOT be treated as "deleted"
+// — the heal aborts rather than re-materializing on a guess.
+func TestEnsureBinaryPresent_StatErrorAborts(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	statErr := errors.New("permission denied")
+	d.selfExists = func(string) (bool, error) { return false, statErr }
+	placeCalled := false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if !errors.Is(err, statErr) {
+		t.Fatalf("want the stat error surfaced, got %v", err)
+	}
+	if changed || newSelf != "" || placeCalled {
+		t.Error("an ambiguous stat failure must not re-materialize")
+	}
+}
+
+// No retained-fd source (empty bytes) is a refusal, not a silent empty placement.
+func TestEnsureBinaryPresent_EmptySourceRefuses(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	d.readSelfBytes = func() ([]byte, error) { return nil, nil }
+	placeCalled := false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+
+	_, changed, err := ensureBinaryPresent(d, spec, true)
+	if !errors.Is(err, errNoSelfSource) {
+		t.Fatalf("want errNoSelfSource, got %v", err)
+	}
+	if changed || placeCalled {
+		t.Error("empty source must not place anything")
+	}
+}
+
+// The binary IS placed even if the launchd re-bootstrap fails: the caller must
+// adopt the fresh path (the next tick's EnsureAll retries the plist side).
+func TestEnsureBinaryPresent_ReinstallErrStillAdoptsNewPath(t *testing.T) {
+	d, spec, workdir := testBinPresentDeps(t)
+	d.reinstall = func(Spec) error { return errors.New("bootstrap boom") }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err == nil {
+		t.Fatal("want the reinstall error surfaced")
+	}
+	if !changed || newSelf == "" {
+		t.Fatal("the binary was placed; caller must adopt newSelf even if launchd rebuild failed")
+	}
+	if filepath.Dir(newSelf) != workdir {
+		t.Errorf("fresh binary %q not directly in workdir %q", newSelf, workdir)
+	}
+	if _, statErr := os.Stat(newSelf); statErr != nil {
+		t.Errorf("binary should be on disk despite the reinstall failure: %v", statErr)
+	}
+}
+
+// safeToCreateUnder is the create-side containment guard.
+func TestSafeToCreateUnder(t *testing.T) {
+	root := t.TempDir()
+	wd := filepath.Join(root, "wd")
+	if err := os.MkdirAll(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(wd, "bin.x")
+	other := t.TempDir()
+
+	cases := []struct {
+		name                        string
+		newPath, workdir, supportRt string
+		want                        bool
+	}{
+		{"happy path", good, wd, root, true},
+		{"relative newPath", "rel/bin", wd, root, false},
+		{"relative workdir", good, "wd", root, false},
+		{"relative supportRoot", good, wd, "root", false},
+		{"traversal base", wd + "/..", wd, root, false},
+		{"workdir equals supportRoot (not strictly under)", filepath.Join(root, "bin"), root, root, false},
+		{"workdir outside supportRoot", good, wd, other, false},
+		{"empty newPath", "", wd, root, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := safeToCreateUnder(c.newPath, c.workdir, c.supportRt); got != c.want {
+				t.Errorf("safeToCreateUnder(%q,%q,%q) = %v, want %v",
+					c.newPath, c.workdir, c.supportRt, got, c.want)
+			}
+		})
+	}
+}

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -4,6 +4,7 @@ package osadapter
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
@@ -18,6 +19,11 @@ func Uninstall(bool) error             { return ErrUnsupported }
 func EnsureAll(Spec) ([]Role, error)   { return nil, ErrUnsupported }
 func IsLoaded(bool, Role) bool         { return false }
 func UninstallProd() ([]string, error) { return nil, ErrUnsupported }
+
+// EnsureBinaryPresent is a no-op on non-darwin (no launchd mesh binary to
+// re-materialize). Returns ("", false, nil) so the reconcile loop wires it
+// uniformly (FEATURE 22 follow-up).
+func EnsureBinaryPresent(Spec, bool, *os.File) (string, bool, error) { return "", false, nil }
 
 // Verifier is the signature-check seam (no-op on non-darwin since
 // FindCurrentInstall returns ErrUnsupported here).

--- a/platform/cmd/platform/main.go
+++ b/platform/cmd/platform/main.go
@@ -156,6 +156,14 @@ func parseCommon(name string, honorConfigFlag bool, args []string) app.Options {
 	// SIGNED embedded default — the workdir's config.yaml is NOT consulted
 	// (it was a tamper surface and has been removed).
 	if *wd != "" {
+		// Daemon-managed run: the daemon already tees the child's stdout+stderr
+		// into the disguised workdir's svc.log, so the engine's own DefaultLogDir
+		// file (<supportRoot>/focusd/logs/svc.log) is redundant AND the sole
+		// `focusd`-literal on-disk footprint. Suppress it (FEATURE 24 /
+		// HF-disguise); the logger degrades to stderr-only, which the daemon
+		// captures. Direct-run (`platform validate/run` without --workdir) keeps
+		// DefaultLogDir for dev ergonomics.
+		opts.NoLogFile = true
 		if opts.StateDBPath == "" {
 			opts.StateDBPath = filepath.Join(*wd, "state.db")
 		}

--- a/platform/internal/core/app/app.go
+++ b/platform/internal/core/app/app.go
@@ -58,6 +58,16 @@ type Options struct {
 	PluginDir string
 	// ForceMode pins the run mode. "" => config, then adapter detection.
 	ForceMode osadapter.RunMode
+	// NoLogFile suppresses the engine's own on-disk log file, leaving the
+	// logger stderr-only. The daemon-managed run path sets this (FEATURE 24 /
+	// HF-disguise): the daemon already tees the child's stdout+stderr into the
+	// disguised workdir's svc.log, so the engine's separate DefaultLogDir file
+	// (<supportRoot>/focusd/logs/svc.log) is redundant AND the only
+	// `focusd`-literal footprint a `find -iname '*focus*'` would surface. When
+	// NoLogFile is set, logDir is cleared before logging.New so no file under
+	// DefaultLogDir is ever opened. Zero value (dev/direct-run) keeps the
+	// on-disk log for ergonomics.
+	NoLogFile bool
 }
 
 // App holds the wired runtime dependencies.
@@ -104,21 +114,13 @@ func Bootstrap(opts Options) (*App, error) {
 	// (the result of defaultconfig.Load — the signed embedded default;
 	// the workdir config.yaml is inert). Fall back to a path-based load
 	// if no pre-loaded Config was provided.
-	var (
-		cfg     *config.Config
-		cfgPath string // for the bootstrapped log line only
-	)
+	var cfg *config.Config
 	if opts.Config != nil {
 		cfg = opts.Config
-		// Best-effort label for the log: the override path if one was
-		// passed (the loader may or may not have actually merged it),
-		// otherwise mark the source as the embedded default.
-		cfgPath = opts.ConfigPath
-		if cfgPath == "" {
-			cfgPath = "<embedded default>"
-		}
 	} else {
-		cfgPath = opts.ConfigPath
+		// Path-based load: the config path is used ONLY to open the file here
+		// (never logged — see the redacted "platform bootstrapped" line below).
+		cfgPath := opts.ConfigPath
 		if cfgPath == "" {
 			// Need a provisional mode just to find the default config
 			// path; detection is safe and side-effect free.
@@ -156,6 +158,12 @@ func Bootstrap(opts Options) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve log dir: %w", err)
 	}
+	// Daemon-managed runs suppress the engine's own file (the daemon already
+	// captures the child's stdio into the workdir); "" degrades logging.New to
+	// stderr-only, leaving no `focusd`-literal DefaultLogDir footprint.
+	if opts.NoLogFile {
+		logDir = ""
+	}
 	log, logClose, err := logging.New(cfg.Platform.LogLevel, logDir)
 	if err != nil {
 		return nil, err
@@ -183,9 +191,12 @@ func Bootstrap(opts Options) (*App, error) {
 		snap = snapshot.NewStore(filepath.Dir(dbPath))
 	}
 
+	// Redaction (FEATURE 24 / HF-disguise): drop the config + state_db fields —
+	// state_db is the plaintext disguised workdir path, which must never reach
+	// the INFO log stream. Keep only the path-free os/arch/mode context.
 	log.Info("platform bootstrapped",
 		"os", adapter.CurrentOS(), "arch", adapter.CurrentArch(),
-		"mode", string(mode), "config", cfgPath, "state_db", dbPath)
+		"mode", string(mode))
 
 	pluginDir := opts.PluginDir
 	if pluginDir == "" {
@@ -265,7 +276,13 @@ func (a *App) DiscoverPlugins() ([]plugin.Discovered, error) {
 		}
 		switch {
 		case p.OK:
-			a.Log.Info("plugin discovered", "id", p.Manifest.ID, "dir", p.Dir)
+			// Redaction (FEATURE 24 / HF-disguise): the OK branch carries the
+			// plugin id (e.g. skill-protector) + its on-disk dir (the disguised
+			// workdir path). At Debug it never reaches the default-INFO prod log,
+			// so a filesystem grep of the engine log can't recover a plugin name
+			// or the workdir. The WARN/rejected branches stay redacted via
+			// redactPaths for the rare genuine-defect case.
+			a.Log.Debug("plugin discovered", "id", p.Manifest.ID, "dir", p.Dir)
 		case p.Expected:
 			// A normal environment mismatch (wrong host, or a plugin this
 			// install's mode can't serve). The bundle ships every plugin to

--- a/platform/internal/core/app/app_test.go
+++ b/platform/internal/core/app/app_test.go
@@ -230,3 +230,46 @@ func TestBootstrapExplicitPathsOverride(t *testing.T) {
 		t.Errorf("state db not created at explicit path: %v", err)
 	}
 }
+
+// TestBootstrapNoLogFileSuppressesDiskLog asserts Options.NoLogFile leaves the
+// logger stderr-only: nothing is opened under DefaultLogDir. The daemon-managed
+// run path sets NoLogFile because the daemon already tees the child's stdio into
+// the disguised workdir — the engine's own DefaultLogDir file is redundant AND
+// the sole `focusd`-literal on-disk footprint (FEATURE 24 / HF-disguise).
+func TestBootstrapNoLogFileSuppressesDiskLog(t *testing.T) {
+	fa := testutil.NewFakeAdapter(t.TempDir())
+	writeUserConfig(t, fa, sampleConfig)
+
+	a, err := Bootstrap(Options{Adapter: fa, NoLogFile: true})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer a.Close()
+	// The logger must remain usable — it degrades to stderr-only, not nil.
+	a.Log.Info("still logs to stderr")
+
+	logDir, _ := fa.DefaultLogDir(osadapter.ModeUser)
+	if entries, err := os.ReadDir(logDir); err == nil && len(entries) > 0 {
+		t.Errorf("NoLogFile opened %d file(s) under DefaultLogDir %s; want none", len(entries), logDir)
+	}
+}
+
+// TestBootstrapDefaultOpensDiskLog is the control: a direct-run Bootstrap (no
+// NoLogFile) keeps its DefaultLogDir file for dev ergonomics, so the suppression
+// test above is proving a real difference rather than a vacuous truth.
+func TestBootstrapDefaultOpensDiskLog(t *testing.T) {
+	fa := testutil.NewFakeAdapter(t.TempDir())
+	writeUserConfig(t, fa, sampleConfig)
+
+	a, err := Bootstrap(Options{Adapter: fa})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer a.Close()
+
+	logDir, _ := fa.DefaultLogDir(osadapter.ModeUser)
+	entries, rerr := os.ReadDir(logDir)
+	if rerr != nil || len(entries) == 0 {
+		t.Errorf("default Bootstrap opened no log file under %s (entries=%d err=%v); want one", logDir, len(entries), rerr)
+	}
+}


### PR DESCRIPTION
## Round-2 disguise + self-recovery hardening

Defensive hardening of the self-protection commitment tool, driven by the
red-team findings. Two axes: (1) shrink the **observable footprint** a
weak-moment teardown would grep/`find` for, and (2) close a **recovery hole**
where a single file delete was an effective permanent kill. Disguised on-disk
identifiers are referred to abstractly throughout.

Base: `master` @ `459ad1f`. **Do not merge / deploy from this PR** — verify +
release happen separately.

### The 5 findings and their fixes

**#1a (P0) — engine wrote a `focusd`-literal log file when daemon-managed.**
The daemon already tees the child's stdout+stderr into the disguised workdir's
`svc.log`, so the engine's own `DefaultLogDir` file
(`<supportRoot>/focusd/logs/svc.log`) was redundant **and** the only
`focusd`-literal path a `find -iname '*focus*'` would surface.
Fix: `Options.NoLogFile`; `parseCommon` sets it inside the `--workdir` block so
the daemon-managed run never opens that file (`logging.New("")` → stderr-only,
which the daemon captures). Direct-run (`platform validate/run` without
`--workdir`) keeps `DefaultLogDir` for dev ergonomics. `AppName="focusd"` left
untouched (dev/direct-run default only).

**#1b (P1) — plugin names / workdir path leaked into the slog stream.**
Lowered the OK-branch `plugin discovered` line (`id` + on-disk `dir`) from
`Info` to `Debug` (default level is INFO → never hits disk in prod); dropped the
`config` + `state_db` (plaintext workdir path) fields from `platform
bootstrapped`. WARN/rejected branches already redact via `redactPaths`.

**#2a-log (P0) — per-tick `daemon.log` beacon.** Removed the unconditional
`log.Info("tick", …)` in `tick()`. Non-steady actions are already logged by the
executor and mesh/companion calls log only on change/error, so real events stay
recorded while the steady-state log goes silent (the `tick error` branch is
kept).

**#2a-hb (P1) — companion heartbeat mtime churned every ~2s.** Throttled the
touch to at most once per `companionHeartbeatInterval` (15s) via a
`lastHeartbeat` closure var. 15s stays well under the companion
`StaleThreshold` (30s), so kill-detection/recovery timing is unchanged.

**#2b (P0) — a surviving mesh worker now re-materializes a deleted binary
(closes `rm` = permanent kill). TDD'd.** `ensureAll` heals plists/state but
every plist points at `spec.SelfPath = os.Executable()`; if the binary **file**
is `rm`'d, launchd can't exec the mesh and nothing in-mesh recreates it — only
the ~60s out-of-band companion could.
New in-mesh FAST path `EnsureBinaryPresent`:
- **Byte source:** `loop()` retains a read-only fd to its own binary for the
  process lifetime; `pread` returns the original inode bytes after the path is
  unlinked.
- **Verify-before-place:** `sig.SplitTrailer` + `sig.Verify` on those bytes;
  refuse to place anything that doesn't verify.
- **Fresh disguised path:** `relocate.RandomBinaryName()` under the workdir
  (also satisfies AMFI per-path CDHash rotation), placed **atomically,
  create-only** (temp+rename, 0755).
- **Repoint:** re-render + re-bootstrap the 3 plists via `installAll`
  (repointing `SelfPath` repoints all three); `loop()` adopts the new path so
  the next tick stats the existing file (no heal loop).
- **Gating:** non-test mode + the single platform-singleton-lock holder (new
  `Executor.HoldsPlatformLock()`), so mesh roles A and B never both place; one
  cheap `stat` at rest.

**CRITICAL SAFETY — avoids the RemoveAll-class bug:** the path is CREATE-ONLY.
It deletes nothing (no `os.RemoveAll` anywhere), never touches the old
(already-ENOENT) path, and asserts `newPath` is strictly under the workdir under
the mode's SupportRoot (`safeToCreateUnder`, the create-side mirror of
`safeToRemoveWorkdir`) before writing. The deps struct has no delete seam at
all. Composition: the survivor is the FAST first line (partial kill: binary
rm'd while A/B alive); the companion remains the LAST line (total kill /
reboot). Both kept.

### KISS rationale
Each fix is the smallest change that closes its finding: #1a is one bool + one
conditional; #1b/#2a-log delete/relabel log lines; #2a-hb adds one time-gate;
#2b adds one seam-injected, create-only helper reusing existing primitives
(`sig`, `relocate.RandomBinaryName`, the atomic byte placer, `installAll`,
`safeToRemoveWorkdir`'s containment style). No new config knobs, no new
abstractions.

### Tests / acceptance
- **#1a:** `TestBootstrapNoLogFileSuppressesDiskLog` (no file under
  `DefaultLogDir`, logger stays usable) + a control `TestBootstrapDefaultOpensDiskLog`
  proving direct-run still opens one.
- **#2b (TDD, `binpresent_test.go`):** ENOENT self ⇒ fresh file under workdir;
  present self ⇒ no-op; verify-fail ⇒ refuse (nothing placed); all 3 plists
  repointed; unrelated workdir contents survive (create-only, no collateral
  delete); placed path strictly under workdir (+ refuse when the workdir escapes
  SupportRoot); non-lock-holder ⇒ no-op; test-mode ⇒ no-op; ambiguous stat ⇒
  abort; empty source ⇒ refuse; reinstall-fail still adopts the placed path.
  Plus `TestSafeToCreateUnder` table.
- **Live acceptance (verify separately, not in this PR):** daemon-managed run
  creates no `<supportRoot>/focusd/` dir; steady-state `msg=tick` grep empty and
  `daemon.log` mtime not within the last minute; heartbeat mtime advances ~4x
  (not ~30x) over 60s; a manual mesh removal still logs "mesh recreated"; a
  killed mesh recovers within ~60s; `rm` of the binary is re-materialized in-mesh
  within one tick.

### Build/test
`go build ./... && go vet ./... && go test ./...` green for both `daemon` and
`platform` (incl. `-race`); `gofmt -s` clean. Two pre-existing failures on the
sandbox host are unrelated and reproduce on `459ad1f`:
`platform/.../runner.TestPrepareDropPathsMakesBinaryUserReachable` (can't
`chmod` the macOS temp-dir root — env limitation) and a timing flake in
`platformsvc.TestStartCapturesEngineLogToFile` (passes in isolation); neither
package is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
