### PR TITLE
feat(daemon): status reports generation cleanliness (orphaned prior-gen count)

### DIFF
--- a/daemon/internal/osadapter/count_generations_test.go
+++ b/daemon/internal/osadapter/count_generations_test.go
@@ -54,6 +54,11 @@ func TestCountOtherGenerations_Pure(t *testing.T) {
 			name: "no generations at all → 0",
 			want: 0,
 		},
+		{
+			name: "dead entry equal to keep is guarded out → 0 (defensive, mirrors retire)",
+			dead: []DeadGeneration{{BinaryPath: keep}},
+			want: 0,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/daemon/internal/osadapter/count_generations_test.go
+++ b/daemon/internal/osadapter/count_generations_test.go
@@ -1,0 +1,108 @@
+//go:build darwin
+
+package osadapter
+
+import (
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/mode"
+)
+
+// TestCountOtherGenerations_Pure drives the read-only count core over its full
+// matrix with plain slices (no launchd / FS scan), mirroring how the retire
+// tests exercise retireGenerations. An "other" generation is a live generation
+// whose binary differs from the keep, PLUS every dead generation.
+func TestCountOtherGenerations_Pure(t *testing.T) {
+	keep := "/Library/Application Support/.keep/keep.bin"
+	other := "/Library/Application Support/.old/old.bin"
+	cases := []struct {
+		name string
+		live []Generation
+		dead []DeadGeneration
+		keep string
+		want int
+	}{
+		{
+			name: "keep only → 0 (clean)",
+			live: []Generation{{BinaryPath: keep}},
+			want: 0,
+		},
+		{
+			name: "keep + one live other → 1",
+			live: []Generation{{BinaryPath: keep}, {BinaryPath: other}},
+			want: 1,
+		},
+		{
+			name: "keep + one dead → 1",
+			live: []Generation{{BinaryPath: keep}},
+			dead: []DeadGeneration{{BinaryPath: other}},
+			want: 1,
+		},
+		{
+			name: "keep + one live other + two dead → 3",
+			live: []Generation{{BinaryPath: keep}, {BinaryPath: other}},
+			dead: []DeadGeneration{{BinaryPath: "/x/a.bin"}, {BinaryPath: "/x/b.bin"}},
+			want: 3,
+		},
+		{
+			name: "non-canonical keep still matches the keep generation → 0",
+			live: []Generation{{BinaryPath: keep}},
+			keep: keep + "/", // trailing slash; Clean must normalise before compare
+			want: 0,
+		},
+		{
+			name: "no generations at all → 0",
+			want: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			k := c.keep
+			if k == "" {
+				k = keep
+			}
+			if got := countOtherGenerations(c.live, c.dead, k); got != c.want {
+				t.Fatalf("countOtherGenerations = %d; want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCountOtherGenerations_ViaDiscovery exercises the full read-only path over
+// a temp support-root fixture with two live generations (one is the keep, one an
+// orphan) plus a dead/zombie generation: DiscoverAllGenerations (real scan, fake
+// verifier) → countOtherGenerations must report exactly the two non-keep
+// generations, and never retire anything (the fixture is untouched afterward).
+func TestCountOtherGenerations_ViaDiscovery(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+
+	keepRoster := []string{"com.apple.metadata.helper.1", "com.google.keystone.daemon.2", "org.mozilla.updater.agent.3"}
+	otherRoster := []string{"com.docker.helper.4", "us.zoom.ZoomDaemon.svc.5", "io.tailscale.ipnextension.relay.6"}
+	deadRoster := []string{"com.slack.helper.7", "com.spotify.client.8", "com.dropbox.agent.9"}
+
+	keepBin, _ := writeGeneration(t, home, laDir, "keep", keepRoster)
+	writeGeneration(t, home, laDir, "other", otherRoster) // a live ORPHAN generation
+	writeDeadGeneration(t, home, laDir, "dead", deadRoster, AllRoles...)
+
+	live, dead, err := DiscoverAllGenerations(mode.User, Verifier(readFileVerifier))
+	if err != nil {
+		t.Fatalf("DiscoverAllGenerations: %v", err)
+	}
+	// Sanity: the fixture yields 2 live (keep + other) and 1 dead generation.
+	if len(live) != 2 || len(dead) != 1 {
+		t.Fatalf("fixture: live=%d dead=%d; want 2 live, 1 dead", len(live), len(dead))
+	}
+
+	if got := countOtherGenerations(live, dead, keepBin); got != 2 {
+		t.Fatalf("countOtherGenerations(keep) = %d; want 2 (1 live orphan + 1 dead)", got)
+	}
+}
+
+// TestCountOtherGenerations_EmptyKeepErrors pins the guard: an empty keep would
+// make every generation "other", so it must ERROR (status folds to unknown)
+// rather than answer a meaningless count.
+func TestCountOtherGenerations_EmptyKeepErrors(t *testing.T) {
+	if _, err := CountOtherGenerations(mode.User, ""); err == nil {
+		t.Fatal("empty keepBinaryPath must return an error")
+	}
+}

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -546,9 +546,13 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath, supportRoot string) (in
 // "unknown" rather than falsely counting the live generation as an orphan).
 //
 // Returns a COUNT ONLY — never the disguised labels/paths — so a caller like
-// `daemon status` physically cannot leak a teardown string. A filesystem
-// failure at the scan is surfaced as err so status buckets it to "unknown"
-// rather than ever fabricating a "clean" 0.
+// `daemon status` physically cannot leak a teardown string. NOTE: the returned
+// err can carry a *PathError from the underlying scan (its .Error() embeds a
+// filesystem path), so callers must never log/render it verbatim — the sole
+// caller (gather_darwin) discards it into a boolean "unknown" flag.
+//
+// A filesystem failure at the scan is surfaced as err so status buckets it to
+// "unknown" rather than ever fabricating a "clean" 0.
 func CountOtherGenerations(m mode.Mode, keepBinaryPath string) (others int, err error) {
 	if keepBinaryPath == "" {
 		return 0, fmt.Errorf("count generations: keepBinaryPath must not be empty")
@@ -567,7 +571,10 @@ func CountOtherGenerations(m mode.Mode, keepBinaryPath string) (others int, err 
 // binary path differs from keepBinaryPath, PLUS every dead generation (its
 // deleted binary can never equal the surviving keep). Paths are Clean'd before
 // comparison so a trailing-slash / non-canonical keep never mis-counts the keep
-// itself as an orphan.
+// itself as an orphan. A dead generation carries the SAME defensive keep-equality
+// guard as retireGenerations' dead loop — by construction a dead (deleted) binary
+// can never equal the present, verified keep, but the twin read/write paths stay
+// consistent so a future divergence can't silently over-count.
 func countOtherGenerations(live []Generation, dead []DeadGeneration, keepBinaryPath string) int {
 	keep := filepath.Clean(keepBinaryPath)
 	others := 0
@@ -576,7 +583,12 @@ func countOtherGenerations(live []Generation, dead []DeadGeneration, keepBinaryP
 			others++
 		}
 	}
-	return others + len(dead)
+	for _, d := range dead {
+		if filepath.Clean(d.BinaryPath) != keep {
+			others++
+		}
+	}
+	return others
 }
 
 // SweepOrphanWorkdirs deletes daemon-home workdirs that survive on disk with NO

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -527,6 +527,58 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath, supportRoot string) (in
 		c.bootout, os.Remove, pkillBinary, killGenerationPlatform(supportRoot), os.RemoveAll), nil
 }
 
+// CountOtherGenerations is the READ-ONLY counterpart of RetireOtherGenerations
+// (FEATURE 17 generation cleanliness / `daemon status`): it reuses the SAME
+// DiscoverAllGenerations scan but retires NOTHING, returning only how many
+// OTHER focusd generations exist besides the one rooted at keepBinaryPath. It is
+// the sanctioned way for status to answer the owner's "new version starts clean,
+// no dup / no old version" acceptance signal without enumerating processes.
+//
+// An "other" generation is either a LIVE generation whose Ed25519-verified
+// binary path differs from keepBinaryPath, or ANY dead/zombie generation (a
+// workdir-delete/recovery leftover whose plists + orphan processes persist). A
+// clean install returns 0 — the only generation present IS the keep.
+//
+// keepBinaryPath is the current good install's binary path (FindCurrentInstall's
+// FEATURE 14 correlation key); it MUST be non-empty — with no keep to compare
+// against, every discovered generation would count as "other", so an empty
+// keepBinaryPath is a caller bug and returns an error (status buckets it to
+// "unknown" rather than falsely counting the live generation as an orphan).
+//
+// Returns a COUNT ONLY — never the disguised labels/paths — so a caller like
+// `daemon status` physically cannot leak a teardown string. A filesystem
+// failure at the scan is surfaced as err so status buckets it to "unknown"
+// rather than ever fabricating a "clean" 0.
+func CountOtherGenerations(m mode.Mode, keepBinaryPath string) (others int, err error) {
+	if keepBinaryPath == "" {
+		return 0, fmt.Errorf("count generations: keepBinaryPath must not be empty")
+	}
+	live, dead, derr := DiscoverAllGenerations(m, sig.VerifyFile)
+	if derr != nil {
+		return 0, derr
+	}
+	return countOtherGenerations(live, dead, keepBinaryPath), nil
+}
+
+// countOtherGenerations is the pure core of CountOtherGenerations, split out so
+// the count logic is unit-tested with plain slices (no real launchd / FS scan),
+// mirroring how retireGenerations is the seam-injected core of
+// RetireOtherGenerations. An "other" generation is a live generation whose
+// binary path differs from keepBinaryPath, PLUS every dead generation (its
+// deleted binary can never equal the surviving keep). Paths are Clean'd before
+// comparison so a trailing-slash / non-canonical keep never mis-counts the keep
+// itself as an orphan.
+func countOtherGenerations(live []Generation, dead []DeadGeneration, keepBinaryPath string) int {
+	keep := filepath.Clean(keepBinaryPath)
+	others := 0
+	for _, g := range live {
+		if filepath.Clean(g.BinaryPath) != keep {
+			others++
+		}
+	}
+	return others + len(dead)
+}
+
 // SweepOrphanWorkdirs deletes daemon-home workdirs that survive on disk with NO
 // loaded plist or running process backing them — the residual a teardown /
 // recovery / re-install cycle leaves behind (FEATURE 17 follow-up, TC-21).

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -60,6 +60,11 @@ func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, []DeadGeneration
 // to do" rather than surfacing ErrUnsupported on every install.
 func RetireOtherGenerations(mode.Mode, string, string) (int, error) { return 0, nil }
 
+// CountOtherGenerations is unsupported on non-darwin (no launchd mesh to scan).
+// It returns ErrUnsupported so `daemon status` buckets generation cleanliness to
+// "unknown" (never a fabricated "clean" 0) off-platform.
+func CountOtherGenerations(mode.Mode, string) (int, error) { return 0, ErrUnsupported }
+
 // SweepOrphanWorkdirs is a no-op on non-darwin (no launchd mesh / generation
 // workdirs to sweep). Returns (0, nil) so the cross-platform install path treats
 // it as "nothing to do" rather than surfacing ErrUnsupported on every install.

--- a/daemon/internal/status/assess.go
+++ b/daemon/internal/status/assess.go
@@ -15,6 +15,8 @@
 // So nothing the assessor or renderer touches can leak a teardown string.
 package status
 
+import "fmt"
+
 // Verdict is the daemon-status health classification. Reused names mirror
 // the platform's verdict vocabulary so the combined output reads coherently.
 type Verdict string
@@ -43,6 +45,18 @@ type Snapshot struct {
 	// ProcCount is how many live processes match the good platform binary
 	// (exact path match). Expected 1 in steady state; 0 ⇒ down; >1 ⇒ anomaly.
 	ProcCount int
+
+	// OtherGenerations is how many ORPHANED prior-generation focusd installs
+	// exist besides the current good one (the reaper's read-only enumeration —
+	// osadapter.CountOtherGenerations). 0 ⇒ clean ("new version started clean,
+	// no dup / no old version"); >0 ⇒ a prior generation that should have been
+	// retired is still present (a real anomaly). It counts LIVE other-binary
+	// generations AND dead/zombie generations. GenerationsUnknown means the scan
+	// could not run (no current install identified, off-platform, or an IO
+	// failure) — distinct from a genuine "clean 0"; an unknown read must never
+	// be reported as clean OR as degraded (mirrors VersionsUnknown/MeshUnknown).
+	OtherGenerations   int
+	GenerationsUnknown bool
 
 	// Desired / Good are the platform version the daemon wants vs the last
 	// version it promoted to good. VersionsUnknown means the workdir couldn't
@@ -144,9 +158,21 @@ func Assess(s Snapshot) Result {
 		return Result{Degraded, "more than one platform process running (anomaly)"}
 	}
 
-	// Could not read mesh and/or versions, but nothing read as broken →
-	// honest unknown (e.g. system install without sudo). Folds to exit 0.
-	if s.MeshUnknown || s.VersionsUnknown {
+	// Generation cleanliness — an orphaned prior generation is still present
+	// (should have been retired). Ranked alongside the ProcCount>1 anomaly: a
+	// live leftover generation is a real anomaly (DEGRADED), but it never
+	// overrides a hard DOWN above. Gated on the count being KNOWN: an unknown
+	// generation read must never upgrade to Degraded (folds to Unknown below).
+	if s.OtherGenerations > 0 && !s.GenerationsUnknown {
+		return Result{Degraded, fmt.Sprintf(
+			"%d orphaned prior-generation install(s) present (should have been retired)",
+			s.OtherGenerations)}
+	}
+
+	// Could not read mesh, versions, and/or the generation scan, but nothing
+	// read as broken → honest unknown (e.g. system install without sudo). Folds
+	// to exit 0.
+	if s.MeshUnknown || s.VersionsUnknown || s.GenerationsUnknown {
 		return Result{Unknown, "some facts unknown (re-run with sudo for full read)"}
 	}
 

--- a/daemon/internal/status/assess_test.go
+++ b/daemon/internal/status/assess_test.go
@@ -1,6 +1,9 @@
 package status
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAssess_Verdicts(t *testing.T) {
 	cases := []struct {
@@ -82,6 +85,96 @@ func TestAssess_Verdicts(t *testing.T) {
 				t.Fatalf("Assess(%+v) verdict = %s; want %s", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+// TestAssess_GenerationCleanliness pins the generation-cleanliness verdict: a
+// clean install (0 orphaned prior generations) keeps its current verdict; a
+// KNOWN orphan (>0) reads DEGRADED (the "new version should start clean, no old
+// version" anomaly); an UNKNOWN generation read folds to UNKNOWN, never up to
+// DEGRADED; and a live orphan never overrides a hard DOWN or a warming-up state.
+func TestAssess_GenerationCleanliness(t *testing.T) {
+	healthy := Snapshot{Found: true, MeshLoaded: 3, MeshTotal: 3, ProcCount: 1, Desired: "v1", Good: "v1"}
+	cases := []struct {
+		name string
+		in   Snapshot
+		want Verdict
+	}{
+		{
+			name: "zero orphans (known) leaves the healthy verdict unchanged",
+			in:   healthy, // OtherGenerations=0, GenerationsUnknown=false
+			want: Healthy,
+		},
+		{
+			name: "one orphaned prior generation is DEGRADED",
+			in:   withGen(healthy, 1, false),
+			want: Degraded,
+		},
+		{
+			name: "several orphaned prior generations is DEGRADED",
+			in:   withGen(healthy, 3, false),
+			want: Degraded,
+		},
+		{
+			name: "generation count UNKNOWN folds to UNKNOWN, not DEGRADED",
+			in:   withGen(healthy, 0, true),
+			want: Unknown,
+		},
+		{
+			name: "unknown must never upgrade a positive-looking count to DEGRADED",
+			in:   withGen(healthy, 3, true), // contradictory count while unknown → ignored
+			want: Unknown,
+		},
+		{
+			name: "an orphan never overrides a hard DOWN (process gone)",
+			in: withGen(Snapshot{Found: true, MeshLoaded: 3, MeshTotal: 3,
+				Good: "v1", Desired: "v1", ProcCount: 0}, 2, false),
+			want: Down,
+		},
+		{
+			name: "an orphan never overrides a genuine mesh-down",
+			in: withGen(Snapshot{Found: true, MeshLoaded: 0, MeshTotal: 3,
+				Good: "v1", Desired: "v1", ProcCount: 1}, 2, false),
+			want: Down,
+		},
+		{
+			name: "an orphan never overrides warming-up (stays HEALTHY)",
+			in: withGen(Snapshot{Found: true, MeshLoaded: 3, MeshTotal: 3,
+				WarmingUp: true, Good: "", ProcCount: 0}, 2, false),
+			want: Healthy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Assess(c.in).Verdict; got != c.want {
+				t.Fatalf("Assess(%+v) verdict = %s; want %s", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// withGen returns a copy of s with the generation-cleanliness fields set —
+// keeping the immutable-copy convention (never mutate the shared base).
+func withGen(s Snapshot, others int, unknown bool) Snapshot {
+	s.OtherGenerations = others
+	s.GenerationsUnknown = unknown
+	return s
+}
+
+// TestAssess_GenerationDegradedMessage pins the human-facing note for a live
+// orphaned generation — it names the count and the "should have been retired"
+// intent without any disguised path.
+func TestAssess_GenerationDegradedMessage(t *testing.T) {
+	in := withGen(Snapshot{Found: true, MeshLoaded: 3, MeshTotal: 3,
+		ProcCount: 1, Desired: "v1", Good: "v1"}, 2, false)
+	res := Assess(in)
+	if res.Verdict != Degraded {
+		t.Fatalf("verdict = %s; want Degraded", res.Verdict)
+	}
+	for _, want := range []string{"2", "orphaned prior-generation", "retired"} {
+		if !strings.Contains(res.Note, want) {
+			t.Errorf("note %q missing %q", res.Note, want)
+		}
 	}
 }
 

--- a/daemon/internal/status/gather_darwin.go
+++ b/daemon/internal/status/gather_darwin.go
@@ -85,6 +85,10 @@ const platformStatusTimeout = 8 * time.Second
 func Gather(workdirOverride string, jsonMode bool) (Snapshot, PlatformDetail) {
 	m := mode.Resolve()
 	s := Snapshot{Mode: string(m)}
+	// Generation cleanliness defaults to UNKNOWN until we successfully scan +
+	// count (below). An unreadable / not-yet-computed state must never fabricate
+	// a "clean" 0 — mirror the VersionsUnknown/MeshUnknown honesty pattern.
+	s.GenerationsUnknown = true
 
 	// --- Mesh roles (counts only cross the osadapter boundary) ---
 	loaded, total, found, err := osadapter.MeshStatus(m)
@@ -130,6 +134,21 @@ func Gather(workdirOverride string, jsonMode bool) (Snapshot, PlatformDetail) {
 		} else if cur.Workdir != "" {
 			workdirTok = redact.New(cur.Workdir)
 			s.Found = s.Found || cur.BinaryPath != ""
+		}
+
+		// --- Generation cleanliness (counts only, reuses the reaper's scan) ---
+		// Reuse osadapter.CountOtherGenerations (the READ-ONLY twin of the
+		// reaper's RetireOtherGenerations enumeration) to affirmatively report
+		// whether any ORPHANED prior-generation install lingers besides the
+		// current good one. Only answerable once the current install's binary
+		// (the keep) is identified; on any read failure (or no keep) we leave
+		// GenerationsUnknown=true rather than fabricate a "clean" 0. Only a COUNT
+		// crosses the boundary — no disguised path enters the Snapshot.
+		if cur.BinaryPath != "" {
+			if others, cerr := osadapter.CountOtherGenerations(m, cur.BinaryPath); cerr == nil {
+				s.OtherGenerations = others
+				s.GenerationsUnknown = false
+			}
 		}
 	}
 

--- a/daemon/internal/status/gather_other.go
+++ b/daemon/internal/status/gather_other.go
@@ -14,6 +14,7 @@ func Gather(workdirOverride string, jsonMode bool) (Snapshot, PlatformDetail) {
 		Mode:                runtime.GOOS,
 		MeshUnknown:         true,
 		VersionsUnknown:     true,
+		GenerationsUnknown:  true,
 		PlatformUnavailable: true,
 	}, PlatformDetail{Available: false}
 }

--- a/daemon/internal/status/render.go
+++ b/daemon/internal/status/render.go
@@ -107,6 +107,14 @@ func RenderText(s Snapshot, res Result, pd PlatformDetail, out io.Writer, color 
 	fmt.Fprintf(out, "  %-22s %s\n", "platform process", procLine(s))
 	fmt.Fprintf(out, "  %-22s %s\n", "platform version", versionLine(s))
 
+	// Generation cleanliness — an affirmative "no orphaned old version" signal.
+	// Shown only when an install exists (the "not installed" engine line already
+	// covers the empty case); clean / degraded / unknown per generationsLine.
+	// Counts only — no disguised path is ever printed.
+	if s.Found {
+		fmt.Fprintf(out, "  %-22s %s\n", "generations", generationsLine(s))
+	}
+
 	// Out-of-band watchdog rail liveness (FEATURE 12 / ADR-0016). PRESENT-ONLY:
 	// the watchdog is a best-effort, flaky secondary rail — it must never read
 	// as a problem on the CURRENT-state status. We print the line ONLY when the
@@ -161,6 +169,22 @@ func procLine(s Snapshot) string {
 	}
 }
 
+// generationsLine describes generation cleanliness: "1 (clean)" when the current
+// good generation is the only one present, a ⚠ warning naming how many orphaned
+// prior generations linger when the reaper's read-only count is >0, and an honest
+// "unknown" when the scan could not run. Counts only — never a disguised path.
+func generationsLine(s Snapshot) string {
+	if s.GenerationsUnknown {
+		return "unknown (re-run with sudo)"
+	}
+	if s.OtherGenerations == 0 {
+		return "1 (clean)"
+	}
+	// total present = the keep + the orphaned others.
+	return fmt.Sprintf("⚠ %d — %d orphaned prior generation(s)",
+		s.OtherGenerations+1, s.OtherGenerations)
+}
+
 // watchdogPresent reports whether the out-of-band watchdog rail is fully up
 // (checked, cron line present, AND its binary copy on disk). It is the single
 // gate for whether the watchdog line renders at all (present-only): absent /
@@ -189,21 +213,23 @@ func versionLine(s Snapshot) string {
 // daemonJSON is the daemon-owned half of the combined JSON. All primitives,
 // no disguised identifier — safe to marshal directly.
 type daemonJSON struct {
-	Mode            string `json:"mode"`
-	MeshLoaded      int    `json:"mesh_loaded"`
-	MeshTotal       int    `json:"mesh_total"`
-	MeshUnknown     bool   `json:"mesh_unknown"`
-	ProcCount       int    `json:"proc_count"`
-	Desired         string `json:"desired"`
-	Good            string `json:"good"`
-	VersionsUnknown bool   `json:"versions_unknown"`
-	WarmingUp       bool   `json:"warming_up"`
-	Found           bool   `json:"found"`
-	WatchdogChecked bool   `json:"watchdog_checked"`
-	WatchdogCron    bool   `json:"watchdog_rail"` // rail presence; mechanism name deliberately not exposed
-	WatchdogCopyOK  bool   `json:"watchdog_copy_ok"`
-	Verdict         string `json:"verdict"`
-	Note            string `json:"note"`
+	Mode               string `json:"mode"`
+	MeshLoaded         int    `json:"mesh_loaded"`
+	MeshTotal          int    `json:"mesh_total"`
+	MeshUnknown        bool   `json:"mesh_unknown"`
+	ProcCount          int    `json:"proc_count"`
+	OtherGenerations   int    `json:"other_generations"`
+	GenerationsUnknown bool   `json:"generations_unknown"`
+	Desired            string `json:"desired"`
+	Good               string `json:"good"`
+	VersionsUnknown    bool   `json:"versions_unknown"`
+	WarmingUp          bool   `json:"warming_up"`
+	Found              bool   `json:"found"`
+	WatchdogChecked    bool   `json:"watchdog_checked"`
+	WatchdogCron       bool   `json:"watchdog_rail"` // rail presence; mechanism name deliberately not exposed
+	WatchdogCopyOK     bool   `json:"watchdog_copy_ok"`
+	Verdict            string `json:"verdict"`
+	Note               string `json:"note"`
 }
 
 // combinedJSON is the structural composition of the daemon snapshot and the
@@ -221,21 +247,23 @@ type combinedJSON struct {
 func RenderJSON(s Snapshot, res Result, pd PlatformDetail, out io.Writer) {
 	c := combinedJSON{
 		Daemon: daemonJSON{
-			Mode:            s.Mode,
-			MeshLoaded:      s.MeshLoaded,
-			MeshTotal:       s.MeshTotal,
-			MeshUnknown:     s.MeshUnknown,
-			ProcCount:       s.ProcCount,
-			Desired:         s.Desired,
-			Good:            s.Good,
-			VersionsUnknown: s.VersionsUnknown,
-			WarmingUp:       s.WarmingUp,
-			Found:           s.Found,
-			WatchdogChecked: s.WatchdogChecked,
-			WatchdogCron:    s.WatchdogCron,
-			WatchdogCopyOK:  s.WatchdogCopyOK,
-			Verdict:         string(res.Verdict),
-			Note:            res.Note,
+			Mode:               s.Mode,
+			MeshLoaded:         s.MeshLoaded,
+			MeshTotal:          s.MeshTotal,
+			MeshUnknown:        s.MeshUnknown,
+			ProcCount:          s.ProcCount,
+			OtherGenerations:   s.OtherGenerations,
+			GenerationsUnknown: s.GenerationsUnknown,
+			Desired:            s.Desired,
+			Good:               s.Good,
+			VersionsUnknown:    s.VersionsUnknown,
+			WarmingUp:          s.WarmingUp,
+			Found:              s.Found,
+			WatchdogChecked:    s.WatchdogChecked,
+			WatchdogCron:       s.WatchdogCron,
+			WatchdogCopyOK:     s.WatchdogCopyOK,
+			Verdict:            string(res.Verdict),
+			Note:               res.Note,
 		},
 		Overall: string(res.Verdict),
 	}

--- a/daemon/internal/status/render_test.go
+++ b/daemon/internal/status/render_test.go
@@ -281,6 +281,96 @@ func TestRender_WatchdogPresentOnly(t *testing.T) {
 	}
 }
 
+// TestRender_GenerationsLine verifies the generation-cleanliness line: a clean
+// install reads "1 (clean)", a lingering orphan reads a ⚠ warning naming the
+// count, an unreadable scan reads honest "unknown", and a not-installed box
+// omits the line entirely (the "not installed" engine line already covers it).
+// Every rendered form stays free of disguised identifiers.
+func TestRender_GenerationsLine(t *testing.T) {
+	base := realisticSnapshot() // Found=true
+	cases := []struct {
+		name      string
+		mutate    func(Snapshot) Snapshot
+		wantLine  bool
+		wantValue string
+	}{
+		{
+			name:      "clean → generations 1 (clean)",
+			mutate:    func(s Snapshot) Snapshot { s.OtherGenerations = 0; s.GenerationsUnknown = false; return s },
+			wantLine:  true,
+			wantValue: "1 (clean)",
+		},
+		{
+			name:      "one orphan → warning names the count",
+			mutate:    func(s Snapshot) Snapshot { s.OtherGenerations = 1; s.GenerationsUnknown = false; return s },
+			wantLine:  true,
+			wantValue: "1 orphaned prior generation(s)",
+		},
+		{
+			name:      "two orphans → total and orphan count",
+			mutate:    func(s Snapshot) Snapshot { s.OtherGenerations = 2; s.GenerationsUnknown = false; return s },
+			wantLine:  true,
+			wantValue: "⚠ 3 — 2 orphaned prior generation(s)",
+		},
+		{
+			name:      "unknown scan → honest unknown",
+			mutate:    func(s Snapshot) Snapshot { s.GenerationsUnknown = true; return s },
+			wantLine:  true,
+			wantValue: "unknown (re-run with sudo)",
+		},
+		{
+			name:      "not installed → generations line omitted",
+			mutate:    func(s Snapshot) Snapshot { s.Found = false; s.GenerationsUnknown = true; return s },
+			wantLine:  false,
+			wantValue: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := c.mutate(base)
+			var txt bytes.Buffer
+			RenderText(s, Assess(s), PlatformDetail{Available: false}, &txt, false)
+			out := txt.String()
+			hasLine := strings.Contains(out, "generations")
+			if hasLine != c.wantLine {
+				t.Fatalf("generations line present=%v want %v:\n%s", hasLine, c.wantLine, out)
+			}
+			if c.wantValue != "" && !strings.Contains(out, c.wantValue) {
+				t.Errorf("generations line missing %q:\n%s", c.wantValue, out)
+			}
+			assertNoLeak(t, "generations text", out)
+		})
+	}
+}
+
+// TestRenderJSON_GenerationsFields verifies the machine report carries the raw
+// generation-cleanliness signal (count + unknown flag) for consumers.
+func TestRenderJSON_GenerationsFields(t *testing.T) {
+	s := realisticSnapshot()
+	s.OtherGenerations = 2
+	s.GenerationsUnknown = false
+
+	var buf bytes.Buffer
+	RenderJSON(s, Assess(s), PlatformDetail{Available: false}, &buf)
+
+	var top struct {
+		Daemon struct {
+			OtherGenerations   int  `json:"other_generations"`
+			GenerationsUnknown bool `json:"generations_unknown"`
+		} `json:"daemon"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &top); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if top.Daemon.OtherGenerations != 2 {
+		t.Errorf("other_generations = %d; want 2", top.Daemon.OtherGenerations)
+	}
+	if top.Daemon.GenerationsUnknown {
+		t.Errorf("generations_unknown = true; want false")
+	}
+	assertNoLeak(t, "generations json", buf.String())
+}
+
 // TestCombine_DisabledAndRecoveredPluginNotDegraded verifies the cross-layer
 // agreement: when the platform reports a healthy roll-up (a recovered-tamper
 // plugin reads "ok" → Healthy, and an intentionally-disabled plugin is
@@ -321,7 +411,7 @@ func TestCombine_DisabledAndRecoveredPluginNotDegraded(t *testing.T) {
 // honest "unknown (re-run with sudo)" lines and exits via Unknown→0, not a
 // hard failure or a DOWN.
 func TestRender_UnknownLinesHonest(t *testing.T) {
-	s := Snapshot{Mode: "system", Found: true, MeshUnknown: true, VersionsUnknown: true}
+	s := Snapshot{Mode: "system", Found: true, MeshUnknown: true, VersionsUnknown: true, GenerationsUnknown: true}
 	res := Assess(s)
 	if res.Verdict != Unknown {
 		t.Fatalf("verdict = %s; want Unknown", res.Verdict)


### PR DESCRIPTION
## The gap (confirmed)

`daemon status` could not detect a leftover **OLD-generation** focusd install.
`gather_darwin.go` computes `ProcCount` via `pgrep -f -x <current-good-binary-path>`,
so it only counts processes matching the **current good** binary's exact path. An
orphaned prior-generation platform/daemon runs from a **previous rotated path**, so
it is invisible to `ProcCount` — status had no way to report a leftover old version.
Meanwhile the reaper already knows how to enumerate those generations.

This is the owner's key "**new version starts clean, no dup / no old version**"
acceptance criterion — now verifiable via the sanctioned `status` surface instead
of `ps`.

## Approach — reuse the reaper, read-only

The reaper's `RetireOtherGenerations` calls `DiscoverAllGenerations` to enumerate
other/dead generations **before** retiring them. This adds a **read-only twin**:

- **`osadapter.CountOtherGenerations(m, keepBinaryPath)`** — reuses the same
  `DiscoverAllGenerations` scan and returns only a **count** of OTHER generations
  (live other-binary generations + dead/zombie generations) besides the current
  good one. Retires nothing. An empty keep errors (would make every generation
  "other").
- Pure **`countOtherGenerations(live, dead, keep)`** seam extracted for unit
  testing — mirrors the existing `RetireOtherGenerations` / `retireGenerations`
  split. `filepath.Clean` on both sides so a non-canonical keep never mis-counts.
- **Counts only** cross the boundary — no disguised path/label/binary-name ever
  enters a `Snapshot` field or rendered output (ADR-0011).

## Verdict + render

- New `Snapshot.OtherGenerations int` + `GenerationsUnknown bool`, populated in
  `gather_darwin` from the reused scan. **Default UNKNOWN**; flips to a known
  count **only on a successful read** — an unreadable state never fabricates a
  "clean" 0 (mirrors the `VersionsUnknown` / `MeshUnknown` honesty pattern). A
  `!darwin` stub returns unknown.
- `Assess`: ranked near the `ProcCount>1` anomaly. `>0 && known` → **DEGRADED**
  ("N orphaned prior-generation install(s) present (should have been retired)").
  **UNKNOWN folds to UNKNOWN** (never upgrades to DEGRADED). It never overrides a
  hard **DOWN** or a **warming-up** state.
- Text: `generations: 1 (clean)` / `⚠ generations: N — <N-1> orphaned prior
  generation(s)` / `generations: unknown (re-run with sudo)` (omitted when not
  installed). JSON: adds `other_generations` + `generations_unknown`.

## Tests

- `assess_test.go`: table cases — 0 = verdict unchanged; ≥1 known = Degraded +
  message; unknown = Unknown-not-Degraded; unknown never upgrades a positive
  count; never overrides DOWN / mesh-down / warming.
- `render_test.go`: text line for clean / orphan / unknown states + not-found
  omission + no-leak; JSON carries the raw count/flag.
- `count_generations_test.go` (osadapter): pure count matrix, a
  2-generation + 1-dead **discovery fixture** feeding the count, and the
  empty-keep guard.

## Verification

```
cd daemon && go build ./... && go vet ./internal/status/... ./internal/osadapter/...
go test ./internal/status/... ./internal/osadapter/...   # green
gofmt -s -l internal/status internal/osadapter            # clean
```

Full `daemon` module test suite passes. Does **not** touch the reaper's retire
path, the mesh, or any enforcement — read-only observability only. Ships in
v0.19.4 bundled with other pending work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)