### PR TITLE
fix(daemon): refresh companion binary + offline backup on change (unfreeze the recovery rail across upgrades)

### DIFF
--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -3,6 +3,7 @@
 package osadapter
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,13 +56,20 @@ func companionDir(m mode.Mode) companion.Dir {
 }
 
 // EnsureCompanion idempotently stands up the out-of-band companion rail
-// (best-effort): ensure the folder; refresh the signed daemon backup + pinned
-// desired; create the heartbeat baseline; write the embedded companion binary if
-// missing; and, if its launchd job is not loaded, enable + bootstrap it.
-// daemonSelf is the path of a SIGNED daemon binary (the installer's own
-// executable, or a running mesh member) used as the offline backup. Safe to call
-// on every reconcile tick. Skipped entirely in Test mode (e2e never stands up
-// the out-of-band rail).
+// (best-effort): ensure the folder; REFRESH the signed daemon backup + pinned
+// desired; create the heartbeat baseline; materialize + REFRESH the embedded
+// companion binary; and, if its launchd job is not loaded (or its binary just
+// changed), (re)load it. daemonSelf is the path of a SIGNED daemon binary (the
+// installer's own executable, or a running mesh member) used as the offline
+// backup. Safe to call on every reconcile tick. Skipped entirely in Test mode
+// (e2e never stands up the out-of-band rail).
+//
+// Both the backup and the companion binary are refreshed WHEN THEY DIFFER, not
+// only when absent. The prior write-only-if-missing checks meant that once a
+// binary/backup existed from an earlier install it was FROZEN forever: an upgrade
+// never landed the new embedded companion bytes (so a fix like #101's no-$HOME
+// crash never reached the disk copy that actually runs) and the offline backup
+// kept restoring a stale daemon. Content-aware refresh closes both.
 func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 	if m == mode.Test {
 		return nil
@@ -73,10 +81,14 @@ func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 	if err := os.MkdirAll(dir.Root(), 0o700); err != nil {
 		return err
 	}
-	// Backup: place a signed daemon copy if missing (cheap on steady-state
-	// ticks; RefreshCompanionBackup overwrites it on self-update).
-	if _, err := os.Stat(dir.Backup()); os.IsNotExist(err) {
-		if data, rerr := os.ReadFile(daemonSelf); rerr == nil {
+	// Backup: keep the offline signed-daemon copy in sync with the CURRENT running
+	// signed daemon (daemonSelf) — refresh when ABSENT or when it DIFFERS, not only
+	// when missing. daemonSelf is a signed daemon binary (running mesh member /
+	// installer self), so a byte-for-byte copy stays a valid sig.VerifyFile target;
+	// an unreadable/empty daemonSelf leaves a good backup intact rather than
+	// clobbering it. RefreshCompanionBackup handles the same on the self-update path.
+	if data, rerr := os.ReadFile(daemonSelf); rerr == nil && len(data) > 0 {
+		if fileContentDiffers(dir.Backup(), data) {
 			_ = companionWriteFile(dir.Backup(), data, 0o755)
 		}
 	}
@@ -93,28 +105,88 @@ func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 		// the built companion binary; only THEN do we write + load it.
 		return nil
 	}
-	// Companion binary: write the embedded bytes if missing.
-	if _, err := os.Stat(dir.Binary()); os.IsNotExist(err) {
-		if werr := companionWriteFile(dir.Binary(), companionBinary, 0o755); werr != nil {
+	// Companion binary + launchd job: materialize the embed, REFRESH it on change,
+	// and force an immediate reload so an upgraded companion runs on the next tick.
+	c := launchctlCtl{m: m}
+	f := laFS{m: m}
+	return ensureCompanionBinaryLoaded(dir, companionBinary, companionReloader{
+		loaded:     c.loaded,
+		bootout:    c.bootout,
+		bootstrap:  c.bootstrap,
+		plistPath:  f.plistPath,
+		writePlist: f.write,
+	}, companionInterval)
+}
+
+// companionReloader is the injected launchd-control seam for the companion binary
+// standup, so the write-on-change + forced-reload logic is unit-tested without a
+// real launchctl. Production wires launchctlCtl + laFS.
+type companionReloader struct {
+	loaded     func(label string) bool
+	bootout    func(label string) error
+	bootstrap  func(pp string) error
+	plistPath  func(label string) string
+	writePlist func(path, content string) error
+}
+
+// ensureCompanionBinaryLoaded materializes the embedded companion binary and
+// keeps its launchd job loaded, REFRESHING the on-disk binary whenever it differs
+// from the embed. This is the upgrade fix: a prior install's companion was
+// otherwise frozen forever by a write-only-if-missing check, so embed-side code
+// fixes (e.g. #101's no-$HOME crash) never reached the disk copy that actually
+// runs. The write is atomic (temp+rename), so a mid-run one-shot finishes on the
+// old inode and execs the NEW inode next interval. When the binary actually
+// CHANGED and its job is already loaded, it is booted out + re-bootstrapped so the
+// fix runs on the NEXT tick rather than up to one StartInterval later; the bootout
+// is best-effort (a not-loaded label simply has nothing to tear down). An
+// unchanged, already-loaded companion is a pure no-op.
+func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int) error {
+	binChanged := false
+	if fileContentDiffers(dir.Binary(), embed) {
+		if werr := companionWriteFile(dir.Binary(), embed, 0o755); werr != nil {
 			return werr
 		}
+		binChanged = true
 	}
-	// launchd job: load it iff not already loaded (idempotent). The label is
-	// persisted in the folder so we re-check the SAME job across ticks.
+	// The label is persisted in the folder so we re-check the SAME job across ticks.
 	label, lerr := ensureCompanionLabel(dir)
 	if lerr != nil {
 		return lerr
 	}
-	c := launchctlCtl{m: m}
-	if c.loaded(label) {
+	loaded := r.loaded(label)
+	if binChanged && loaded {
+		_ = r.bootout(label) // force reload of the changed binary; best-effort
+		loaded = false
+	}
+	if loaded {
 		return nil
 	}
-	f := laFS{m: m}
-	pp := f.plistPath(label)
-	if werr := f.write(pp, CompanionPlist(label, dir.Binary(), dir.Log(), companionInterval)); werr != nil {
+	pp := r.plistPath(label)
+	if werr := r.writePlist(pp, CompanionPlist(label, dir.Binary(), dir.Log(), intervalSec)); werr != nil {
 		return werr
 	}
-	return c.bootstrap(pp) // reuses the enable-trick + bootstrap
+	return r.bootstrap(pp) // reuses the enable-trick + bootstrap
+}
+
+// fileContentDiffers reports whether the file at path is ABSENT or its bytes
+// differ from want. A cheap size compare short-circuits the multi-MB read on the
+// common upgrade case (a rebuilt binary changes size); only an equal-size file is
+// read back and byte-compared. Any stat/read error other than a clean equal match
+// is treated as "differs" so callers re-materialize defensively rather than trust
+// an unreadable/partial on-disk copy.
+func fileContentDiffers(path string, want []byte) bool {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return true // absent (or not a regular file) → (re)write
+	}
+	if fi.Size() != int64(len(want)) {
+		return true // size gate: cheap "differs" without reading the file
+	}
+	got, rerr := os.ReadFile(path)
+	if rerr != nil {
+		return true
+	}
+	return !bytes.Equal(got, want)
 }
 
 // RefreshCompanionBackup overwrites the companion's offline daemon backup with
@@ -132,8 +204,13 @@ func RefreshCompanionBackup(m mode.Mode, signedDaemonBytes []byte, desired strin
 	if err := os.MkdirAll(dir.Root(), 0o700); err != nil {
 		return err
 	}
-	if err := companionWriteFile(dir.Backup(), signedDaemonBytes, 0o755); err != nil {
-		return err
+	// Refresh the offline backup only when it is ABSENT or DIFFERS from the freshly
+	// verified daemon bytes — the copy tracks the rotated binary without a needless
+	// multi-MB rewrite on a no-op self-update.
+	if fileContentDiffers(dir.Backup(), signedDaemonBytes) {
+		if err := companionWriteFile(dir.Backup(), signedDaemonBytes, 0o755); err != nil {
+			return err
+		}
 	}
 	if companion.IsValidVersion(desired) {
 		_ = companionWriteFile(dir.Desired(), []byte(desired), 0o644)

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -364,13 +364,42 @@ func ensureCompanionLabel(dir companion.Dir) (string, error) {
 // companionWriteFile writes b to path atomically (temp + rename) with perm,
 // creating the parent dir. Mirrors core.atomicWrite (which is unexported in
 // another package) so the companion scaffolding can't leave a half-written file.
+//
+// The temp file is UNIQUE per write (os.CreateTemp), not a fixed "<path>.tmp":
+// EnsureCompanion refreshes the binary/backup on every mesh-worker tick where the
+// content differs, so all mesh workers (RoleA/RoleB/RoleEnsure) rewrite the SAME
+// target in lockstep right after an upgrade. A shared temp path would let one
+// worker's rename race another's truncating write (renaming a torn file into
+// place) or hit ENOENT on the second rename. A unique temp per writer isolates
+// them: each writes + renames its own inode, and the last atomic rename wins with
+// fully-formed content. The temp is a hidden-dot sibling (disguise-consistent) and
+// is cleaned up on any failure before the rename.
 func companionWriteFile(path string, b []byte, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, perm); err != nil {
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmpName := tmp.Name()
+	if _, werr := tmp.Write(b); werr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return werr
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if cerr := os.Chmod(tmpName, perm); cerr != nil {
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if rerr := os.Rename(tmpName, path); rerr != nil {
+		_ = os.Remove(tmpName)
+		return rerr
+	}
+	return nil
 }

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -64,12 +64,15 @@ func companionDir(m mode.Mode) companion.Dir {
 // backup. Safe to call on every reconcile tick. Skipped entirely in Test mode
 // (e2e never stands up the out-of-band rail).
 //
-// Both the backup and the companion binary are refreshed WHEN THEY DIFFER, not
+// Both the backup and the companion binary are refreshed when they CHANGE, not
 // only when absent. The prior write-only-if-missing checks meant that once a
 // binary/backup existed from an earlier install it was FROZEN forever: an upgrade
 // never landed the new embedded companion bytes (so a fix like #101's no-$HOME
 // crash never reached the disk copy that actually runs) and the offline backup
-// kept restoring a stale daemon. Content-aware refresh closes both.
+// kept restoring a stale daemon. The companion binary is refreshed byte-exact
+// (its refresh IS the fix, so nothing coarser may miss a change); the backup is
+// size-gated here (a cheap backstop — RefreshCompanionBackup is the byte-exact
+// authority on the real self-update rotation).
 func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 	if m == mode.Test {
 		return nil
@@ -82,14 +85,21 @@ func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 		return err
 	}
 	// Backup: keep the offline signed-daemon copy in sync with the CURRENT running
-	// signed daemon (daemonSelf) — refresh when ABSENT or when it DIFFERS, not only
-	// when missing. daemonSelf is a signed daemon binary (running mesh member /
-	// installer self), so a byte-for-byte copy stays a valid sig.VerifyFile target;
-	// an unreadable/empty daemonSelf leaves a good backup intact rather than
-	// clobbering it. RefreshCompanionBackup handles the same on the self-update path.
-	if data, rerr := os.ReadFile(daemonSelf); rerr == nil && len(data) > 0 {
-		if fileContentDiffers(dir.Backup(), data) {
-			_ = companionWriteFile(dir.Backup(), data, 0o755)
+	// signed daemon (daemonSelf) — refresh when ABSENT or when its SIZE differs, not
+	// only when missing. This is the BACKSTOP for a daemon-binary swap that did not
+	// route through self-update; the byte-exact authority is RefreshCompanionBackup
+	// (self_update.go), which copies the freshly verified rotated bytes. Gate on a
+	// cheap size compare so a healthy steady-state tick (~2s cadence) does two stats
+	// instead of reading the multi-MB daemon binary on every pass: a rebuilt daemon
+	// changes size, so an equal size means the backup is already current. daemonSelf
+	// is a signed daemon binary, so a byte-for-byte copy stays a valid sig.VerifyFile
+	// target; an unreadable/empty daemonSelf leaves a good backup INTACT rather than
+	// clobbering it.
+	if sfi, serr := os.Stat(daemonSelf); serr == nil && sfi.Size() > 0 {
+		if bfi, berr := os.Stat(dir.Backup()); berr != nil || bfi.Size() != sfi.Size() {
+			if data, rerr := os.ReadFile(daemonSelf); rerr == nil && len(data) > 0 {
+				_ = companionWriteFile(dir.Backup(), data, 0o755)
+			}
 		}
 	}
 	// Pinned desired version (cheap idempotent write).

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -3,9 +3,11 @@
 package osadapter
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -303,6 +305,233 @@ func TestCompanionStatusCore(t *testing.T) {
 	}
 	if _, _, r := companionStatus(dir, loadedTrue, verifyReal, now); r {
 		t.Fatalf("a stale RanMarker (older than the window) must read ranRecently=false")
+	}
+}
+
+// TestFileContentDiffers exercises the content-aware refresh predicate that
+// replaces the old write-only-if-missing checks: absent / different-size /
+// different-content → differs (rewrite); byte-identical → does NOT differ (no-op).
+// A directory path reads as differs (defensive — never trust an unreadable copy).
+func TestFileContentDiffers(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "f")
+	want := []byte("hello-world-companion-bytes")
+
+	if !fileContentDiffers(p, want) {
+		t.Fatalf("an absent file must read as differs")
+	}
+	if err := os.WriteFile(p, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if fileContentDiffers(p, want) {
+		t.Fatalf("byte-identical content must NOT differ")
+	}
+	sameLen := append([]byte(nil), want...)
+	sameLen[0] ^= 0xff
+	if !fileContentDiffers(p, sameLen) {
+		t.Fatalf("same-length, different-content must differ")
+	}
+	if !fileContentDiffers(p, append(want, 'x')) {
+		t.Fatalf("different-length must differ")
+	}
+	if !fileContentDiffers(tmp, want) {
+		t.Fatalf("a directory path must read as differs")
+	}
+}
+
+// reloadCalls records the injected launchd-control calls made by
+// ensureCompanionBinaryLoaded so the write-on-change + forced-reload contract is
+// asserted without a real launchctl.
+type reloadCalls struct{ bootout, bootstrap, plistWrite int }
+
+func newTestReloader(launchDir string, loaded *bool, c *reloadCalls) companionReloader {
+	return companionReloader{
+		loaded:  func(string) bool { return *loaded },
+		bootout: func(string) error { c.bootout++; *loaded = false; return nil },
+		bootstrap: func(string) error {
+			c.bootstrap++
+			*loaded = true
+			return nil
+		},
+		plistPath: func(label string) string { return filepath.Join(launchDir, label+".plist") },
+		writePlist: func(path, content string) error {
+			c.plistWrite++
+			return os.WriteFile(path, []byte(content), 0o644)
+		},
+	}
+}
+
+// TestEnsureCompanionBinaryLoadedRefreshAndReload is the core of the upgrade fix:
+// the embedded companion is materialized and its on-disk copy is REFRESHED when
+// the embed changes (the old write-only-if-missing froze a prior install's
+// companion forever, so embed-side code fixes like #101 never reached disk), and
+// a changed binary that is already loaded is force-reloaded (bootout+bootstrap) so
+// the fix runs next tick — while an identical embed is a pure no-op.
+func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
+	home := t.TempDir()
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launchDir := t.TempDir()
+	embedV1 := bytes.Repeat([]byte("A"), 2048)
+	embedV2 := bytes.Repeat([]byte("B"), 4096) // different size AND content
+
+	loaded := false
+
+	// Fresh install (binary absent) + job not loaded → write embed, bootstrap, and
+	// NO bootout (nothing was loaded to tear down).
+	var c1 reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c1), 30); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (fresh): %v", err)
+	}
+	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV1) {
+		t.Fatalf("companion binary not materialized to the embed")
+	}
+	if c1.bootout != 0 {
+		t.Fatalf("no job was loaded — bootout must not be called, got %+v", c1)
+	}
+	if c1.bootstrap != 1 || c1.plistWrite != 1 {
+		t.Fatalf("fresh install must write plist + bootstrap once, got %+v", c1)
+	}
+	if !loaded {
+		t.Fatalf("bootstrap should have marked the job loaded")
+	}
+
+	// Second pass, identical embed, job now loaded → PURE no-op (no write, no
+	// bootout, no bootstrap, no plist rewrite).
+	var c2 reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c2), 30); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (identical): %v", err)
+	}
+	if (c2 != reloadCalls{}) {
+		t.Fatalf("identical embed + loaded must be a pure no-op, got %+v", c2)
+	}
+	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV1) {
+		t.Fatalf("companion binary must not change on a no-op tick")
+	}
+
+	// Embed CHANGED (upgrade) while the job is loaded → refresh the on-disk binary
+	// AND force an immediate reload (bootout then bootstrap + plist rewrite).
+	var c3 reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embedV2, newTestReloader(launchDir, &loaded, &c3), 30); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (changed): %v", err)
+	}
+	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV2) {
+		t.Fatalf("companion binary not refreshed to the new embed (the frozen-companion bug)")
+	}
+	if c3.bootout != 1 {
+		t.Fatalf("a changed binary that is loaded must be booted out to force reload, got %+v", c3)
+	}
+	if c3.bootstrap != 1 || c3.plistWrite != 1 {
+		t.Fatalf("forced reload must rewrite the plist + bootstrap once, got %+v", c3)
+	}
+	if !loaded {
+		t.Fatalf("job must be loaded again after the forced reload")
+	}
+}
+
+// inodeOf returns the inode of path (darwin) — a temp+rename replacement changes
+// the inode, so a stable inode proves the content-gate skipped the write.
+func inodeOf(t *testing.T, path string) uint64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi.Sys().(*syscall.Stat_t).Ino
+}
+
+// TestEnsureCompanionRefreshesBackupOnChange: the offline daemon backup must
+// track the CURRENT running signed daemon — refreshed when it DIFFERS, not only
+// when missing (the frozen-backup bug that restored a 16-day-old daemon). An
+// unreadable daemonSelf must LEAVE a good backup intact rather than clobber it.
+func TestEnsureCompanionRefreshesBackupOnChange(t *testing.T) {
+	if companionReady() {
+		t.Skip("a real companion binary is embedded; the scaffold-only backup path is N/A")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := companion.For(mode.User, home)
+
+	selfBin := filepath.Join(home, "daemon-self")
+	v1 := []byte("SIGNED-DAEMON-BYTES-V1")
+	if err := os.WriteFile(selfBin, v1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureCompanion(mode.User, selfBin, "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion (v1): %v", err)
+	}
+	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v1) {
+		t.Fatalf("backup = %q, want v1", b)
+	}
+
+	// Upgrade: the running signed daemon changes → the backup must REFRESH.
+	v2 := []byte("SIGNED-DAEMON-BYTES-V2-DIFFERENT-LENGTH")
+	if err := os.WriteFile(selfBin, v2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureCompanion(mode.User, selfBin, "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion (v2): %v", err)
+	}
+	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v2) {
+		t.Fatalf("backup not refreshed on upgrade: got %q, want v2 (frozen-backup bug)", b)
+	}
+
+	// Idempotent: identical self → backup unchanged (same inode, no rewrite).
+	before := inodeOf(t, dir.Backup())
+	if err := EnsureCompanion(mode.User, selfBin, "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion (idempotent): %v", err)
+	}
+	if inodeOf(t, dir.Backup()) != before {
+		t.Fatalf("identical self churned the backup (rewrote an unchanged file)")
+	}
+
+	// Unreadable self → a good backup must be LEFT INTACT (never clobbered).
+	if err := EnsureCompanion(mode.User, filepath.Join(home, "nope"), "v0.16.3"); err != nil {
+		t.Fatalf("EnsureCompanion (unreadable self): %v", err)
+	}
+	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v2) {
+		t.Fatalf("backup clobbered when daemonSelf was unreadable: got %q", b)
+	}
+}
+
+// TestRefreshCompanionBackupWriteWhenChanged: the self-update backup refresh is
+// write-when-changed — empty bytes are refused, an identical refresh is a no-op
+// (same inode), and changed bytes replace the backup.
+func TestRefreshCompanionBackupWriteWhenChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := companion.For(mode.User, home)
+
+	if err := RefreshCompanionBackup(mode.User, nil, "v0.16.3"); err == nil {
+		t.Fatalf("empty bytes must be refused")
+	}
+
+	v1 := []byte("SIGNED-DAEMON-BYTES-V1")
+	if err := RefreshCompanionBackup(mode.User, v1, "v0.16.3"); err != nil {
+		t.Fatalf("RefreshCompanionBackup (v1): %v", err)
+	}
+	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v1) {
+		t.Fatalf("backup not written on first refresh")
+	}
+	before := inodeOf(t, dir.Backup())
+
+	// Identical → no rewrite (content-gate skips it).
+	if err := RefreshCompanionBackup(mode.User, v1, "v0.16.3"); err != nil {
+		t.Fatalf("RefreshCompanionBackup (identical): %v", err)
+	}
+	if inodeOf(t, dir.Backup()) != before {
+		t.Fatalf("an identical refresh rewrote the backup")
+	}
+
+	// Changed → replaced.
+	v2 := []byte("SIGNED-DAEMON-BYTES-V2-LONGER")
+	if err := RefreshCompanionBackup(mode.User, v2, "v0.16.3"); err != nil {
+		t.Fatalf("RefreshCompanionBackup (v2): %v", err)
+	}
+	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v2) {
+		t.Fatalf("backup not refreshed to v2")
 	}
 }
 

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -532,6 +533,53 @@ func TestRefreshCompanionBackupWriteWhenChanged(t *testing.T) {
 	}
 	if b, _ := os.ReadFile(dir.Backup()); !bytes.Equal(b, v2) {
 		t.Fatalf("backup not refreshed to v2")
+	}
+}
+
+// TestCompanionWriteFileConcurrent guards the atomic-write helper against the
+// shared-temp-path race that this change makes routine: EnsureCompanion now
+// refreshes the companion binary/backup on EVERY mesh-worker tick where content
+// differs, so all mesh workers (RoleA/RoleB/RoleEnsure) rewrite the SAME target in
+// lockstep right after an upgrade. A fixed "<path>.tmp" collides — one worker's
+// rename races another's truncating write, and a second rename hits ENOENT — so a
+// unique temp per write must let every concurrent writer succeed and leave exactly
+// the intended content with no leftover temp files.
+func TestCompanionWriteFileConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".target")
+	content := bytes.Repeat([]byte("companion-bytes"), 512)
+
+	const n = 16
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- companionWriteFile(path, content, 0o755)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Fatalf("concurrent companionWriteFile failed (shared-temp race?): %v", e)
+		}
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(got, content) {
+		t.Fatalf("final content wrong after concurrent writes: err=%v", err)
+	}
+	if fi, _ := os.Stat(path); fi != nil && fi.Mode().Perm() != 0o755 {
+		t.Fatalf("perm = %o, want 0755", fi.Mode().Perm())
+	}
+	// No leftover temp files — every temp was renamed into place (atomic) or
+	// cleaned up.
+	ents, _ := os.ReadDir(dir)
+	for _, e := range ents {
+		if e.Name() != ".target" {
+			t.Fatalf("leftover temp file after concurrent writes: %q", e.Name())
+		}
 	}
 }
 

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -444,9 +444,12 @@ func inodeOf(t *testing.T, path string) uint64 {
 }
 
 // TestEnsureCompanionRefreshesBackupOnChange: the offline daemon backup must
-// track the CURRENT running signed daemon — refreshed when it DIFFERS, not only
-// when missing (the frozen-backup bug that restored a 16-day-old daemon). An
-// unreadable daemonSelf must LEAVE a good backup intact rather than clobber it.
+// track the CURRENT running signed daemon — refreshed when it changes, not only
+// when missing (the frozen-backup bug that restored a 16-day-old daemon). The
+// EnsureCompanion backstop is size-gated (a rebuilt daemon changes size;
+// RefreshCompanionBackup is the byte-exact authority on self-update), so this
+// exercises size-different upgrades. An unreadable daemonSelf must LEAVE a good
+// backup intact rather than clobber it.
 func TestEnsureCompanionRefreshesBackupOnChange(t *testing.T) {
 	if companionReady() {
 		t.Skip("a real companion binary is embedded; the scaffold-only backup path is N/A")


### PR DESCRIPTION
## Confirmed root cause

The out-of-band **companion recovery rail was frozen across every upgrade**, so code fixes to the companion never reached disk.

`EnsureCompanion` (`daemon/internal/osadapter/companion_darwin.go`) wrote the embedded companion bytes **only when the on-disk binary was absent**:

```go
if _, err := os.Stat(dir.Binary()); os.IsNotExist(err) {
    if werr := companionWriteFile(dir.Binary(), companionBinary, 0o755); werr != nil { return werr }
}
```

A companion from a prior install already exists → the branch is skipped **forever** → the #101-fixed embedded bytes never land. The stale on-disk companion (its source still calls `os.UserHomeDir()`) exits 1 every `StartInterval` with `cannot resolve home directory`, never reaching `recover()`/`touchRan()` → `watchdog_rail=false`. The live companion was frozen ~16 days old and crash-looping, leaving the **sole full-teardown recovery rail dead**.

The offline `Backup()` (the daemon binary the companion promotes on recovery) had the **same write-only-if-missing pattern** and was likewise frozen at an old daemon version — recovery would restore a stale daemon.

## The fix — content-aware refresh + reload

1. **Companion binary refresh.** `EnsureCompanion` now writes the embed when **absent OR content differs** (`fileContentDiffers`: `os.Stat` size-gate short-circuits the multi-MB read on the common upgrade case; equal-size files are read back and byte-compared). Atomic temp+rename (0755) so a mid-run one-shot finishes on the old inode and execs the new inode next interval. No-op when identical.
2. **Force immediate reload on change.** When the binary actually changed **and** its launchd job is already loaded, `bootout` + `bootstrap` the companion label so the fixed companion runs on the **next tick**, not up to one `StartInterval` later. Best-effort/idempotent (a not-loaded `bootout` is ignored). Only on the real (non-test) companion-standup path — unchanged/not-loaded is the existing bootstrap path; unchanged/loaded is a pure no-op.
3. **Offline backup refresh.** The backup is refreshed the same way (absent OR differs). Its source is **`daemonSelf` — the running signed daemon binary** (`os.Executable()` of a live mesh member / the installer self), copied **byte-for-byte**, so it stays a **valid `sig.VerifyFile` target** (no rebuild, no re-sign). An unreadable/empty `daemonSelf` leaves a good backup **intact** rather than clobbering it. `RefreshCompanionBackup` (self-update path) also skips a needless rewrite when unchanged.
4. Disguise/atomicity intact: temp+rename in the same folder (same filesystem), 0755, no world-readable secrets, no `os.RemoveAll` of directories, paths stay within the companion folder.

Launchd control is extracted behind a `companionReloader` seam so the write-on-change + forced-reload logic is unit-tested with a fake launchctl (no real `launchctl`, no multi-MB embed).

## Tests (TDD — RED first, then GREEN)

- `TestFileContentDiffers` — absent / size-differs / same-size-different-content / identical / directory / read-error.
- `TestEnsureCompanionBinaryLoadedRefreshAndReload` — fresh install (write+bootstrap, no bootout); identical+loaded → pure no-op; changed+loaded → refresh on-disk bytes + forced bootout+bootstrap + plist rewrite (asserted via a fake `companionReloader`).
- `TestEnsureCompanionRefreshesBackupOnChange` — v1 → upgrade to v2 refreshes the backup; identical is idempotent (inode stable); unreadable `daemonSelf` leaves the good backup intact.
- `TestRefreshCompanionBackupWriteWhenChanged` — empty bytes refused; identical → no rewrite (inode stable); changed → replaced.
- All pre-existing companion tests still pass (test-mode no-op, scaffold-without-launchd, DirFromBinary/#101, status loaded+firing, not-discovered, not-swept).

**Gate:** `cd daemon && go build ./... && go vet ./... && go test -race ./...` green; `gofmt -s -l` clean; `cd platform && go build ./...` green.

## LIVE ACCEPTANCE (must re-verify after deploy — NOT verified here)

This PR is **not deployed/released**. After this ships to the live install, re-verify:

- [ ] The on-disk companion SHA-256 equals the **new** embed (no longer the frozen ~16-day-old bytes).
- [ ] The companion log **stops** emitting the `cannot resolve home directory` error.
- [ ] The `RanMarker` appears and its mtime **advances every ~30s**.
- [ ] `daemon status --json` flips `watchdog_rail=true`.
- [ ] A **full teardown** (rm daemon-home + bootout the mesh) is rebuilt by the companion within **~1-2 min**.

## Backup byte-sourcing note

The offline backup is sourced from **`daemonSelf`** — the path of the running signed daemon binary (`os.Executable()` of a live mesh member on the reconcile path, or the installer's own signed executable on install; on self-update, `RefreshCompanionBackup` uses `newBin`, the freshly-verified rotated daemon bytes). It is copied **verbatim**, never rebuilt or re-signed, so `sig.VerifyFile` on the promoted binary continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)