### PR TITLE
fix(recovery): companion survives system launchd, in-mesh self-restore stays 3/3, status stops masking a dead rail (#101, #102)

### DIFF
--- a/daemon/cmd/companion/main.go
+++ b/daemon/cmd/companion/main.go
@@ -19,23 +19,28 @@ import (
 	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/companion"
-	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/sig"
 )
 
 func main() { os.Exit(run()) }
 
 func run() int {
-	m := mode.Resolve()
-	home, err := os.UserHomeDir()
+	// Issue #101: SELF-DERIVE the companion folder from our OWN binary path — NOT
+	// from $HOME or mode. All companion files are siblings of this binary under
+	// Dir.root, and Dir.root == filepath.Dir(os.Executable()) in both user and
+	// system installs (the daemon placed this binary under the mode-correct root).
+	// A system LaunchDaemon runs with NO $HOME, so the old os.UserHomeDir() call
+	// errored EVERY interval and returned BEFORE reaching recover() — leaving the
+	// sole out-of-band recovery rail permanently dead. We now refuse ONLY if we
+	// cannot resolve our own executable (which would make every sibling path
+	// wrong); mode/home no longer enter the picture.
+	exe, err := os.Executable()
 	if err != nil {
-		// No resolvable home → the companion folder path would be relative;
-		// refuse rather than touch the wrong place. launchd re-runs us next
-		// interval. PATH-FREE: print nothing identifying.
-		os.Stderr.WriteString("companion: cannot resolve home directory\n")
+		// PATH-FREE: never print identifying paths; launchd re-runs us next interval.
+		os.Stderr.WriteString("companion: cannot resolve own executable path\n")
 		return 1
 	}
-	dir := companion.For(m, home)
+	dir := companion.DirFromBinary(exe)
 	if rerr := recover(dir, time.Now(), sig.VerifyFile, execWatchdog); rerr != nil {
 		// PATH-FREE: never print the disguised companion/daemon paths a
 		// weak-moment self would need. Keep it abstract; launchd captures this

--- a/daemon/cmd/companion/recover.go
+++ b/daemon/cmd/companion/recover.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"time"
@@ -74,7 +76,7 @@ func recover(
 // rail honestly reads as not-firing. Only the mtime matters; content is empty.
 func touchRan(dir companion.Dir, now time.Time) {
 	p := dir.RanMarker()
-	if err := os.Chtimes(p, now, now); err != nil && os.IsNotExist(err) {
+	if err := os.Chtimes(p, now, now); err != nil && errors.Is(err, fs.ErrNotExist) {
 		// Create it, then stamp the intended mtime (a fresh create's mtime is the
 		// real wall clock; align it to now for deterministic staleness checks).
 		if f, cerr := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0o644); cerr == nil {

--- a/daemon/cmd/companion/recover.go
+++ b/daemon/cmd/companion/recover.go
@@ -37,6 +37,7 @@ func recover(
 	//    error) falls through to the restore path (treated as stale).
 	if fi, err := os.Stat(dir.Heartbeat()); err == nil {
 		if !companion.DecideStale(fi.ModTime(), now) {
+			touchRan(dir, now) // completed pass (no-op path): record the rail is firing
 			return nil
 		}
 	}
@@ -59,7 +60,28 @@ func recover(
 	if err := placeExecutable(dir.Backup(), dir.Promote()); err != nil {
 		return fmt.Errorf("companion: place backup failed")
 	}
-	return execDaemon(dir.Promote(), desired)
+	if err := execDaemon(dir.Promote(), desired); err != nil {
+		return err
+	}
+	touchRan(dir, now) // completed pass (restore path): record the rail is firing
+	return nil
+}
+
+// touchRan sets the RanMarker's mtime to now (best-effort), recording that this
+// recovery pass COMPLETED. status treats the rail as firing only when this marker
+// is recent — so a companion that dies before reaching a completion point (the
+// #101 no-$HOME class exited before recover ran at all) never touches it and the
+// rail honestly reads as not-firing. Only the mtime matters; content is empty.
+func touchRan(dir companion.Dir, now time.Time) {
+	p := dir.RanMarker()
+	if err := os.Chtimes(p, now, now); err != nil && os.IsNotExist(err) {
+		// Create it, then stamp the intended mtime (a fresh create's mtime is the
+		// real wall clock; align it to now for deterministic staleness checks).
+		if f, cerr := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0o644); cerr == nil {
+			_ = f.Close()
+			_ = os.Chtimes(p, now, now)
+		}
+	}
 }
 
 // readTrimmed reads a small file and trims surrounding whitespace.

--- a/daemon/cmd/companion/recover_test.go
+++ b/daemon/cmd/companion/recover_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -37,6 +38,74 @@ type recorder struct {
 }
 
 const goodDesired = "v0.16.3"
+
+// TestRecoverWorksWithoutHOME is the #101 regression guard: the companion's
+// recovery pass must run with the Dir derived from its OWN binary path and NO
+// $HOME set (a system LaunchDaemon has none). It proves recover never depends on
+// os.UserHomeDir()/mode — the DOA-on-system-launchd bug that killed the sole
+// out-of-band rail. It also asserts the RanMarker is stamped on a completed pass
+// (the firing signal status reads), on BOTH the no-op and the restore path.
+func TestRecoverWorksWithoutHOME(t *testing.T) {
+	// Unset HOME for the duration; restore after (os.Unsetenv is a raw global
+	// mutation, but these tests are non-parallel).
+	oldHome, had := os.LookupEnv("HOME")
+	os.Unsetenv("HOME")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("HOME", oldHome)
+		}
+	})
+
+	// Dir derived purely from a binary path (HOME-free), rooted at a temp dir.
+	root := t.TempDir()
+	dir := companion.DirFromBinary(filepath.Join(root, "companion-bin"))
+	if dir.Root() != root {
+		t.Fatalf("DirFromBinary root = %q, want %q", dir.Root(), root)
+	}
+
+	t.Run("fresh heartbeat no-op still stamps RanMarker", func(t *testing.T) {
+		writeFile(t, dir.Heartbeat(), "") // just touched (mtime = now) ⇒ fresh
+		rec := &recorder{}
+		err := recover(dir, time.Now(),
+			func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+			func(bin, desired string) error { rec.execCalls++; return nil },
+		)
+		if err != nil {
+			t.Fatalf("recover without HOME = %v, want nil", err)
+		}
+		if rec.execCalls != 0 {
+			t.Fatalf("fresh heartbeat must be a no-op, execCalls=%d", rec.execCalls)
+		}
+		if _, statErr := os.Stat(dir.RanMarker()); statErr != nil {
+			t.Fatalf("RanMarker not stamped on a completed no-op pass: %v", statErr)
+		}
+	})
+
+	t.Run("stale heartbeat restore stamps RanMarker", func(t *testing.T) {
+		os.Remove(dir.RanMarker()) // clear the marker from the previous sub-case
+		staleMtime := time.Now().Add(-companion.StaleThreshold - time.Minute)
+		writeFile(t, dir.Heartbeat(), "")
+		if err := os.Chtimes(dir.Heartbeat(), staleMtime, staleMtime); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, dir.Desired(), goodDesired)
+		writeFile(t, dir.Backup(), "SIGNED-DAEMON")
+		rec := &recorder{}
+		err := recover(dir, time.Now(),
+			func(p string) (bool, error) { rec.verified = append(rec.verified, p); return true, nil },
+			func(bin, desired string) error { rec.execCalls++; return nil },
+		)
+		if err != nil {
+			t.Fatalf("recover (stale, no HOME) = %v, want nil", err)
+		}
+		if rec.execCalls != 1 {
+			t.Fatalf("stale heartbeat must restore, execCalls=%d", rec.execCalls)
+		}
+		if _, statErr := os.Stat(dir.RanMarker()); statErr != nil {
+			t.Fatalf("RanMarker not stamped on a completed restore pass: %v", statErr)
+		}
+	})
+}
 
 // TestRecoverFreshHeartbeatNoOp: a fresh heartbeat means the daemon is alive —
 // recover must be a pure no-op: it never verifies the backup and never execs.

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -517,11 +517,22 @@ func loop(args []string, once bool) int {
 			// cheap stat at rest). On a real re-materialize it returns the fresh
 			// disguised path, which we adopt so the NEXT tick stats the new file
 			// (no heal loop) and EnsureAll/EnsureCompanion below use it.
-			if newSelf, changed, berr := osadapter.EnsureBinaryPresent(spec, osadapter.Role(o.role), e.HoldsPlatformLock(), selfFD); berr != nil {
-				log.Warn("ensure-binary-present", "err", berr)
-			} else if changed {
+			newSelf, changed, berr := osadapter.EnsureBinaryPresent(spec, osadapter.Role(o.role), e.HoldsPlatformLock(), selfFD)
+			// Adopt the fresh path whenever the binary was PLACED — INDEPENDENT of
+			// berr. binpresent's contract: changed=true with a non-nil err means the
+			// binary WAS placed but the launchd re-bootstrap partially failed; the
+			// caller adopts newSelfPath and the next tick retries the launchd side.
+			// Adopting BEFORE EnsureAll(spec) below is critical: otherwise EnsureAll
+			// would run with the STALE spec.SelfPath (the just-deleted binary) and
+			// rewrite a partially-reloaded role's plist back to the dead path,
+			// spawning it onto ENOENT while falsely logging "mesh recreated".
+			if changed {
 				self = newSelf
 				spec.SelfPath = newSelf
+			}
+			if berr != nil {
+				log.Warn("ensure-binary-present", "err", berr)
+			} else if changed {
 				log.Info("daemon binary re-materialized") // no path (redaction-safe)
 			}
 			if rec, eerr := osadapter.EnsureAll(spec); eerr != nil {

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -517,7 +517,7 @@ func loop(args []string, once bool) int {
 			// cheap stat at rest). On a real re-materialize it returns the fresh
 			// disguised path, which we adopt so the NEXT tick stats the new file
 			// (no heal loop) and EnsureAll/EnsureCompanion below use it.
-			if newSelf, changed, berr := osadapter.EnsureBinaryPresent(spec, e.HoldsPlatformLock(), selfFD); berr != nil {
+			if newSelf, changed, berr := osadapter.EnsureBinaryPresent(spec, osadapter.Role(o.role), e.HoldsPlatformLock(), selfFD); berr != nil {
 				log.Warn("ensure-binary-present", "err", berr)
 			} else if changed {
 				self = newSelf

--- a/daemon/internal/companion/companion.go
+++ b/daemon/internal/companion/companion.go
@@ -62,6 +62,22 @@ func For(m mode.Mode, home string) Dir {
 	return Dir{root: filepath.Join(mode.SupportRoot(m, home), dirName)}
 }
 
+// DirFromBinary returns the companion Dir derived purely from the companion
+// binary's OWN path — every companion file is a sibling of the binary under
+// Dir.root, and Dir.root == filepath.Dir(exe) in BOTH modes (For roots the
+// binary at <SupportRoot>/<dirName>/<binary>, so Dir(binary) == that folder).
+//
+// This is HOME-FREE and MODE-FREE by construction, which is the whole point:
+// a system LaunchDaemon runs with NO $HOME (and mode resolution is irrelevant),
+// so a companion that self-derives its folder from os.Executable() re-resolves
+// the exact folder the daemon installed it into — where For(System) ignores home
+// and For(User) uses the launchd-agent's home — without ever calling
+// os.UserHomeDir() or mode.Resolve() (issue #101: the companion used to error out
+// on os.UserHomeDir() before it could recover, killing the sole out-of-band rail).
+func DirFromBinary(exe string) Dir {
+	return Dir{root: filepath.Dir(exe)}
+}
+
 // Root is the companion folder path.
 func (d Dir) Root() string { return d.root }
 
@@ -107,6 +123,18 @@ func (d Dir) LabelFile() string {
 // Log is the companion's launchd stdout/stderr sink, inside its own folder.
 func (d Dir) Log() string {
 	return filepath.Join(d.root, ".com.apple.MobileAsset.log")
+}
+
+// RanMarker is touched by the companion on EVERY completed recovery pass (both
+// the fresh-heartbeat no-op path and the post-restore path). Its mtime is the
+// rail's OWN liveness signal — distinct from the daemon's Heartbeat, which the
+// DAEMON writes. status treats the rail as firing only when this marker is recent;
+// a companion that dies BEFORE completing a pass (e.g. the #101 no-$HOME crash)
+// never touches it, so a silently-dead rail honestly reads as not-firing instead
+// of being trusted on mere on-disk presence. Its CONTENT is irrelevant — only the
+// mtime matters.
+func (d Dir) RanMarker() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.ran")
 }
 
 // versionTagRE is a minimal semver-tag check (KISS), local to this package so

--- a/daemon/internal/companion/companion_test.go
+++ b/daemon/internal/companion/companion_test.go
@@ -48,6 +48,7 @@ func TestDirPathsUnderRootDistinct(t *testing.T) {
 		"promote":   d.Promote(),
 		"label":     d.LabelFile(),
 		"log":       d.Log(),
+		"ranmarker": d.RanMarker(),
 	}
 	seen := map[string]string{}
 	for name, p := range paths {
@@ -58,6 +59,25 @@ func TestDirPathsUnderRootDistinct(t *testing.T) {
 			t.Fatalf("%s and %s collide on path %q", name, other, p)
 		}
 		seen[p] = name
+	}
+}
+
+// TestDirFromBinaryMatchesFor is the #101 correctness invariant: deriving the
+// companion Dir from the companion BINARY's path (HOME-free, mode-free) resolves
+// the EXACT same folder For() installed it into — in BOTH user and system modes.
+// This is what lets a system LaunchDaemon (no $HOME) re-find its own folder.
+func TestDirFromBinaryMatchesFor(t *testing.T) {
+	for _, m := range []mode.Mode{mode.User, mode.System} {
+		want := For(m, "/home/u")
+		got := DirFromBinary(want.Binary())
+		if got.Root() != want.Root() {
+			t.Fatalf("mode %s: DirFromBinary(%q).Root() = %q, want %q",
+				m, want.Binary(), got.Root(), want.Root())
+		}
+		// Every derived sibling path must match too (the binary's parent IS the root).
+		if got.Backup() != want.Backup() || got.Heartbeat() != want.Heartbeat() || got.Desired() != want.Desired() {
+			t.Fatalf("mode %s: DirFromBinary sibling paths diverge from For", m)
+		}
 	}
 }
 

--- a/daemon/internal/osadapter/binpresent.go
+++ b/daemon/internal/osadapter/binpresent.go
@@ -32,6 +32,12 @@ type binPresentDeps struct {
 	// place writes bytes to a NEW path atomically (temp+rename, 0755). CREATE-ONLY:
 	// it never removes a directory.
 	place func(bytes []byte, dst string) error
+	// findAdoptable scans the IMMEDIATE files of workdir for an already-present,
+	// signature-VERIFIED daemon binary at a path other than excludePath (the known-
+	// missing SelfPath), returning its path or "" (issue #102-b belt). Only a signed
+	// release in the 0700 daemon-home passes verification, so a partial/foreign file
+	// is never adopted. Optional (nil ⇒ the belt is skipped; the create path runs).
+	findAdoptable func(workdir, excludePath string) string
 	// reinstall re-renders the three mesh plists at newSpec.SelfPath and
 	// re-bootstraps them (installAll). Repointing SelfPath repoints all three by
 	// construction.
@@ -83,6 +89,24 @@ func ensureBinaryPresent(d binPresentDeps, spec Spec, holdsLock bool) (newSelfPa
 	}
 	if present { // steady state: the file is there, nothing to do
 		return "", false, nil
+	}
+
+	// BELT (issue #102-b): before placing a fresh binary, check whether a sibling
+	// already re-materialized a signature-VERIFIED daemon binary in the workdir
+	// (at a path != the missing SelfPath). If so, ADOPT it and just repoint the
+	// plists — never place a SECOND binary. 102-a's single-actor reinstall already
+	// prevents the double-place, but this makes placement idempotent regardless of
+	// lock timing. Only a signed release in the 0700 home verifies, so a partial
+	// (.tmp) or foreign file is never adopted.
+	if d.findAdoptable != nil {
+		if adopt := d.findAdoptable(spec.Workdir, spec.SelfPath); adopt != "" {
+			newSpec := spec
+			newSpec.SelfPath = adopt
+			if ierr := d.reinstall(newSpec); ierr != nil {
+				return adopt, true, ierr
+			}
+			return adopt, true, nil
+		}
 	}
 
 	// The binary FILE is gone. Re-materialize it from the retained-fd bytes.

--- a/daemon/internal/osadapter/binpresent_darwin.go
+++ b/daemon/internal/osadapter/binpresent_darwin.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
@@ -67,7 +68,7 @@ func EnsureBinaryPresent(spec Spec, selfRole Role, holdsLock bool, retained *os.
 			// EnsureAll re-bootstraps self onto the new binary. The self label is
 			// stable across the path rotation (the roster is unchanged), so
 			// ns.Label(selfRole) == spec.Label(selfRole).
-			return reinstallExceptSelf(ns, launchctlCtl{m: ns.Mode}, laFS{m: ns.Mode}, rs, ns.Label(selfRole))
+			return reinstallExceptSelf(ns, launchctlCtl{m: ns.Mode}, laFS{m: ns.Mode}, rs, ns.Label(selfRole), time.Sleep)
 		},
 		supportRoot: mode.SupportRoot(spec.Mode, home),
 	}

--- a/daemon/internal/osadapter/binpresent_darwin.go
+++ b/daemon/internal/osadapter/binpresent_darwin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
 	"github.com/eliteGoblin/focusd/daemon/internal/relocate"
@@ -26,7 +27,14 @@ import (
 // remains the backstop. holdsLock is the caller's platform-singleton-lock state
 // (Executor.HoldsPlatformLock) — only the lock holder re-materializes, so mesh
 // roles A and B never both place.
-func EnsureBinaryPresent(spec Spec, holdsLock bool, retained *os.File) (newSelf string, changed bool, err error) {
+//
+// selfRole is the CALLER's own mesh role (issue #102): the reinstall repoints the
+// mesh via reinstallExceptSelf, which reloads every label EXCEPT the caller's own
+// (booting self out last, no bootstrap) — so no process ever bootstraps its own
+// executing label mid-install and SIGTERMs itself (the 102-a fault). The next
+// reconcile's EnsureAll re-bootstraps self onto the new binary. The self label is
+// derived from selfRole against the (roster-stable) spec.
+func EnsureBinaryPresent(spec Spec, selfRole Role, holdsLock bool, retained *os.File) (newSelf string, changed bool, err error) {
 	// Cheap no-op gates hoisted from the core so a non-participant skips the home
 	// resolution + fd work below (and never logs a spurious home error every tick).
 	// The core re-checks both, so its unit-tested guards remain authoritative.
@@ -48,16 +56,50 @@ func EnsureBinaryPresent(spec Spec, holdsLock bool, retained *os.File) (newSelf 
 		verify:        verifySignedBytes,
 		randName:      relocate.RandomBinaryName,
 		place:         binPlacerFS{}.place,
+		findAdoptable: findAdoptableBinary,
 		reinstall: func(ns Spec) error {
 			var rs rosterIO
 			if ns.Workdir != "" {
 				rs = newWorkdirRoster(ns.Workdir)
 			}
-			return installAll(ns, launchctlCtl{m: ns.Mode}, laFS{m: ns.Mode}, rs)
+			// Repoint via reinstallExceptSelf: reload every label EXCEPT the
+			// caller's own, boot self out last (no self-bootstrap) — the next
+			// EnsureAll re-bootstraps self onto the new binary. The self label is
+			// stable across the path rotation (the roster is unchanged), so
+			// ns.Label(selfRole) == spec.Label(selfRole).
+			return reinstallExceptSelf(ns, launchctlCtl{m: ns.Mode}, laFS{m: ns.Mode}, rs, ns.Label(selfRole))
 		},
 		supportRoot: mode.SupportRoot(spec.Mode, home),
 	}
 	return ensureBinaryPresent(d, spec, holdsLock)
+}
+
+// findAdoptableBinary scans the IMMEDIATE children of workdir for a regular file
+// (other than excludePath) whose bytes pass Ed25519 verification — an already-
+// placed, signed daemon binary a sibling re-materialized (issue #102-b). Returns
+// its path or "". A partial `.tmp` from an in-flight place, or any foreign file,
+// fails verification and is never adopted; only a signed release verifies.
+func findAdoptableBinary(workdir, excludePath string) string {
+	if workdir == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(workdir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p := filepath.Join(workdir, e.Name())
+		if p == excludePath {
+			continue
+		}
+		if ok, verr := sig.VerifyFile(p); verr == nil && ok {
+			return p
+		}
+	}
+	return ""
 }
 
 // verifySignedBytes splits a signed-release image (program ++ 64-byte trailer)

--- a/daemon/internal/osadapter/binpresent_test.go
+++ b/daemon/internal/osadapter/binpresent_test.go
@@ -266,6 +266,64 @@ func TestEnsureBinaryPresent_ReinstallErrStillAdoptsNewPath(t *testing.T) {
 	}
 }
 
+// TestEnsureBinaryPresent_AdoptsExistingVerifiedBinary (issue #102-b belt): when
+// a sibling has ALREADY re-materialized a signature-verified daemon binary in the
+// workdir, the heal ADOPTS it (repoints the plists at it) instead of PLACING a
+// second binary. This keeps placement idempotent regardless of lock timing.
+func TestEnsureBinaryPresent_AdoptsExistingVerifiedBinary(t *testing.T) {
+	d, spec, _ := testBinPresentDeps(t)
+	adoptPath := filepath.Join(spec.Workdir, "sibling.placed.binary")
+	d.findAdoptable = func(workdir, excludePath string) string {
+		if workdir == spec.Workdir && excludePath == spec.SelfPath {
+			return adoptPath
+		}
+		return ""
+	}
+	placeCalled, readCalled := false, false
+	d.place = func([]byte, string) error { placeCalled = true; return nil }
+	d.readSelfBytes = func() ([]byte, error) { readCalled = true; return []byte("x"), nil }
+	var gotSpec Spec
+	d.reinstall = func(ns Spec) error { gotSpec = ns; return nil }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || !changed {
+		t.Fatalf("want an adopt (changed, no err), got changed=%v err=%v", changed, err)
+	}
+	if newSelf != adoptPath {
+		t.Fatalf("must adopt the existing verified binary %q, got %q", adoptPath, newSelf)
+	}
+	if placeCalled {
+		t.Fatal("must NOT place a second binary when an adoptable one exists")
+	}
+	if readCalled {
+		t.Fatal("must NOT even read self bytes when adopting")
+	}
+	if gotSpec.SelfPath != adoptPath {
+		t.Fatalf("reinstall must repoint at the adopted path %q, got %q", adoptPath, gotSpec.SelfPath)
+	}
+}
+
+// TestEnsureBinaryPresent_NoAdoptableFallsThroughToPlace: when findAdoptable finds
+// nothing, the heal proceeds to place a fresh binary as before (the belt is a
+// fast-path optimisation, not a gate).
+func TestEnsureBinaryPresent_NoAdoptableFallsThroughToPlace(t *testing.T) {
+	d, spec, workdir := testBinPresentDeps(t)
+	d.findAdoptable = func(string, string) string { return "" } // nothing to adopt
+	placeCalled := false
+	d.place = func(b []byte, dst string) error { placeCalled = true; return os.WriteFile(dst, b, 0o755) }
+
+	newSelf, changed, err := ensureBinaryPresent(d, spec, true)
+	if err != nil || !changed || newSelf == "" {
+		t.Fatalf("want a fresh place, got (%q,%v,%v)", newSelf, changed, err)
+	}
+	if !placeCalled {
+		t.Fatal("with nothing adoptable, the heal must place a fresh binary")
+	}
+	if filepath.Dir(newSelf) != workdir {
+		t.Errorf("fresh binary %q not directly in workdir %q", newSelf, workdir)
+	}
+}
+
 // safeToCreateUnder is the create-side containment guard.
 func TestSafeToCreateUnder(t *testing.T) {
 	root := t.TempDir()

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -159,18 +159,61 @@ func RemoveCompanion(m mode.Mode) error {
 	return os.RemoveAll(dir.Root())
 }
 
+// companionRanRecentlyWindow is how recent the companion RanMarker's mtime must
+// be for status to treat the rail as FIRING (issue #status-2). ~3× the 30s
+// StartInterval, so a single missed pass does not flap the signal. A companion
+// that never completes a recovery pass (e.g. the #101 no-$HOME crash) never
+// touches the marker → this reads false → status honestly omits the rail line.
+const companionRanRecentlyWindow = 90 * time.Second
+
 // CompanionStatus reports the companion rail's liveness for status (bools only,
-// no paths cross the boundary): present — the companion binary is on disk;
-// backupOK — the offline daemon backup exists AND passes Ed25519 verification.
-func CompanionStatus(m mode.Mode) (present, backupOK bool) {
+// no paths cross the boundary):
+//   - present   — the companion binary is on disk AND its persisted launchd job
+//     is LOADED (issue #status-2 (a): mere on-disk presence used to read "present"
+//     even while the job was DOA);
+//   - backupOK  — the offline daemon backup exists AND passes Ed25519 verification;
+//   - ranRecently — the RanMarker shows a recovery pass COMPLETED within
+//     companionRanRecentlyWindow (issue #status-2 (b): a silently-dead rail that
+//     never fires reads false, so status omits the line instead of trusting
+//     presence).
+func CompanionStatus(m mode.Mode) (present, backupOK, ranRecently bool) {
 	dir := companionDir(m)
+	return companionStatus(dir, launchctlCtl{m: m}.loaded, sig.VerifyFile, time.Now())
+}
+
+// companionStatus is the seam-injected core of CompanionStatus, split out so the
+// launchd-loaded + signature + firing checks are unit-tested without a real
+// launchctl or the offline signing key. loadedFn probes launchd; verify checks the
+// backup signature; now anchors the RanMarker staleness compare.
+func companionStatus(
+	dir companion.Dir,
+	loadedFn func(string) bool,
+	verify func(string) (bool, error),
+	now time.Time,
+) (present, backupOK, ranRecently bool) {
+	binOnDisk := false
 	if fi, err := os.Stat(dir.Binary()); err == nil && !fi.IsDir() {
-		present = true
+		binOnDisk = true
 	}
-	if ok, err := sig.VerifyFile(dir.Backup()); err == nil && ok {
+	present = binOnDisk && companionJobLoaded(dir, loadedFn)
+	if ok, err := verify(dir.Backup()); err == nil && ok {
 		backupOK = true
 	}
-	return present, backupOK
+	if fi, err := os.Stat(dir.RanMarker()); err == nil {
+		ranRecently = now.Sub(fi.ModTime()) < companionRanRecentlyWindow
+	}
+	return present, backupOK, ranRecently
+}
+
+// companionJobLoaded reports whether the companion's persisted launchd label is
+// currently loaded. A missing/empty label file (never bootstrapped) → false.
+func companionJobLoaded(dir companion.Dir, loadedFn func(string) bool) bool {
+	b, err := os.ReadFile(dir.LabelFile())
+	if err != nil {
+		return false
+	}
+	label := strings.TrimSpace(string(b))
+	return label != "" && loadedFn(label)
 }
 
 // TouchCompanionHeartbeat updates the companion heartbeat's mtime to now — the

--- a/daemon/internal/osadapter/companion_other.go
+++ b/daemon/internal/osadapter/companion_other.go
@@ -14,4 +14,4 @@ func RefreshCompanionBackup(mode.Mode, []byte, string) error { return nil }
 func RemoveCompanion(mode.Mode) error                        { return nil }
 func TouchCompanionHeartbeat(mode.Mode) error                { return nil }
 
-func CompanionStatus(mode.Mode) (present, backupOK bool) { return false, false }
+func CompanionStatus(mode.Mode) (present, backupOK, ranRecently bool) { return false, false, false }

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/companion"
 	"github.com/eliteGoblin/focusd/daemon/internal/mode"
@@ -242,40 +243,66 @@ func TestEnsureCompanionScaffoldsWithoutLaunchd(t *testing.T) {
 	}
 }
 
-// TestCompanionStatusReflectsBackupSignature: CompanionStatus.present tracks the
-// companion binary on disk, and backupOK tracks whether the offline daemon
-// backup passes Ed25519 verification. This is the rail `daemon status` now reads
-// for watchdog_copy_ok (GAP 2 fix) — an unsigned/corrupted backup honestly reads
-// false; on a real install the backup is a byte-exact copy of the signed daemon
-// (see TestEnsureCompanionScaffoldsWithoutLaunchd) so it verifies true.
-func TestCompanionStatusReflectsBackupSignature(t *testing.T) {
+// TestCompanionStatusCore exercises the seam-injected core of CompanionStatus
+// (issue #status-2). present now requires the binary on disk AND the launchd job
+// LOADED (not mere on-disk presence — the old bug that read "present" while the
+// job was DOA); backupOK tracks Ed25519 verification of the offline backup; and
+// ranRecently tracks the RanMarker firing signal. Injected loadedFn/verify keep it
+// deterministic without a real launchctl or the offline signing key.
+func TestCompanionStatusCore(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
 	dir := companion.For(mode.User, home)
 	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	now := time.Now()
+	loadedTrue := func(string) bool { return true }
+	loadedFalse := func(string) bool { return false }
+	verifyReal := func(p string) (bool, error) { return sig.VerifyFile(p) }
 
-	// Empty folder: no binary, no backup → absent + backup fails.
-	if present, backupOK := CompanionStatus(mode.User); present || backupOK {
-		t.Fatalf("empty companion folder: want (false,false), got (%v,%v)", present, backupOK)
+	// Empty folder: nothing present, nothing verifies, never fired.
+	if p, b, r := companionStatus(dir, loadedTrue, verifyReal, now); p || b || r {
+		t.Fatalf("empty companion folder: want (false,false,false), got (%v,%v,%v)", p, b, r)
 	}
 
-	// Companion binary on disk → present=true. An UNSIGNED backup (random
-	// trailer) must NOT verify → backupOK=false.
+	// Binary on disk + a persisted label — but the job is NOT loaded → present
+	// stays false (the #status-2 (a) fix: on-disk presence alone is not "present").
 	if err := os.WriteFile(dir.Binary(), []byte("companion-bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir.LabelFile(), []byte("com.apple.MobileAsset.helper.dead"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	unsigned := append([]byte("not a signed daemon binary"), make([]byte, sig.SigLen)...)
 	if err := os.WriteFile(dir.Backup(), unsigned, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	present, backupOK := CompanionStatus(mode.User)
-	if !present {
-		t.Fatalf("companion binary on disk → present must be true")
+	if p, _, _ := companionStatus(dir, loadedFalse, verifyReal, now); p {
+		t.Fatalf("binary on disk but job NOT loaded → present must be false")
 	}
-	if backupOK {
+
+	// Job loaded → present=true. Unsigned backup → backupOK=false.
+	p, b, _ := companionStatus(dir, loadedTrue, verifyReal, now)
+	if !p {
+		t.Fatalf("binary on disk + label loaded → present must be true")
+	}
+	if b {
 		t.Fatalf("an unsigned backup must NOT verify → backupOK must be false")
+	}
+
+	// RanMarker firing signal: a recent marker reads true; a stale one reads false.
+	if err := os.WriteFile(dir.RanMarker(), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, r := companionStatus(dir, loadedTrue, verifyReal, now); !r {
+		t.Fatalf("a freshly-touched RanMarker must read ranRecently=true")
+	}
+	stale := now.Add(-companionRanRecentlyWindow - time.Minute)
+	if err := os.Chtimes(dir.RanMarker(), stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, r := companionStatus(dir, loadedTrue, verifyReal, now); r {
+		t.Fatalf("a stale RanMarker (older than the window) must read ranRecently=false")
 	}
 }
 

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -287,16 +287,9 @@ func MeshStatus(m mode.Mode) (loaded, total int, found bool, err error) {
 	if ferr != nil {
 		return 0, 0, false, ferr
 	}
-	if len(cur.Labels) == 0 {
-		return 0, 0, false, nil
-	}
 	c := launchctlCtl{m: m}
-	for _, lbl := range cur.Labels {
-		if c.loaded(lbl) {
-			loaded++
-		}
-	}
-	return loaded, len(cur.Labels), true, nil
+	loaded, total, found = meshStatusCounts(cur, c.loaded)
+	return loaded, total, found, nil
 }
 
 // UninstallProd removes a disguised user/system install whose labels are
@@ -408,8 +401,13 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) (live []Generation, de
 	var deadOrder []string // dead (deleted) binary paths in first-seen order
 	deadByBin := map[string]*genAccum{}
 	// accumulate groups one plist into the given bin-keyed map, mirroring the
-	// live and dead grouping so the corroboration logic is identical.
-	accumulate := func(into map[string]*genAccum, ord *[]string, bin, label, pp string, argv []string, env map[string]string) {
+	// live and dead grouping. corroborate is the predicate that decides whether a
+	// plist marks its group as a real focusd mesh generation — it DIFFERS by branch:
+	//   - LIVE: isFocusdMeshWorkerPlist (strict worker-only; an ensure-only live
+	//     "generation" is not a real mesh — preserved from FEATURE 17).
+	//   - DEAD: isFocusdMeshOrEnsurePlist (also matches the ensurer, so a dead
+	//     generation left as ONLY its ensurer plist is swept, not stranded — #102-c).
+	accumulate := func(into map[string]*genAccum, ord *[]string, bin, label, pp string, argv []string, env map[string]string, corroborate func(map[string]string, []string) bool) {
 		g := into[bin]
 		if g == nil {
 			g = &genAccum{binaryPath: bin, workdir: WorkdirFromBinary(bin)}
@@ -418,11 +416,7 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) (live []Generation, de
 		}
 		g.labels = append(g.labels, label)
 		g.plistPaths = append(g.plistPaths, pp)
-		// FEATURE 19 union: a NEW plist corroborates via its env worker marker
-		// (MeshEnvKey="run:<role>"), an OLD plist via the legacy --mesh argv.
-		// The ensure role corroborates neither — an ensure-only generation is
-		// not a real mesh (preserved from FEATURE 17).
-		if isFocusdMeshWorkerPlist(env, argv) {
+		if corroborate(env, argv) {
 			g.meshSeen = true
 		}
 	}
@@ -438,17 +432,19 @@ func DiscoverAllGenerations(m mode.Mode, verify Verifier) (live []Generation, de
 		ok, verr := verify(bin)
 		switch {
 		case verr == nil && ok:
-			// Live generation: a present, Ed25519-verified binary.
-			accumulate(byBin, &order, bin, label, pp, argv, env)
+			// Live generation: a present, Ed25519-verified binary. STRICT
+			// worker-only corroboration (no regression: an ensure-only live
+			// generation is still not a real mesh).
+			accumulate(byBin, &order, bin, label, pp, argv, env, isFocusdMeshWorkerPlist)
 		case verr != nil && errors.Is(verr, fs.ErrNotExist):
 			// Dead generation: ProgramArguments[0] names a binary that no
 			// longer exists (its workdir was deleted by a recovery cycle). A
-			// file that is gone cannot be Ed25519-verified, so the mesh worker
-			// marker is the ONLY signal this orphan plist is ours — group +
-			// corroborate it exactly like a live generation, keyed by the
-			// (now-dangling) bin path so the sibling ensure plist (no marker)
-			// is swept in via the shared path.
-			accumulate(deadByBin, &deadOrder, bin, label, pp, argv, env)
+			// file that is gone cannot be Ed25519-verified, so a focusd-specific
+			// env/argv marker is the ONLY signal this orphan plist is ours.
+			// #102-c: corroborate with isFocusdMeshOrEnsurePlist (also the
+			// ensurer) so a dead generation left as ONLY its ensurer plist is
+			// swept instead of stranded launchd-active with a missing binary.
+			accumulate(deadByBin, &deadOrder, bin, label, pp, argv, env, isFocusdMeshOrEnsurePlist)
 		default:
 			// ok==false: a binary that EXISTS but fails the signature (a real
 			// vendor binary) → never ours. A non-ENOENT verify error (a present

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -22,8 +22,8 @@ func UninstallProd() ([]string, error) { return nil, ErrUnsupported }
 
 // EnsureBinaryPresent is a no-op on non-darwin (no launchd mesh binary to
 // re-materialize). Returns ("", false, nil) so the reconcile loop wires it
-// uniformly (FEATURE 22 follow-up).
-func EnsureBinaryPresent(Spec, bool, *os.File) (string, bool, error) { return "", false, nil }
+// uniformly (FEATURE 22 follow-up). selfRole mirrors the darwin signature (#102).
+func EnsureBinaryPresent(Spec, Role, bool, *os.File) (string, bool, error) { return "", false, nil }
 
 // Verifier is the signature-check seam (no-op on non-darwin since
 // FindCurrentInstall returns ErrUnsupported here).

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -205,10 +205,12 @@ func TestDiscoverAllGenerationsRecordsDeadBinary(t *testing.T) {
 	deadRoster := []string{"com.docker.helper.4", "us.zoom.ZoomDaemon.svc.5", "io.tailscale.ipnextension.relay.6"}
 	deadBin, deadWd := writeDeadGeneration(t, home, laDir, "dead", deadRoster, AllRoles...)
 
-	// A non-mesh DEAD plist: binary deleted, ONLY the ensure role (no marker)
-	// under a distinct dangling bin → must NOT be treated as ours.
+	// An ENSURE-ONLY DEAD orphan: binary deleted, ONLY the ensure plist left (its
+	// workers already swept). Issue #102-c: this MUST now be recognised as ours (a
+	// dead ensurer carries the focusd-specific APP_LAUNCH_CONTEXT="ensure" marker),
+	// so it is swept rather than stranded launchd-active with a missing binary.
 	ensRoster := []string{"com.vendor.x.7", "com.vendor.y.8", "com.vendor.z.9"}
-	writeDeadGeneration(t, home, laDir, "ensonly", ensRoster, RoleEnsure)
+	ensBin, _ := writeDeadGeneration(t, home, laDir, "ensonly", ensRoster, RoleEnsure)
 
 	// A vendor plist whose binary EXISTS but fails the signature.
 	vendorWd := filepath.Join(home, "Library", "Application Support", ".vendor")
@@ -237,19 +239,31 @@ func TestDiscoverAllGenerationsRecordsDeadBinary(t *testing.T) {
 	if len(gens) != 1 || gens[0].BinaryPath != liveBin {
 		t.Fatalf("want exactly the live generation, got %+v", gens)
 	}
-	// Exactly one dead generation: the full-mesh zombie (ensure-only + vendor excluded).
-	if len(dead) != 1 {
-		t.Fatalf("want exactly 1 dead generation, got %d: %+v", len(dead), dead)
+	// TWO dead generations now: the full-mesh zombie AND the ensure-only orphan
+	// (#102-c). The vendor plist (present binary, fails sig) is still excluded.
+	if len(dead) != 2 {
+		t.Fatalf("want exactly 2 dead generations (full-mesh + ensure-only), got %d: %+v", len(dead), dead)
 	}
-	d := dead[0]
-	if d.BinaryPath != deadBin {
-		t.Errorf("dead binary = %q, want %q", d.BinaryPath, deadBin)
+	byBin := map[string]DeadGeneration{}
+	for _, d := range dead {
+		byBin[d.BinaryPath] = d
 	}
-	if d.Workdir != deadWd {
-		t.Errorf("dead workdir = %q, want %q", d.Workdir, deadWd)
+	full, ok := byBin[deadBin]
+	if !ok {
+		t.Fatalf("full-mesh dead generation %q missing from %+v", deadBin, dead)
 	}
-	if len(d.Labels) != 3 || len(d.PlistPaths) != 3 {
-		t.Errorf("dead generation: want 3 labels/plists (incl. swept-in ensure), got %d/%d", len(d.Labels), len(d.PlistPaths))
+	if full.Workdir != deadWd {
+		t.Errorf("dead workdir = %q, want %q", full.Workdir, deadWd)
+	}
+	if len(full.Labels) != 3 || len(full.PlistPaths) != 3 {
+		t.Errorf("full-mesh dead generation: want 3 labels/plists (incl. swept-in ensure), got %d/%d", len(full.Labels), len(full.PlistPaths))
+	}
+	ens, ok := byBin[ensBin]
+	if !ok {
+		t.Fatalf("ensure-only dead orphan %q must now be recognised (#102-c), got %+v", ensBin, dead)
+	}
+	if len(ens.Labels) != 1 {
+		t.Errorf("ensure-only dead orphan: want 1 label, got %d", len(ens.Labels))
 	}
 }
 

--- a/daemon/internal/osadapter/manager.go
+++ b/daemon/internal/osadapter/manager.go
@@ -119,7 +119,16 @@ func installAll(s Spec, c controller, fs fsio, rs rosterIO) error {
 // label. selfLabel must be a real role label; an empty selfLabel skips nothing
 // (defensive: the mesh still comes back, at the old self-kill risk — but the sole
 // caller is the lock-holding worker, whose role label is always known).
-func reinstallExceptSelf(s Spec, c controller, fs fsio, rs rosterIO, selfLabel string) error {
+//
+// CRITICAL failure semantics: if a NON-self label's reload permanently fails we
+// return the error BEFORE booting self out, so self stays loaded (never left
+// down). The binary was already placed by the caller (ensureBinaryPresent), which
+// reports changed=true regardless — the caller adopts the new path so the next
+// tick's ensureAll retries the launchd side against the CORRECT path.
+//
+// sleep is injected (mirrors robustReload) so the partial-failure path is
+// unit-tested without real backoff time; production passes time.Sleep.
+func reinstallExceptSelf(s Spec, c controller, fs fsio, rs rosterIO, selfLabel string, sleep func(time.Duration)) error {
 	if rs != nil {
 		if err := rs.writeRoster(rosterLabels(s)); err != nil {
 			return fmt.Errorf("osadapter: write roster: %w", err)
@@ -139,7 +148,7 @@ func reinstallExceptSelf(s Spec, c controller, fs fsio, rs rosterIO, selfLabel s
 		if label == selfLabel {
 			continue
 		}
-		if err := robustReload(c, label, fs.plistPath(label), time.Sleep); err != nil {
+		if err := robustReload(c, label, fs.plistPath(label), sleep); err != nil {
 			return fmt.Errorf("osadapter: bootstrap %s: %w", label, err)
 		}
 	}

--- a/daemon/internal/osadapter/manager.go
+++ b/daemon/internal/osadapter/manager.go
@@ -1,6 +1,9 @@
 package osadapter
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // controller is the launchd seam (real on darwin, fake in tests).
 type controller interface {
@@ -36,6 +39,45 @@ func rosterLabels(s Spec) []string {
 	return labels
 }
 
+// reloadAttempts is how many bootout+bootstrap tries robustReload makes before
+// giving up. On a LIVE mesh, launchctl bootout returns BEFORE launchd finishes
+// its async teardown, so an immediate bootstrap of a still-loaded label returns
+// EIO ("Bootstrap failed: 5" / "already loaded"). Re-issuing bootout (idempotent)
+// + a brief backoff absorbs that window; ~3 tries is ample.
+const reloadAttempts = 3
+
+// reloadBackoff is the delay before retry #attempt (attempt≥1): ~250ms, then
+// ~500ms. Enough for launchd's async teardown to settle without a slow reconcile.
+func reloadBackoff(attempt int) time.Duration {
+	return time.Duration(attempt) * 250 * time.Millisecond
+}
+
+// robustReload boots out label then bootstraps pp, retrying bootout+bootstrap up
+// to reloadAttempts times with a brief backoff between tries (issue #102-a). It
+// exists because on a LIVE mesh a single bootout+bootstrap is racy:
+//   - booting out the EXECUTING worker's OWN label SIGTERMs itself, and an
+//     immediate bootstrap of that label returns EIO; and
+//   - bootout of a SIBLING returns before launchd finishes async teardown, so an
+//     immediate bootstrap of that sibling also returns EIO.
+//
+// bootout is idempotent, so re-issuing it before each retry clears the async
+// "already-loaded" state. On a fresh install (labels not loaded) the first
+// bootstrap succeeds and there is zero retry cost. sleep is injected so the retry
+// path is unit-testable without real time (production passes time.Sleep).
+func robustReload(c controller, label, pp string, sleep func(time.Duration)) error {
+	var err error
+	for attempt := 0; attempt < reloadAttempts; attempt++ {
+		if attempt > 0 {
+			sleep(reloadBackoff(attempt))
+		}
+		_ = c.bootout(label) // idempotent; clears any async-teardown "already loaded"
+		if err = c.bootstrap(pp); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
 // installAll writes the masked roster FIRST (so a survivor relaunched
 // before the plists settle can still recover), then writes + (re)loads
 // all three mesh entries (idempotent: any stale instance is booted out
@@ -52,10 +94,59 @@ func installAll(s Spec, c controller, fs fsio, rs rosterIO) error {
 		if err := fs.write(pp, Plist(s, r)); err != nil {
 			return fmt.Errorf("osadapter: write %s: %w", label, err)
 		}
-		_ = c.bootout(label)
-		if err := c.bootstrap(pp); err != nil {
+		if err := robustReload(c, label, pp, time.Sleep); err != nil {
 			return fmt.Errorf("osadapter: bootstrap %s: %w", label, err)
 		}
+	}
+	return nil
+}
+
+// reinstallExceptSelf re-materializes the whole mesh at the new binary path
+// WITHOUT any process ever bootstrapping its OWN label (issue #102). It writes the
+// roster + all three plists, robustly reloads every label EXCEPT selfLabel, and
+// then boots selfLabel OUT (last, no bootstrap).
+//
+// This replaces the old installAll on the in-mesh re-materialize path (102-a/b),
+// where a surviving worker re-installing the mesh would bootout its OWN executing
+// label mid-loop → SIGTERM itself → the platform-lock released → a sibling
+// re-entered, saw the binary still "missing", and placed a SECOND binary (two
+// binaries, mesh 2/3). Here the lock HOLDER completes the whole re-materialize
+// while holding the lock (true single-actor), and never restarts its own label.
+//
+// Booting self out LAST leaves self genuinely !loaded, so the EXISTING ensureAll
+// `!loaded` path — running on a freshly-reloaded sibling/ensurer — re-bootstraps
+// self onto the new binary within one ~2s reconcile. No process bootstraps its own
+// label. selfLabel must be a real role label; an empty selfLabel skips nothing
+// (defensive: the mesh still comes back, at the old self-kill risk — but the sole
+// caller is the lock-holding worker, whose role label is always known).
+func reinstallExceptSelf(s Spec, c controller, fs fsio, rs rosterIO, selfLabel string) error {
+	if rs != nil {
+		if err := rs.writeRoster(rosterLabels(s)); err != nil {
+			return fmt.Errorf("osadapter: write roster: %w", err)
+		}
+	}
+	// Write all three plists at the new path FIRST so the roster + plists agree
+	// before any (re)load.
+	for _, r := range AllRoles {
+		label := s.Label(r)
+		if err := fs.write(fs.plistPath(label), Plist(s, r)); err != nil {
+			return fmt.Errorf("osadapter: write %s: %w", label, err)
+		}
+	}
+	// Reload every label EXCEPT self.
+	for _, r := range AllRoles {
+		label := s.Label(r)
+		if label == selfLabel {
+			continue
+		}
+		if err := robustReload(c, label, fs.plistPath(label), time.Sleep); err != nil {
+			return fmt.Errorf("osadapter: bootstrap %s: %w", label, err)
+		}
+	}
+	// Boot self OUT last (no bootstrap): self ends genuinely !loaded, and the
+	// freshly-reloaded sibling/ensurer's next ensureAll re-bootstraps it.
+	if selfLabel != "" {
+		_ = c.bootout(selfLabel)
 	}
 	return nil
 }
@@ -102,8 +193,7 @@ func ensureAll(s Spec, c controller, fs fsio, rs rosterIO) (recreated []Role, er
 		if werr := fs.write(pp, Plist(s, r)); werr != nil {
 			return recreated, fmt.Errorf("osadapter: rewrite %s: %w", label, werr)
 		}
-		_ = c.bootout(label)
-		if berr := c.bootstrap(pp); berr != nil {
+		if berr := robustReload(c, label, pp, time.Sleep); berr != nil {
 			return recreated, fmt.Errorf("osadapter: rebootstrap %s: %w", label, berr)
 		}
 		recreated = append(recreated, r)

--- a/daemon/internal/osadapter/manager_test.go
+++ b/daemon/internal/osadapter/manager_test.go
@@ -238,7 +238,7 @@ func TestReinstallExceptSelfNeverBootstrapsSelf(t *testing.T) {
 	ns := s
 	ns.SelfPath = "/wd/fresh-binary"
 	c.boots = nil // reset to observe only the reinstall's bootstraps
-	if err := reinstallExceptSelf(ns, c, fs, rs, selfLabel); err != nil {
+	if err := reinstallExceptSelf(ns, c, fs, rs, selfLabel, noSleep); err != nil {
 		t.Fatalf("reinstallExceptSelf: %v", err)
 	}
 
@@ -271,6 +271,45 @@ func TestReinstallExceptSelfNeverBootstrapsSelf(t *testing.T) {
 	}
 	if !c.loaded(selfLabel) {
 		t.Fatalf("self must be loaded again after the next EnsureAll")
+	}
+}
+
+// TestReinstallExceptSelfSiblingFailureKeepsSelfLoaded (go-review MEDIUM #3): if a
+// NON-self label's reload permanently fails, reinstallExceptSelf must return the
+// error BEFORE booting self out — so self stays loaded (never left down) and is
+// never bootstrapped by the reinstall. This is the safety-critical guarantee: a
+// partial failure must not take the surviving actor down. The caller then adopts
+// the already-placed new path and the next tick's EnsureAll retries the failed
+// sibling against the correct path.
+func TestReinstallExceptSelfSiblingFailureKeepsSelfLoaded(t *testing.T) {
+	s := spec()
+	c, fs, rs := newFakeCtl(), newFakeFS(), &fakeRoster{}
+	if err := installAll(s, c, fs, rs); err != nil {
+		t.Fatal(err)
+	}
+	selfRole := RoleA
+	selfLabel := s.Label(selfRole)
+
+	// A NON-self sibling (RoleB) permanently fails to reload.
+	ns := s
+	ns.SelfPath = "/wd/fresh-binary"
+	c.bootstrapFailOn = fs.plistPath(s.Label(RoleB))
+	c.boots = nil
+
+	err := reinstallExceptSelf(ns, c, fs, rs, selfLabel, noSleep)
+	if err == nil {
+		t.Fatal("a permanent sibling-reload failure must surface as an error")
+	}
+	// Self must NOT have been booted out (we returned before the self bootout),
+	// so it stays loaded from the original install — never taken down.
+	if !c.loaded(selfLabel) {
+		t.Fatalf("self %q must stay loaded when a sibling reload fails", selfLabel)
+	}
+	// Self must never have been bootstrapped by the reinstall either.
+	for _, pp := range c.boots {
+		if labelFromPath(pp) == selfLabel {
+			t.Fatalf("self %q must never be bootstrapped by reinstallExceptSelf", selfLabel)
+		}
 	}
 }
 

--- a/daemon/internal/osadapter/manager_test.go
+++ b/daemon/internal/osadapter/manager_test.go
@@ -10,7 +10,8 @@ type fakeCtl struct {
 	loadedSet       map[string]bool
 	boots           []string
 	bouts           []string
-	bootstrapFailOn string           // plist path that should fail bootstrap
+	bootstrapFailOn string           // plist path that should fail bootstrap (always)
+	bootstrapFailN  map[string]int   // plist path → # of times to fail before succeeding (transient)
 	bootoutErrOn    map[string]error // label → error to return from bootout
 }
 
@@ -19,6 +20,12 @@ func newFakeCtl() *fakeCtl { return &fakeCtl{loadedSet: map[string]bool{}} }
 func (f *fakeCtl) loaded(l string) bool { return f.loadedSet[l] }
 func (f *fakeCtl) bootstrap(pp string) error {
 	if pp == f.bootstrapFailOn {
+		return errCtlSynthetic
+	}
+	// Transient failure: model launchd's async "already-loaded"/EIO window that a
+	// robustReload retry (bootout+backoff+bootstrap) is meant to absorb.
+	if f.bootstrapFailN != nil && f.bootstrapFailN[pp] > 0 {
+		f.bootstrapFailN[pp]--
 		return errCtlSynthetic
 	}
 	f.boots = append(f.boots, pp)
@@ -166,6 +173,104 @@ func TestEnsureAllHealsRosterFromMemory(t *testing.T) {
 	}
 	if !rs.present || !sameRoster(rs.labels, rosterLabels(spec())) {
 		t.Fatalf("missing roster must be rewritten from memory, got %v", rs.labels)
+	}
+}
+
+// noSleep is a no-op sleep so robustReload's retry path is exercised without real
+// time in unit tests.
+func noSleep(time.Duration) {}
+
+// TestRobustReloadRetriesTransientBootstrap (issue #102-a): on a LIVE mesh, an
+// immediate bootstrap after bootout can return EIO ("already loaded") while
+// launchd finishes its async teardown. robustReload re-issues bootout + retries
+// and succeeds within reloadAttempts — a single bootout+bootstrap would have
+// failed (the 2/3 mesh fault).
+func TestRobustReloadRetriesTransientBootstrap(t *testing.T) {
+	c := newFakeCtl()
+	label := "com.vendor.alpha"
+	pp := "/p/" + label + ".plist"
+	c.bootstrapFailN = map[string]int{pp: reloadAttempts - 1} // fail all but the last try
+
+	if err := robustReload(c, label, pp, noSleep); err != nil {
+		t.Fatalf("robustReload should succeed after transient failures, got %v", err)
+	}
+	if !c.loaded(label) {
+		t.Fatalf("label must be loaded after a successful robustReload")
+	}
+	// bootout is idempotent and re-issued each attempt: reloadAttempts bootouts.
+	if len(c.bouts) != reloadAttempts {
+		t.Fatalf("want %d bootouts (one per attempt), got %d (%v)", reloadAttempts, len(c.bouts), c.bouts)
+	}
+}
+
+// TestRobustReloadGivesUpAfterMaxAttempts: a bootstrap that NEVER succeeds returns
+// the underlying error after reloadAttempts tries (does not loop forever).
+func TestRobustReloadGivesUpAfterMaxAttempts(t *testing.T) {
+	c := newFakeCtl()
+	label := "com.vendor.bravo"
+	pp := "/p/" + label + ".plist"
+	c.bootstrapFailOn = pp // always fails
+
+	if err := robustReload(c, label, pp, noSleep); err == nil {
+		t.Fatal("robustReload must surface the error when every attempt fails")
+	}
+	if c.loaded(label) {
+		t.Fatal("label must NOT be loaded when every bootstrap failed")
+	}
+}
+
+// TestReinstallExceptSelfNeverBootstrapsSelf (issue #102-a/b): the re-materialize
+// path must reload every mesh label EXCEPT the caller's own, and boot self OUT
+// (no bootstrap) — so no process ever restarts its OWN executing label mid-install
+// (the self-SIGTERM that released the lock and let a sibling double-place). Self
+// ends genuinely !loaded; the next EnsureAll re-bootstraps it.
+func TestReinstallExceptSelfNeverBootstrapsSelf(t *testing.T) {
+	s := spec()
+	// Pre-load all three (simulate the running mesh at the OLD path).
+	c, fs, rs := newFakeCtl(), newFakeFS(), &fakeRoster{}
+	if err := installAll(s, c, fs, rs); err != nil {
+		t.Fatal(err)
+	}
+	selfRole := RoleA
+	selfLabel := s.Label(selfRole)
+
+	// Re-materialize at a NEW binary path (roster/labels unchanged).
+	ns := s
+	ns.SelfPath = "/wd/fresh-binary"
+	c.boots = nil // reset to observe only the reinstall's bootstraps
+	if err := reinstallExceptSelf(ns, c, fs, rs, selfLabel); err != nil {
+		t.Fatalf("reinstallExceptSelf: %v", err)
+	}
+
+	// Self must NOT have been bootstrapped, and must be genuinely !loaded now.
+	for _, pp := range c.boots {
+		if labelFromPath(pp) == selfLabel {
+			t.Fatalf("self label %q must NEVER be bootstrapped by reinstallExceptSelf", selfLabel)
+		}
+	}
+	if c.loaded(selfLabel) {
+		t.Fatalf("self label %q must be booted OUT (!loaded) after reinstallExceptSelf", selfLabel)
+	}
+	// The two non-self labels ARE reloaded and loaded.
+	for _, r := range []Role{RoleB, RoleEnsure} {
+		if !c.loaded(s.Label(r)) {
+			t.Fatalf("non-self role %s must be reloaded by reinstallExceptSelf", r)
+		}
+	}
+	// All three plists were (re)written at the new path (the roster + plists agree).
+	if len(fs.files) != 3 {
+		t.Fatalf("want 3 plists written at the new path, got %d", len(fs.files))
+	}
+	// The next EnsureAll re-bootstraps self onto the new binary (the mesh converges).
+	rec, err := ensureAll(ns, c, fs, rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec) != 1 || rec[0] != selfRole {
+		t.Fatalf("EnsureAll must re-bootstrap ONLY self, got %v", rec)
+	}
+	if !c.loaded(selfLabel) {
+		t.Fatalf("self must be loaded again after the next EnsureAll")
 	}
 }
 

--- a/daemon/internal/osadapter/meshenv.go
+++ b/daemon/internal/osadapter/meshenv.go
@@ -83,17 +83,28 @@ func isFocusdMeshWorkerPlist(env map[string]string, argv []string) bool {
 	return strings.HasPrefix(env[MeshEnvKey], meshEnvRunPrefix) || hasMeshFlag(argv)
 }
 
-// hasEnsureArgv reports whether a parsed argv carries the ensurer subcommand
-// ("ensure") — the OLD-plist / test-mode ensurer marker (a PROD ensurer carries
-// it in env as MeshEnvKey="ensure" instead). Used ONLY by isFocusdMeshOrEnsurePlist
-// for the DEAD-branch sweep; a worker argv never contains "ensure".
-func hasEnsureArgv(argv []string) bool {
+// testModeFlag is the focusd-specific test-mode marker the installer bakes into a
+// TEST-mode plist's argv (see plist.go args(): "--test-mode-flag"). It is what
+// makes the test-mode ensurer argv focusd-specific — a bare "ensure" token is NOT.
+const testModeFlag = "--test-mode-flag"
+
+// isTestModeEnsureArgv reports whether argv is focusd's TEST-mode ensurer argv:
+// the "ensure" subcommand ALONGSIDE the focusd-specific "--test-mode-flag". A bare
+// "ensure" token on its own is NOT focusd-specific — a third-party orphan plist
+// could carry it — so requiring the test-mode marker keeps the dead-branch match
+// focusd-specific (Copilot review). A PROD ensurer does not rely on this at all:
+// it carries MeshEnvKey="ensure" in env, matched by decodeMeshEnv below.
+func isTestModeEnsureArgv(argv []string) bool {
+	hasEnsure, hasTestFlag := false, false
 	for _, a := range argv {
-		if a == string(RoleEnsure) { // "ensure"
-			return true
+		switch a {
+		case string(RoleEnsure): // "ensure"
+			hasEnsure = true
+		case testModeFlag:
+			hasTestFlag = true
 		}
 	}
-	return false
+	return hasEnsure && hasTestFlag
 }
 
 // isFocusdMeshOrEnsurePlist is the DEAD-branch corroboration predicate for
@@ -101,16 +112,23 @@ func hasEnsureArgv(argv []string) bool {
 // isFocusdMeshWorkerPlist used on the LIVE branch, it ALSO matches the ENSURER —
 // because a dead generation left as ONLY its ensurer plist (its workers already
 // swept, its binary gone) would otherwise be dropped and stay launchd-active with
-// a missing binary. It matches any focusd mesh env value a/b/ensure
-// (decodeMeshEnv != nil, the NEW-plist marker) OR the legacy --mesh argv (OLD
-// workers) OR the "ensure" argv (OLD/test ensurer).
+// a missing binary. It corroborates via, in order, three FOCUSD-SPECIFIC markers:
+//   - a focusd mesh env value a/b/ensure (decodeMeshEnv != nil) — the marker a
+//     PROD ensurer/worker carries in MeshEnvKey ("APP_LAUNCH_CONTEXT", a
+//     focusd-invented key no vendor plist sets); this handles the real #102-c case;
+//   - the legacy --mesh argv (OLD prod workers);
+//   - the TEST-mode ensurer argv (ensure + --test-mode-flag, focusd-specific).
+//
+// A bare "ensure" argv token is deliberately NOT sufficient: it is not
+// focusd-specific, so a third-party orphan plist whose missing-binary argv happens
+// to contain "ensure" must never be misclassified as ours and retired (Copilot
+// review).
 //
 // SAFETY: this is used ONLY where the binary is ALREADY proven missing
-// (fs.ErrNotExist) AND the plist is grouped by that focusd-specific dangling
-// path — MeshEnvKey ("APP_LAUNCH_CONTEXT") with value "ensure" is a focusd-invented
-// marker no vendor plist carries — so a third-party plist whose binary merely
+// (fs.ErrNotExist) AND the plist is grouped by that dangling path, corroborated by
+// a focusd-specific marker above — so a third-party plist whose binary merely
 // happens to be absent is never treated as ours. The LIVE branch stays strict
 // worker-only (no regression: a live ensure-only "generation" is still excluded).
 func isFocusdMeshOrEnsurePlist(env map[string]string, argv []string) bool {
-	return decodeMeshEnv(env[MeshEnvKey]) != nil || hasMeshFlag(argv) || hasEnsureArgv(argv)
+	return decodeMeshEnv(env[MeshEnvKey]) != nil || hasMeshFlag(argv) || isTestModeEnsureArgv(argv)
 }

--- a/daemon/internal/osadapter/meshenv.go
+++ b/daemon/internal/osadapter/meshenv.go
@@ -82,3 +82,35 @@ func ArgvFromEnv() []string {
 func isFocusdMeshWorkerPlist(env map[string]string, argv []string) bool {
 	return strings.HasPrefix(env[MeshEnvKey], meshEnvRunPrefix) || hasMeshFlag(argv)
 }
+
+// hasEnsureArgv reports whether a parsed argv carries the ensurer subcommand
+// ("ensure") — the OLD-plist / test-mode ensurer marker (a PROD ensurer carries
+// it in env as MeshEnvKey="ensure" instead). Used ONLY by isFocusdMeshOrEnsurePlist
+// for the DEAD-branch sweep; a worker argv never contains "ensure".
+func hasEnsureArgv(argv []string) bool {
+	for _, a := range argv {
+		if a == string(RoleEnsure) { // "ensure"
+			return true
+		}
+	}
+	return false
+}
+
+// isFocusdMeshOrEnsurePlist is the DEAD-branch corroboration predicate for
+// DiscoverAllGenerations (issue #102-c). Unlike the strict worker-only
+// isFocusdMeshWorkerPlist used on the LIVE branch, it ALSO matches the ENSURER —
+// because a dead generation left as ONLY its ensurer plist (its workers already
+// swept, its binary gone) would otherwise be dropped and stay launchd-active with
+// a missing binary. It matches any focusd mesh env value a/b/ensure
+// (decodeMeshEnv != nil, the NEW-plist marker) OR the legacy --mesh argv (OLD
+// workers) OR the "ensure" argv (OLD/test ensurer).
+//
+// SAFETY: this is used ONLY where the binary is ALREADY proven missing
+// (fs.ErrNotExist) AND the plist is grouped by that focusd-specific dangling
+// path — MeshEnvKey ("APP_LAUNCH_CONTEXT") with value "ensure" is a focusd-invented
+// marker no vendor plist carries — so a third-party plist whose binary merely
+// happens to be absent is never treated as ours. The LIVE branch stays strict
+// worker-only (no regression: a live ensure-only "generation" is still excluded).
+func isFocusdMeshOrEnsurePlist(env map[string]string, argv []string) bool {
+	return decodeMeshEnv(env[MeshEnvKey]) != nil || hasMeshFlag(argv) || hasEnsureArgv(argv)
+}

--- a/daemon/internal/osadapter/meshenv_test.go
+++ b/daemon/internal/osadapter/meshenv_test.go
@@ -34,6 +34,34 @@ func TestIsFocusdMeshWorkerPlist(t *testing.T) {
 	}
 }
 
+// TestIsFocusdMeshOrEnsurePlist asserts the DEAD-branch corroboration predicate
+// (issue #102-c): unlike the strict worker-only live predicate, it ALSO matches
+// the ENSURER — so a dead generation left as only its ensurer plist is swept, not
+// stranded. It still excludes a vendor plist (no focusd marker).
+func TestIsFocusdMeshOrEnsurePlist(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		argv []string
+		want bool
+	}{
+		{"new worker A (env run:a)", map[string]string{MeshEnvKey: "run:a"}, []string{"/bin/x"}, true},
+		{"new worker B (env run:b)", map[string]string{MeshEnvKey: "run:b"}, []string{"/bin/x"}, true},
+		{"new ensurer (env ensure) — the #102-c case", map[string]string{MeshEnvKey: "ensure"}, []string{"/bin/x"}, true},
+		{"old worker (--mesh argv)", nil, []string{"/bin/x", "run", "--r", "a", "--mesh"}, true},
+		{"old/test ensurer (ensure argv)", nil, []string{"/bin/x", "ensure", "--test-mode-flag", "true"}, true},
+		{"vendor plist (neither)", map[string]string{"OTHER": "x"}, []string{"/bin/x", "--foo"}, false},
+		{"empty", nil, nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isFocusdMeshOrEnsurePlist(c.env, c.argv); got != c.want {
+				t.Fatalf("isFocusdMeshOrEnsurePlist(%v, %v) = %v, want %v", c.env, c.argv, got, c.want)
+			}
+		})
+	}
+}
+
 // TestEncodeRoleExact pins the exact env values the round-trip depends on, so a
 // rename of a role string can never silently desync encode/decode.
 func TestEncodeRoleExact(t *testing.T) {

--- a/daemon/internal/osadapter/meshenv_test.go
+++ b/daemon/internal/osadapter/meshenv_test.go
@@ -49,7 +49,10 @@ func TestIsFocusdMeshOrEnsurePlist(t *testing.T) {
 		{"new worker B (env run:b)", map[string]string{MeshEnvKey: "run:b"}, []string{"/bin/x"}, true},
 		{"new ensurer (env ensure) — the #102-c case", map[string]string{MeshEnvKey: "ensure"}, []string{"/bin/x"}, true},
 		{"old worker (--mesh argv)", nil, []string{"/bin/x", "run", "--r", "a", "--mesh"}, true},
-		{"old/test ensurer (ensure argv)", nil, []string{"/bin/x", "ensure", "--test-mode-flag", "true"}, true},
+		{"test-mode ensurer (ensure + --test-mode-flag)", nil, []string{"/bin/x", "ensure", "--test-mode-flag", "true"}, true},
+		// A bare "ensure" token is NOT focusd-specific → must NOT corroborate, so a
+		// third-party orphan carrying "ensure" is never misclassified (Copilot review).
+		{"third-party bare ensure argv (no focusd marker)", nil, []string{"/usr/bin/thing", "ensure"}, false},
 		{"vendor plist (neither)", map[string]string{"OTHER": "x"}, []string{"/bin/x", "--foo"}, false},
 		{"empty", nil, nil, false},
 	}

--- a/daemon/internal/osadapter/meshstatus.go
+++ b/daemon/internal/osadapter/meshstatus.go
@@ -1,0 +1,36 @@
+package osadapter
+
+// meshStatusCounts is the pure core of MeshStatus (issue #status-1), split out so
+// the "N of 3" logic is unit-tested on Linux CI without a real launchctl. loadedFn
+// is the launchd-loaded probe (real launchctl in production, a fake in tests).
+//
+// The bug it fixes: the old MeshStatus reported total = len(cur.Labels) — the
+// number of plists it FOUND. A lost mesh member leaves only 2 plists on disk, so
+// the status read "2/2 HEALTHY" and hid a degraded mesh. The correct EXPECTED set
+// is the full roster:
+//   - a genuine focusd mesh is ALWAYS the 3 AllRoles, so once any install is found
+//     the total is len(AllRoles); a member that dropped its plist reads as missing
+//     from that expected set (2/3 → DEGRADED, 0/3 → DOWN).
+//   - the expected LABELS are cur.Roster when the roster carries the full mesh (the
+//     roster survives a lost plist, so it is the authoritative "should be running"
+//     set); otherwise (old/degraded discovery with no full roster) fall back to the
+//     labels actually found.
+//
+// found = len(cur.Labels) > 0 — an install was discovered at all. loaded counts how
+// many of the EXPECTED labels are actually loaded.
+func meshStatusCounts(cur CurInstall, loadedFn func(string) bool) (loaded, total int, found bool) {
+	found = len(cur.Labels) > 0
+	if !found {
+		return 0, 0, false
+	}
+	expected := cur.Labels
+	if len(cur.Roster) == len(AllRoles) {
+		expected = cur.Roster
+	}
+	for _, lbl := range expected {
+		if loadedFn(lbl) {
+			loaded++
+		}
+	}
+	return loaded, len(AllRoles), true
+}

--- a/daemon/internal/osadapter/meshstatus_test.go
+++ b/daemon/internal/osadapter/meshstatus_test.go
@@ -1,0 +1,73 @@
+package osadapter
+
+import "testing"
+
+// TestMeshStatusCounts is the issue #status-1 regression guard: the mesh total is
+// the EXPECTED set size (always 3 for a discovered focusd mesh), NOT the count of
+// plists found on disk. A lost member must read N/3 (→ DEGRADED/DOWN), never
+// "2/2 HEALTHY".
+func TestMeshStatusCounts(t *testing.T) {
+	roster := []string{"com.vendor.alpha", "com.vendor.bravo", "com.vendor.charlie"}
+
+	// loadedSet builds a loadedFn that reports only the listed labels loaded.
+	loadedSet := func(loaded ...string) func(string) bool {
+		m := map[string]bool{}
+		for _, l := range loaded {
+			m[l] = true
+		}
+		return func(l string) bool { return m[l] }
+	}
+
+	cases := []struct {
+		name       string
+		cur        CurInstall
+		loadedFn   func(string) bool
+		wantLoaded int
+		wantTotal  int
+		wantFound  bool
+	}{
+		{
+			name:       "full roster, all 3 loaded ⇒ 3/3",
+			cur:        CurInstall{Labels: roster, Roster: roster},
+			loadedFn:   loadedSet(roster...),
+			wantLoaded: 3, wantTotal: 3, wantFound: true,
+		},
+		{
+			// The core fix: a lost member drops its plist, so only 2 labels are
+			// FOUND — but the roster still names all 3, so status must read 2/3.
+			name:       "lost member (2 plists) but full roster ⇒ 2/3 (was 2/2)",
+			cur:        CurInstall{Labels: roster[:2], Roster: roster},
+			loadedFn:   loadedSet(roster[0], roster[1]),
+			wantLoaded: 2, wantTotal: 3, wantFound: true,
+		},
+		{
+			name:       "all roster labels present but none loaded ⇒ 0/3 (DOWN)",
+			cur:        CurInstall{Labels: roster, Roster: roster},
+			loadedFn:   loadedSet(),
+			wantLoaded: 0, wantTotal: 3, wantFound: true,
+		},
+		{
+			// No full roster (old/degraded discovery): expected set is the found
+			// labels, but total is still len(AllRoles) — a focusd mesh is always 3.
+			name:       "no full roster, 1 found + loaded ⇒ 1/3",
+			cur:        CurInstall{Labels: roster[:1]},
+			loadedFn:   loadedSet(roster[0]),
+			wantLoaded: 1, wantTotal: 3, wantFound: true,
+		},
+		{
+			name:       "nothing found ⇒ 0/0 not found",
+			cur:        CurInstall{},
+			loadedFn:   loadedSet(),
+			wantLoaded: 0, wantTotal: 0, wantFound: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			loaded, total, found := meshStatusCounts(c.cur, c.loadedFn)
+			if loaded != c.wantLoaded || total != c.wantTotal || found != c.wantFound {
+				t.Fatalf("meshStatusCounts = (%d,%d,%v), want (%d,%d,%v)",
+					loaded, total, found, c.wantLoaded, c.wantTotal, c.wantFound)
+			}
+		})
+	}
+}

--- a/daemon/internal/status/gather_darwin.go
+++ b/daemon/internal/status/gather_darwin.go
@@ -114,9 +114,9 @@ func Gather(workdirOverride string, jsonMode bool) (Snapshot, PlatformDetail) {
 	// companion is present (a pre-F18 install mid-migration), so the status
 	// never goes dark. Both probes cross ONLY bools (no path leaves the
 	// osadapter boundary), so this cannot leak a disguised identifier.
-	cPresent, cBackupOK := osadapter.CompanionStatus(m)
+	cPresent, cBackupOK, cRan := osadapter.CompanionStatus(m)
 	cronPresent, cronCopyOK := osadapter.WatchdogStatus(m)
-	railPresent, copyOK := recoveryRailStatus(cPresent, cBackupOK, cronPresent, cronCopyOK)
+	railPresent, copyOK := recoveryRailStatus(cPresent, cBackupOK, cRan, cronPresent, cronCopyOK)
 	s.WatchdogChecked = true
 	s.WatchdogCron = railPresent
 	s.WatchdogCopyOK = copyOK

--- a/daemon/internal/status/recovery_rail.go
+++ b/daemon/internal/status/recovery_rail.go
@@ -16,13 +16,18 @@ package status
 // though the companion's signed backup verified fine. Reporting the companion
 // makes the field reflect the rail that actually exists.
 //
-// Pure — unit-tested. railPresent tracks the rail's own presence
-// (companionPresent); copyOK tracks whether its signed backup verifies
-// (companionBackupOK) — so a placeholder-embed build with a verified backup but
-// no companion binary honestly reports copyOK=true, railPresent=false.
-func recoveryRailStatus(companionPresent, companionBackupOK, cronPresent, cronCopyOK bool) (railPresent, copyOK bool) {
+// Pure — unit-tested. railPresent tracks whether the companion rail is genuinely
+// UP: its binary/job is present (companionPresent) AND it is actually FIRING
+// (companionRan — the RanMarker shows a recent completed pass, issue #status-2).
+// A companion that is on-disk-and-loaded but never completes a pass (the #101
+// no-$HOME DOA class) reports companionRan=false → railPresent=false → status
+// omits the line, honestly signalling a dead rail instead of trusting presence.
+// copyOK tracks whether its signed backup verifies (companionBackupOK) — so a
+// placeholder-embed build with a verified backup but no companion binary honestly
+// reports copyOK=true, railPresent=false.
+func recoveryRailStatus(companionPresent, companionBackupOK, companionRan, cronPresent, cronCopyOK bool) (railPresent, copyOK bool) {
 	if companionPresent || companionBackupOK {
-		return companionPresent, companionBackupOK
+		return companionPresent && companionRan, companionBackupOK
 	}
 	return cronPresent, cronCopyOK
 }

--- a/daemon/internal/status/recovery_rail_test.go
+++ b/daemon/internal/status/recovery_rail_test.go
@@ -10,44 +10,52 @@ import "testing"
 // TRUE.
 func TestRecoveryRailStatus(t *testing.T) {
 	tests := []struct {
-		name                                       string
-		cPresent, cBackupOK, cronPresent, cronCopy bool
-		wantPresent, wantCopyOK                    bool
+		name                                             string
+		cPresent, cBackupOK, cRan, cronPresent, cronCopy bool
+		wantPresent, wantCopyOK                          bool
 	}{
 		{
-			name:     "companion present + backup verifies ⇒ report companion (the GAP-2 fix)",
-			cPresent: true, cBackupOK: true,
+			name:     "companion present + firing + backup verifies ⇒ report companion (GAP-2 fix)",
+			cPresent: true, cBackupOK: true, cRan: true,
 			cronPresent: false, cronCopy: false,
 			wantPresent: true, wantCopyOK: true,
 		},
 		{
-			name:     "companion present but backup fails ⇒ report companion (copy_ok false honestly)",
-			cPresent: true, cBackupOK: false,
+			// issue #status-2: on disk + loaded but NOT firing (the #101 DOA class)
+			// → railPresent false so status omits the line (honest dead-rail read).
+			name:     "companion present but NOT firing ⇒ railPresent false (dead-rail honesty)",
+			cPresent: true, cBackupOK: true, cRan: false,
+			cronPresent: true, cronCopy: true, // cron ignored — companion is authoritative
+			wantPresent: false, wantCopyOK: true,
+		},
+		{
+			name:     "companion present + firing but backup fails ⇒ copy_ok false honestly",
+			cPresent: true, cBackupOK: false, cRan: true,
 			cronPresent: true, cronCopy: true, // cron ignored — companion is authoritative
 			wantPresent: true, wantCopyOK: false,
 		},
 		{
 			name:     "placeholder build: verified backup, no companion binary ⇒ copy_ok true, present false",
-			cPresent: false, cBackupOK: true,
+			cPresent: false, cBackupOK: true, cRan: false,
 			cronPresent: true, cronCopy: true, // cron ignored — companion backup present
 			wantPresent: false, wantCopyOK: true,
 		},
 		{
 			name:     "companion entirely absent ⇒ fall back to the legacy cron rail",
-			cPresent: false, cBackupOK: false,
+			cPresent: false, cBackupOK: false, cRan: false,
 			cronPresent: true, cronCopy: true,
 			wantPresent: true, wantCopyOK: true,
 		},
 		{
 			name:     "nothing installed ⇒ all false",
-			cPresent: false, cBackupOK: false,
+			cPresent: false, cBackupOK: false, cRan: false,
 			cronPresent: false, cronCopy: false,
 			wantPresent: false, wantCopyOK: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			present, copyOK := recoveryRailStatus(tt.cPresent, tt.cBackupOK, tt.cronPresent, tt.cronCopy)
+			present, copyOK := recoveryRailStatus(tt.cPresent, tt.cBackupOK, tt.cRan, tt.cronPresent, tt.cronCopy)
 			if present != tt.wantPresent || copyOK != tt.wantCopyOK {
 				t.Fatalf("recoveryRailStatus = (present=%v, copyOK=%v), want (present=%v, copyOK=%v)",
 					present, copyOK, tt.wantPresent, tt.wantCopyOK)


### PR DESCRIPTION
Three live-found failures where the real **system-mode** install could not self-recover from teardown. All three are fixed at the code seam here, but the unit seams provably cannot reproduce the live faults (the fake launchctl is synchronous; companion/status tests inject `$HOME`) — so the **real gate is a live re-verify** (see the section at the bottom). Do **not** treat unit-green as "live faults fixed".

Entirely within the `daemon/` Go module. No deploy, no release.

---

## P0 — #101: companion DOA on system launchd (no `$HOME`) — sole out-of-band rail was dead

**Root:** `daemon/cmd/companion/main.go` `run()` called `mode.Resolve()` + `os.UserHomeDir()` and returned `1` on the home error **before** reaching `recover(...)`. A system LaunchDaemon has no `HOME` → it errored every interval → the one rail meant to restore the daemon after a full mesh wipe never ran a single pass.

**Fix (no plist/env change):** self-derive the companion folder from the companion binary's **own** path — `companion.DirFromBinary(exe)` where `root = filepath.Dir(os.Executable())`. All companion files are siblings under `Dir.root`, and that root equals the folder `For()` installs into in **both** modes (system ignores home; user runs as a LaunchAgent with home). `run()` now refuses only if it cannot resolve its own executable — `$HOME`/mode no longer enter the picture. Deliberately **no** `EvalSymlinks` (launchd execs the literal `ProgramArguments[0]`).

Also adds `Dir.RanMarker()` — `recover()` touches it on **every** completed pass (no-op and restore) as an honest "rail is firing" signal for status (feeds P2).

## P1 — #102: in-mesh binary self-restore leaves mesh 2/3 + a durable orphan (3 defects)

- **102-a — `Bootstrap failed: 5`.** `installAll` did `bootout`+`bootstrap` per role. On a LIVE mesh this races launchd: booting out the executing worker's **own** label SIGTERMs it, and `bootout(sibling)` returns before launchd finishes async teardown — an immediate `bootstrap` of either returns EIO → 2/3 fail. **Fix:** `robustReload` (bootout is idempotent → re-issue + brief backoff, retry ≤3×) in `installAll`/`ensureAll` (pure win on fresh install), plus `reinstallExceptSelf` — the lock holder reloads every label **except its own** and boots self out **last** (no self-bootstrap); the next `ensureAll` re-bootstraps self onto the new binary. No process ever bootstraps its own executing label.
- **102-b — two binaries placed.** The old mid-install self-kill released the lock; a sibling re-entered, still saw the path missing, and placed a **second** binary. 102-a restores true single-actor (holder completes while holding the lock). **Belt:** `findAdoptable` makes placement idempotent — a sibling's already-placed, signature-verified binary is **adopted** (plists repointed) instead of placing fresh.
- **102-c — orphan ensurer plist stranded.** `DiscoverAllGenerations` corroborated a dead (binary-ENOENT) plist only via the **worker** marker, so an orphan group of only the **ensurer** was dropped → left launchd-active with a missing binary. **Fix:** `isFocusdMeshOrEnsurePlist` (also matches the ensurer) used **only** on the dead-branch corroboration; the live branch stays strict worker-only (no regression). Safety unchanged: dead match still requires binary provably missing (ENOENT) **and** a focusd-specific env/argv marker; `retireGenerations` removes only exact scanned paths and `RemoveAll` stays gated by `safeToRemoveWorkdir`.

## P2 — status stops masking a degraded mesh + a dead rail

- **#status-1 — mesh total was the FOUND count.** `MeshStatus` returned `total = len(cur.Labels)` (plists found), so a lost member read `2/2 HEALTHY`. **Fix:** expected set = the roster when it carries all 3 labels (roster survives a lost plist), else the found labels; `total = len(AllRoles)` when found; `loaded` = count of expected labels loaded. A lost member now reads `2/3` → DEGRADED; `0/3` → DOWN. Pure core `meshStatusCounts` is unit-tested on Linux CI. (Rides in the #102 commit — shares `ctl_darwin.go`.)
- **#status-2 — rail health was mere presence.** `CompanionStatus` reported present=binary-on-disk / backupOK=sig-verifies, both true while the companion was DOA (#101). **Fix:** `present` now also requires the persisted launchd job is **loaded**; a new `ranRecently` checks `RanMarker` mtime is recent (<90s ≈ 3× interval). A companion that exits before `recover` never touches the marker → status honestly reads the rail as not-firing → render (present-only) **omits** the line. The rail stays render-only and never drives OVERALL (the assess guard is unchanged).

---

## MUST be live-re-verified (unit seams cannot reproduce these)

The fake launchctl is synchronous and companion/status tests inject `$HOME`, so unit-green does **not** exercise the live faults. On a real **system-mode** install, re-run the exact reproductions:

1. **#101 companion recovery on system launchd (no `$HOME`).** With a system install, take the daemon mesh fully down and confirm the companion completes a recovery pass and restores the mesh within ~1 min — i.e. the companion process is not exiting non-zero every interval. Confirm `RanMarker` mtime advances.
2. **#102-a/b in-mesh self-restore stays 3/3, single binary.** With the mesh live, `rm` the running daemon binary; confirm within one reconcile the mesh is **3/3** loaded (not 2/3), **exactly one** daemon binary exists in the workdir (no double-place), and no `Bootstrap failed: 5` in the companion/daemon logs.
3. **#102-c no stranded orphan ensurer.** After a workdir-delete/recovery cycle + a completed install, confirm **no** launchd-active plist points at a missing binary (in particular an ensurer-only orphan is swept), and generation cleanliness reads clean.
4. **#status-1** `daemon status` on a deliberately lost mesh member reads **N/3** (DEGRADED/DOWN), never `2/2 HEALTHY`.
5. **#status-2** `daemon status` on a DOA companion (job present but not firing) **omits** the recovery-rail line rather than showing it present; a healthy firing companion shows it.

## Verification done here (not a substitute for the above)
- `daemon`: `go build ./...`, `go vet ./...`, `go test -race ./...` all green; `GOOS=linux` build+vet green (non-darwin stubs); `gofmt -s -l` clean.
- `platform`: `go build ./...` green. (Two `platform` tests fail for reasons **outside** this change — an embedded-plugin-binary disguise state and a sandbox `chmod` permission limit; 0 platform files are in this diff.)
- New/updated unit tests: companion works with no `$HOME` + `DirFromBinary` invariant; `robustReload` retry + give-up; `reinstallExceptSelf` never self-bootstraps + converges; idempotent adopt; `meshStatusCounts` N/3; dead-ensurer corroboration; companion-status loaded+firing core.

## Design deviations
- **#status-2** keeps `ranRecently` as a **distinct** bool threaded through `recovery_rail.go` (folded into `railPresent` there) rather than collapsing it into `present` inside `CompanionStatus` — matches the design's "propagate the bool through recovery_rail.go + gather_darwin.go" and keeps a clean structural-vs-liveness split.
- **#status-1 MeshStatus** is committed with #102 because it shares `ctl_darwin.go` with the dead-ensurer change (no clean per-file split); called out in that commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)