### PR TITLE
ci(daemon-release): skip publish when release already exists (stop spurious red X on master)

### DIFF
--- a/.github/workflows/daemon-release.yml
+++ b/.github/workflows/daemon-release.yml
@@ -65,7 +65,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.t.outputs.tag }}" \
-            --title "${{ steps.t.outputs.tag }}" \
+          TAG="${{ steps.t.outputs.tag }}"
+          # The deploy flow publishes the signed release manually (so it can
+          # install + verify immediately), then pushes the tag — which fires
+          # this workflow. If the release already exists, `gh release create`
+          # 422s and the job goes red on master for no real reason. Treat an
+          # existing release as a successful no-op (never clobber the already
+          # published + verified asset); only create when it's genuinely absent
+          # (e.g. a pure tag push with no prior manual publish).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists (published during deploy); CI publish is a no-op — skipping."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
             --notes "Signed daemon release (Ed25519, embedded-key verified). macOS supported; linux/windows future-ready." \
             /tmp/out/*


### PR DESCRIPTION
## What

The `Daemon Release` workflow shows a **red `release` check on master** for every daemon tag (`daemon-v0.7.0` … `daemon-v0.8.5`).

## Why

The deploy flow publishes the signed daemon release **manually** (so it can install + verify the exact bytes immediately), then pushes the `daemon-v*` tag. That tag push fires this workflow, whose `gh release create <tag>` then hits the **already-existing release → HTTP 422 → the Publish step fails**. Build+sign succeeds; only the redundant publish fails. No functional impact (the real releases are published, signed, VERIFY_OK, and deployed live) — but it leaves a spurious red X on master.

## Fix

Make the publish **idempotent**: if the release already exists, treat it as a successful no-op (and never clobber the already-published+verified asset); only `gh release create` when the release is genuinely absent (e.g. a pure tag push with no prior manual publish). Green whether or not the deploy pre-published.

## Test plan
- [x] YAML edit only; no build/logic change
- [ ] After merge, re-run the `daemon-v0.8.5` release workflow → expect green (release exists → skip)