### PR TITLE
fix(daemon): recovery cleanliness — steady-state dead-gen retirement + companion rail self-sustain (#106)

### DIFF
--- a/daemon/cmd/companion/main.go
+++ b/daemon/cmd/companion/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/companion"
@@ -75,10 +76,29 @@ func execWatchdog(bin, desired string) error {
 
 // execWatchdogCtx is the timeout-bounded core of execWatchdog, split out with an
 // explicit context + timeout so the kill-on-timeout behavior is unit-tested without
-// waiting minutes. On timeout, exec.CommandContext SIGKILLs the child and Run
+// waiting minutes. On timeout, the child (and its subtree) is SIGKILLed and Run
 // returns a non-nil error.
+//
+// The watchdog rebuild itself shells out to launchctl (robustReload) — if the hang is
+// IN one of those grandchildren (a stuck/unresponsive launchd is exactly the scenario
+// this timeout guards), killing only the direct child would orphan the grandchild. So
+// the child is put in its OWN process group (Setpgid) and Cancel SIGKILLs the WHOLE
+// group, reaping the subtree. WaitDelay bounds Run() so a grandchild inheriting the
+// (nil ⇒ /dev/null) std handles can never make the wait hang after the kill.
 func execWatchdogCtx(ctx context.Context, bin, desired string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	return exec.CommandContext(ctx, bin, "watchdog", "-v", desired).Run()
+	cmd := exec.CommandContext(ctx, bin, "watchdog", "-v", desired)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Negative PID → signal the whole process group (the child + its launchctl
+		// grandchildren). Best-effort: fall back to the single child if the group
+		// signal fails (e.g. the child already exited).
+		if perr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); perr != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+	return cmd.Run()
 }

--- a/daemon/cmd/companion/main.go
+++ b/daemon/cmd/companion/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"time"
@@ -51,13 +52,33 @@ func run() int {
 	return 0
 }
 
+// watchdogExecTimeout bounds the companion's blocking watchdog handoff (#106-b3).
+// A genuinely hung `daemon watchdog` would otherwise keep the companion one-shot
+// alive forever — launchd never fires a fresh pass (the wedged-rail class #106-b2
+// heals daemon-side), and the rail's own cadence stalls. A few minutes is well above
+// the ~1-minute worst-case healthy rebuild, so it never cuts off a legitimate run;
+// past it, the process is killed and the one-shot exits, freeing launchd to re-run
+// the companion next interval.
+const watchdogExecTimeout = 3 * time.Minute
+
 // execWatchdog runs the promoted daemon binary's idempotent watchdog rebuild:
 //
 //	<bin> watchdog -v <desired>
 //
 // The watchdog no-ops when the mesh is already complete (the anti-fight guard),
 // so a false-positive staleness costs at most one harmless run. A child run +
-// wait is enough; launchd re-runs the companion on the next interval.
+// wait is enough; launchd re-runs the companion on the next interval. Bounded by
+// watchdogExecTimeout (#106-b3) so a hung rebuild can't wedge the one-shot forever.
 func execWatchdog(bin, desired string) error {
-	return exec.Command(bin, "watchdog", "-v", desired).Run()
+	return execWatchdogCtx(context.Background(), bin, desired, watchdogExecTimeout)
+}
+
+// execWatchdogCtx is the timeout-bounded core of execWatchdog, split out with an
+// explicit context + timeout so the kill-on-timeout behavior is unit-tested without
+// waiting minutes. On timeout, exec.CommandContext SIGKILLs the child and Run
+// returns a non-nil error.
+func execWatchdogCtx(ctx context.Context, bin, desired string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return exec.CommandContext(ctx, bin, "watchdog", "-v", desired).Run()
 }

--- a/daemon/cmd/companion/recover.go
+++ b/daemon/cmd/companion/recover.go
@@ -35,6 +35,16 @@ func recover(
 	verify func(path string) (bool, error),
 	execDaemon func(bin, desired string) error,
 ) error {
+	// #106-b1: stamp the RanMarker at the START of every pass — BEFORE the (possibly
+	// long, blocking) watchdog handoff — IN ADDITION to the end-touch below. The
+	// marker means "a recovery pass FIRED" (which is exactly what rail-liveness
+	// needs); without this, a legitimately long rebuild leaves the marker frozen at
+	// the PREVIOUS pass's mtime, so status reads the rail as not-firing (ranRecently
+	// false) even while the companion is actively recovering. A companion that dies
+	// BEFORE reaching here (e.g. the #101 no-$HOME crash in main, before recover ran)
+	// still never stamps it, so a genuinely dead rail honestly reads not-firing.
+	touchRan(dir, now)
+
 	// 1. Heartbeat fresh → daemon alive → no-op. A missing heartbeat (Stat
 	//    error) falls through to the restore path (treated as stale).
 	if fi, err := os.Stat(dir.Heartbeat()); err == nil {
@@ -69,11 +79,13 @@ func recover(
 	return nil
 }
 
-// touchRan sets the RanMarker's mtime to now (best-effort), recording that this
-// recovery pass COMPLETED. status treats the rail as firing only when this marker
-// is recent — so a companion that dies before reaching a completion point (the
-// #101 no-$HOME class exited before recover ran at all) never touches it and the
-// rail honestly reads as not-firing. Only the mtime matters; content is empty.
+// touchRan sets the RanMarker's mtime to now (best-effort), recording that a
+// recovery pass FIRED. It is stamped at the START of every pass (#106-b1) AND on
+// completion, so the marker stays fresh even DURING a legitimately long watchdog
+// rebuild — status treats the rail as firing only when this marker is recent. A
+// companion that dies before reaching recover() at all (the #101 no-$HOME class
+// exited in main before this ran) never touches it, so a genuinely dead rail still
+// honestly reads not-firing. Only the mtime matters; content is empty.
 func touchRan(dir companion.Dir, now time.Time) {
 	p := dir.RanMarker()
 	if err := os.Chtimes(p, now, now); err != nil && errors.Is(err, fs.ErrNotExist) {

--- a/daemon/cmd/companion/recover_test.go
+++ b/daemon/cmd/companion/recover_test.go
@@ -243,6 +243,48 @@ func TestRecoverStaleInvalidDesiredNoVerify(t *testing.T) {
 	}
 }
 
+// TestRecoverStampsRanMarkerBeforeHandoff (#106-b1): the RanMarker must be stamped
+// at the START of a pass — BEFORE the (blocking) watchdog handoff — not only after
+// it returns. Otherwise a legitimately long rebuild leaves the marker frozen and
+// status reads the rail as not-firing. A fake execDaemon that BLOCKS proves the
+// marker already exists while the handoff is in flight (which can only be the
+// start-touch, since the end-touch runs after execDaemon returns).
+func TestRecoverStampsRanMarkerBeforeHandoff(t *testing.T) {
+	dir := companionTestDir(t)
+	staleMtime := time.Now().Add(-companion.StaleThreshold - time.Minute)
+	writeFile(t, dir.Heartbeat(), "")
+	if err := os.Chtimes(dir.Heartbeat(), staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir.Desired(), goodDesired)
+	writeFile(t, dir.Backup(), "SIGNED-DAEMON")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- recover(dir, time.Now(),
+			func(string) (bool, error) { return true, nil },
+			func(bin, desired string) error {
+				close(entered) // the blocking handoff has begun
+				<-release      // ...and stays in flight until the test releases it
+				return nil
+			},
+		)
+	}()
+
+	<-entered
+	// The handoff is BLOCKED; the RanMarker must ALREADY be stamped (start-touch).
+	_, statErr := os.Stat(dir.RanMarker())
+	close(release)
+	if statErr != nil {
+		t.Fatalf("RanMarker not stamped before the blocking handoff (b1 regression): %v", statErr)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("recover = %v, want nil", err)
+	}
+}
+
 // TestRecoverMissingHeartbeatTreatedStale: with NO heartbeat file at all (a
 // freshly-wiped state), recover treats the daemon as down and restores.
 func TestRecoverMissingHeartbeatTreatedStale(t *testing.T) {

--- a/daemon/cmd/companion/watchdog_exec_test.go
+++ b/daemon/cmd/companion/watchdog_exec_test.go
@@ -30,7 +30,9 @@ func TestExecWatchdogCtxTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatalf("a hung watchdog must be killed and surface an error, got nil")
 	}
-	if elapsed > 5*time.Second {
+	// Must return FAR sooner than the 30s sleep (proves the deadline fired). Generous
+	// upper bound tolerates the WaitDelay safety cap + loaded CI, still << 30s.
+	if elapsed > 15*time.Second {
 		t.Fatalf("execWatchdogCtx did not honor the timeout (elapsed %v, sleep was 30s)", elapsed)
 	}
 }
@@ -43,7 +45,9 @@ func TestExecWatchdogCtxSucceedsWithinTimeout(t *testing.T) {
 	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := execWatchdogCtx(context.Background(), script, "v0.1.0", 3*time.Second); err != nil {
+	// A generous timeout: this asserts a fast run is NOT cut off — the deadline must
+	// never be the bottleneck, even under heavy parallel -race process-spawn latency.
+	if err := execWatchdogCtx(context.Background(), script, "v0.1.0", 60*time.Second); err != nil {
 		t.Fatalf("a fast watchdog run within the timeout must succeed, got %v", err)
 	}
 }

--- a/daemon/cmd/companion/watchdog_exec_test.go
+++ b/daemon/cmd/companion/watchdog_exec_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestExecWatchdogCtxTimesOut (#106-b3): a genuinely hung watchdog must be KILLED
+// once the timeout elapses so the companion one-shot exits (freeing launchd's
+// cadence) instead of wedging forever. We point the "daemon" at a script that
+// ignores its args and sleeps far longer than the timeout; execWatchdogCtx must
+// return a non-nil error PROMPTLY (well under the sleep), proving the context
+// deadline killed the child.
+func TestExecWatchdogCtxTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "hang")
+	// `exec sleep 30` so the script process BECOMES sleep (same PID) and
+	// exec.CommandContext's SIGKILL reaps it directly (no orphaned child).
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	err := execWatchdogCtx(context.Background(), script, "v0.1.0", 150*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("a hung watchdog must be killed and surface an error, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("execWatchdogCtx did not honor the timeout (elapsed %v, sleep was 30s)", elapsed)
+	}
+}
+
+// TestExecWatchdogCtxSucceedsWithinTimeout: a fast, well-behaved watchdog run
+// returns nil without being cut off by the timeout.
+func TestExecWatchdogCtxSucceedsWithinTimeout(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "ok")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := execWatchdogCtx(context.Background(), script, "v0.1.0", 3*time.Second); err != nil {
+		t.Fatalf("a fast watchdog run within the timeout must succeed, got %v", err)
+	}
+}

--- a/daemon/cmd/daemon/deadgen.go
+++ b/daemon/cmd/daemon/deadgen.go
@@ -1,0 +1,34 @@
+package main
+
+import "github.com/eliteGoblin/focusd/daemon/internal/core"
+
+// dueEveryTicks reports whether a per-tick-throttled action should fire on the
+// given 1-based winning-tick counter: true on the 1st tick (prompt) and every
+// `every` ticks after. Mirrors the executor's maybeReapForeign throttle math so
+// the steady-state dead-generation retirement (#106-a) shares that cadence. A
+// non-positive `every` degrades to "always" (defensive; never used in prod).
+func dueEveryTicks(counter, every int) bool {
+	return every <= 0 || (counter-1)%every == 0
+}
+
+// steadyDeadGenRetireDue advances the winning-tick counter and reports whether the
+// steady-state dead-generation retirement (#106-a) should run THIS reconcile tick.
+// It is the SINGLE decision point (pure → unit-tested) for the loop wiring:
+//
+//   - it fires ONLY for the non-test platform-lock HOLDER — a standby (lock loser)
+//     never retires (mirroring maybeReapForeign, so two daemons never fight), and
+//     test mode is excluded (the retire's mode.SupportRoot(Test,…) would resolve to
+//     the REAL ~/Library — the storage-separation hazard the reaper is also gated
+//     off for);
+//   - it is throttled to core.ReapEveryTicks — the first winning tick (prompt) then
+//     once per that many ticks (~10s), the same cadence as the foreign-platform reap.
+//
+// A non-eligible tick neither advances the counter nor fires, so a daemon that only
+// briefly holds the lock still gets a prompt retire on its FIRST winning tick.
+func steadyDeadGenRetireDue(isTest, holdsLock bool, ticks int) (fire bool, next int) {
+	if isTest || !holdsLock {
+		return false, ticks // frozen until eligible
+	}
+	next = ticks + 1
+	return dueEveryTicks(next, core.ReapEveryTicks), next
+}

--- a/daemon/cmd/daemon/deadgen_test.go
+++ b/daemon/cmd/daemon/deadgen_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/eliteGoblin/focusd/daemon/internal/core"
+)
+
+// TestDueEveryTicks pins the throttle math shared with the executor's reap:
+// fire on the 1st tick (prompt) and then every `every` ticks.
+func TestDueEveryTicks(t *testing.T) {
+	every := core.ReapEveryTicks
+	var fired []int
+	for tick := 1; tick <= 3*every; tick++ {
+		if dueEveryTicks(tick, every) {
+			fired = append(fired, tick)
+		}
+	}
+	want := []int{1, 1 + every, 1 + 2*every}
+	if len(fired) != len(want) {
+		t.Fatalf("fired ticks = %v, want %v", fired, want)
+	}
+	for i := range want {
+		if fired[i] != want[i] {
+			t.Fatalf("fired ticks = %v, want %v", fired, want)
+		}
+	}
+}
+
+// TestSteadyDeadGenRetireDue (#106-a) verifies the reconcile-loop gate:
+//   - a lock LOSER never fires and never advances the counter;
+//   - TEST mode never fires (the retire would touch the real support root);
+//   - the non-test HOLDER fires on its FIRST winning tick (prompt) and then once per
+//     core.ReapEveryTicks (throttled).
+func TestSteadyDeadGenRetireDue(t *testing.T) {
+	// Lock loser: never fires, counter frozen at 0.
+	if fire, next := steadyDeadGenRetireDue(false /*isTest*/, false /*holdsLock*/, 0); fire || next != 0 {
+		t.Fatalf("lock loser must never fire (fire=%v next=%d)", fire, next)
+	}
+
+	// Test mode holder: never fires, counter frozen.
+	if fire, next := steadyDeadGenRetireDue(true /*isTest*/, true /*holdsLock*/, 7); fire || next != 7 {
+		t.Fatalf("test mode must never fire (fire=%v next=%d)", fire, next)
+	}
+
+	// Non-test holder: prompt on the first winning tick, then throttled.
+	ticks := 0
+	fireCount := 0
+	firstWinTick := -1
+	for i := 0; i < 3*core.ReapEveryTicks; i++ {
+		var fire bool
+		fire, ticks = steadyDeadGenRetireDue(false, true, ticks)
+		if fire {
+			fireCount++
+			if firstWinTick < 0 {
+				firstWinTick = i
+			}
+		}
+	}
+	if firstWinTick != 0 {
+		t.Fatalf("holder must retire PROMPTLY on its first winning tick, first fire at loop %d", firstWinTick)
+	}
+	if fireCount != 3 {
+		t.Fatalf("holder must fire once per ReapEveryTicks (3 times over 3 windows), got %d", fireCount)
+	}
+	if ticks != 3*core.ReapEveryTicks {
+		t.Fatalf("counter must advance once per winning tick, got %d", ticks)
+	}
+}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -497,6 +497,11 @@ func loop(args []string, once bool) int {
 	// companionHeartbeatInterval). Zero value ⇒ the first tick touches immediately.
 	var lastHeartbeat time.Time
 
+	// deadGenTicks is the winning-tick counter for the steady-state dead-generation
+	// retirement (#106-a). It advances only while this daemon holds the platform lock
+	// (non-test), throttling the retire to the foreign-platform reap cadence.
+	var deadGenTicks int
+
 	tick := func() {
 		// Steady-state ticks no longer emit a per-tick "tick" beacon (FEATURE 24 /
 		// HF-disguise): non-steady actions are already logged by the executor, and
@@ -558,6 +563,26 @@ func loop(args []string, once bool) int {
 					log.Warn("touch-heartbeat", "err", herr)
 				} else {
 					lastHeartbeat = now
+				}
+			}
+			// #106-a: steady-state DEAD-generation retirement. The install/rebuild
+			// path retires dead (deleted-binary) generations once, but a single miss
+			// otherwise leaves a launchd-active zombie forever (other_generations=1,
+			// DEGRADED). Give it a throttled steady-state path: only the platform-lock
+			// HOLDER, on the foreign-platform reap cadence, retires DEAD-ONLY
+			// generations (never live: a self-update in-place rotation transiently looks
+			// like two LIVE generations, but a DEAD gen binary is provably gone, so a
+			// dead-only reaper can never fight a self-update). keepBinaryPath is our OWN
+			// (always-present, possibly re-materialized) binary, so the empty-keep guard
+			// can never wipe everything.
+			var retireDead bool
+			retireDead, deadGenTicks = steadyDeadGenRetireDue(spec.Mode == mode.Test, e.HoldsPlatformLock(), deadGenTicks)
+			if retireDead {
+				home, _ := os.UserHomeDir()
+				if n, rerr := osadapter.RetireDeadGenerations(spec.Mode, self, mode.SupportRoot(spec.Mode, home)); rerr != nil {
+					log.Warn("retire-dead-generations", "err", rerr)
+				} else if n > 0 {
+					log.Info("retired dead generation(s)", "count", n)
 				}
 			}
 		}

--- a/daemon/internal/companion/companion.go
+++ b/daemon/internal/companion/companion.go
@@ -125,16 +125,28 @@ func (d Dir) Log() string {
 	return filepath.Join(d.root, ".com.apple.MobileAsset.log")
 }
 
-// RanMarker is touched by the companion on EVERY completed recovery pass (both
-// the fresh-heartbeat no-op path and the post-restore path). Its mtime is the
-// rail's OWN liveness signal — distinct from the daemon's Heartbeat, which the
-// DAEMON writes. status treats the rail as firing only when this marker is recent;
-// a companion that dies BEFORE completing a pass (e.g. the #101 no-$HOME crash)
-// never touches it, so a silently-dead rail honestly reads as not-firing instead
-// of being trusted on mere on-disk presence. Its CONTENT is irrelevant — only the
-// mtime matters.
+// RanMarker is touched by the companion at the START of every recovery pass
+// (#106-b1) and again on completion — so it means "a pass FIRED" and stays fresh
+// even DURING a legitimately long watchdog rebuild. Its mtime is the rail's OWN
+// liveness signal — distinct from the daemon's Heartbeat, which the DAEMON writes.
+// status treats the rail as firing only when this marker is recent; a companion
+// that dies BEFORE reaching recover() (e.g. the #101 no-$HOME crash in main) never
+// touches it, so a silently-dead rail honestly reads as not-firing instead of being
+// trusted on mere on-disk presence. Its CONTENT is irrelevant — only the mtime matters.
 func (d Dir) RanMarker() string {
 	return filepath.Join(d.root, ".com.apple.MobileAsset.ran")
+}
+
+// RearmMarker records when the DAEMON last replaced a WEDGED companion instance
+// (#106-b2): a companion one-shot stuck ALIVE after a blocking watchdog handoff
+// keeps its launchd job loaded, so launchd never fires a fresh pass and the RanMarker
+// freezes. The daemon then bootout+bootstraps the companion label to replace the
+// wedged instance; this marker's mtime THROTTLES that re-arm to once per firing
+// window so it can never churn a legitimately in-progress rebuild. Distinct from the
+// RanMarker (which the COMPANION writes): this one only the DAEMON writes. Its
+// CONTENT is irrelevant — only the mtime matters.
+func (d Dir) RearmMarker() string {
+	return filepath.Join(d.root, ".com.apple.MobileAsset.rearm")
 }
 
 // versionTagRE is a minimal semver-tag check (KISS), local to this package so

--- a/daemon/internal/core/executor.go
+++ b/daemon/internal/core/executor.go
@@ -305,10 +305,13 @@ func (e *Executor) Tick(ctx context.Context) (Action, error) {
 	return act, applyErr
 }
 
-// reapEveryTicks throttles the continuous foreign-platform reap so the winner
+// ReapEveryTicks throttles the continuous foreign-platform reap so the winner
 // scans the process table roughly once per this many reconcile ticks rather than
-// every tick. At the ~2s worker cadence this is ~10s.
-const reapEveryTicks = 5
+// every tick. At the ~2s worker cadence this is ~10s. Exported so the daemon's
+// reconcile loop can throttle its steady-state dead-generation retirement (#106-a)
+// on the SAME cadence — one shared source of truth for the winner's ~10s backstop
+// sweeps (foreign-platform reap + dead-generation retire).
+const ReapEveryTicks = 5
 
 // maybeReapForeign reaps orphaned platform processes when this executor is the
 // lock WINNER and has a live platform to exempt. Structurally incapable of
@@ -320,9 +323,9 @@ func (e *Executor) maybeReapForeign() {
 		return
 	}
 	e.reapTick++
-	// Reap on the first winning tick, then every reapEveryTicks after — prompt
+	// Reap on the first winning tick, then every ReapEveryTicks after — prompt
 	// on startup, throttled thereafter.
-	if (e.reapTick-1)%reapEveryTicks != 0 {
+	if (e.reapTick-1)%ReapEveryTicks != 0 {
 		return
 	}
 	pl, ok := e.Plat.(interface{ RunningPID() int })

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -125,7 +125,7 @@ func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 		bootstrap:  c.bootstrap,
 		plistPath:  f.plistPath,
 		writePlist: f.write,
-	}, companionInterval)
+	}, companionInterval, time.Now())
 }
 
 // companionReloader is the injected launchd-control seam for the companion binary
@@ -139,6 +139,16 @@ type companionReloader struct {
 	writePlist func(path, content string) error
 }
 
+// companionReloaderCtl adapts a companionReloader's func fields to the controller
+// interface robustReload expects (loaded/bootstrap/bootout), so the wedged-instance
+// re-arm (#106-b2) reuses the SAME async-EIO-absorbing retry loop the mesh install
+// uses (manager.go robustReload) instead of a bespoke bootout+bootstrap.
+type companionReloaderCtl struct{ r companionReloader }
+
+func (c companionReloaderCtl) loaded(label string) bool   { return c.r.loaded(label) }
+func (c companionReloaderCtl) bootstrap(pp string) error  { return c.r.bootstrap(pp) }
+func (c companionReloaderCtl) bootout(label string) error { return c.r.bootout(label) }
+
 // ensureCompanionBinaryLoaded materializes the embedded companion binary and
 // keeps its launchd job loaded, REFRESHING the on-disk binary whenever it differs
 // from the embed. This is the upgrade fix: a prior install's companion was
@@ -150,7 +160,18 @@ type companionReloader struct {
 // fix runs on the NEXT tick rather than up to one StartInterval later; the bootout
 // is best-effort (a not-loaded label simply has nothing to tear down). An
 // unchanged, already-loaded companion is a pure no-op.
-func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int) error {
+//
+// #106-b2 (the companion's missing self-heal): a companion one-shot can get STUCK
+// ALIVE after its blocking watchdog handoff. Its launchd job then reads loaded=true,
+// so launchd never fires a fresh instance and the RanMarker freezes — the rail is
+// dead while the daemon is healthy. The existing !loaded re-arm never triggers. So
+// EVEN WHEN loaded==true, if the RanMarker is stale beyond companionRanRecentlyWindow
+// (the companion fired then froze), the DAEMON replaces the wedged instance:
+// bootout+bootstrap via robustReload. The actor is the DAEMON and the target is the
+// COMPANION (different processes), so the #102-a self-SIGTERM hazard does NOT apply.
+// A RearmMarker mtime throttles this to once per window so it can't churn a
+// legitimately in-progress (slow) rebuild.
+func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int, now time.Time) error {
 	binChanged := false
 	if fileContentDiffers(dir.Binary(), embed) {
 		if werr := companionWriteFile(dir.Binary(), embed, 0o755); werr != nil {
@@ -168,6 +189,19 @@ func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionRel
 		_ = r.bootout(label) // force reload of the changed binary; best-effort
 		loaded = false
 	}
+	// #106-b2: replace a WEDGED-but-loaded companion (fired then froze). Gated to a
+	// STALE-but-present RanMarker (b1 stamps it at pass start, so a wedged instance
+	// leaves an EXISTING, frozen marker) and throttled by the RearmMarker so a
+	// genuinely-slow rebuild is not churned every tick. A binChanged reload above
+	// already re-armed the job, so this only runs when we did NOT just reload.
+	if loaded && companionRanStale(dir, now) && !companionRearmedRecently(dir, now) {
+		pp := r.plistPath(label)
+		if werr := r.writePlist(pp, CompanionPlist(label, dir.Binary(), dir.Log(), intervalSec)); werr != nil {
+			return werr
+		}
+		touchCompanionRearm(dir, now) // stamp the throttle BEFORE the (retrying) reload
+		return robustReload(companionReloaderCtl{r}, label, pp, time.Sleep)
+	}
 	if loaded {
 		return nil
 	}
@@ -176,6 +210,44 @@ func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionRel
 		return werr
 	}
 	return r.bootstrap(pp) // reuses the enable-trick + bootstrap
+}
+
+// companionRanStale reports whether the companion RanMarker EXISTS but is older than
+// companionRanRecentlyWindow as of now — the wedged-alive signal (#106-b2): b1 stamps
+// the marker at pass START, so a companion that fired and then FROZE in a blocking
+// handoff leaves an existing, frozen marker. A MISSING marker is deliberately NOT
+// stale here: it means the companion has not completed its first pass yet (a fresh
+// bootstrap) or crash-loops before b1's touch — neither is the wedged-alive case the
+// re-arm targets, and re-bootstrapping would not help.
+func companionRanStale(dir companion.Dir, now time.Time) bool {
+	fi, err := os.Stat(dir.RanMarker())
+	if err != nil {
+		return false // missing → not the wedged-alive case
+	}
+	return now.Sub(fi.ModTime()) >= companionRanRecentlyWindow
+}
+
+// companionRearmedRecently reports whether the daemon re-armed the companion (#106-b2)
+// within the last companionRanRecentlyWindow — the throttle so a wedge re-bootstrap
+// runs at most once per window (not every ~2s tick). A missing marker means never
+// re-armed → not throttled.
+func companionRearmedRecently(dir companion.Dir, now time.Time) bool {
+	fi, err := os.Stat(dir.RearmMarker())
+	if err != nil {
+		return false
+	}
+	return now.Sub(fi.ModTime()) < companionRanRecentlyWindow
+}
+
+// touchCompanionRearm stamps the RearmMarker's mtime to now (best-effort) so the
+// #106-b2 wedge re-arm is throttled to once per window. Mirrors touchRan: create the
+// file if absent, then align its mtime to the injected clock for deterministic tests.
+func touchCompanionRearm(dir companion.Dir, now time.Time) {
+	p := dir.RearmMarker()
+	if _, err := os.Stat(p); err != nil {
+		_ = companionWriteFile(p, nil, 0o644)
+	}
+	_ = os.Chtimes(p, now, now)
 }
 
 // fileContentDiffers reports whether the file at path is ABSENT or its bytes

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -125,7 +125,7 @@ func EnsureCompanion(m mode.Mode, daemonSelf, desired string) error {
 		bootstrap:  c.bootstrap,
 		plistPath:  f.plistPath,
 		writePlist: f.write,
-	}, companionInterval, time.Now())
+	}, companionInterval, time.Now(), time.Sleep)
 }
 
 // companionReloader is the injected launchd-control seam for the companion binary
@@ -172,7 +172,7 @@ func (c companionReloaderCtl) bootout(label string) error { return c.r.bootout(l
 // companionWedgeWindow is deliberately > the companion's own watchdog timeout (b3), so
 // a legitimately-in-progress rebuild is never mistaken for wedged; a RearmMarker mtime
 // throttles this to once per window on top of that.
-func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int, now time.Time) error {
+func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int, now time.Time, sleep func(time.Duration)) error {
 	binChanged := false
 	if fileContentDiffers(dir.Binary(), embed) {
 		if werr := companionWriteFile(dir.Binary(), embed, 0o755); werr != nil {
@@ -200,8 +200,19 @@ func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionRel
 		if werr := r.writePlist(pp, CompanionPlist(label, dir.Binary(), dir.Log(), intervalSec)); werr != nil {
 			return werr
 		}
-		touchCompanionRearm(dir, now) // stamp the throttle BEFORE the (retrying) reload
-		return robustReload(companionReloaderCtl{r}, label, pp, time.Sleep)
+		// Stamp the throttle BEFORE the (retrying) reload so a concurrent mesh worker
+		// (A and B both run EnsureCompanion) can't double-fire the re-arm, and a
+		// SUCCESSFUL re-arm is throttled for the whole window (giving the fresh
+		// companion time to touch RanMarker). On FAILURE, CLEAR it (Copilot review): a
+		// re-arm that didn't succeed must not throttle retries for the full window and
+		// leave the rail dead — the next eligible tick retries instead (robustReload's
+		// own backoff already bounds the launchctl churn on a persistently bad launchd).
+		touchCompanionRearm(dir, now)
+		if rerr := robustReload(companionReloaderCtl{r}, label, pp, sleep); rerr != nil {
+			clearCompanionRearm(dir)
+			return rerr
+		}
+		return nil
 	}
 	if loaded {
 		return nil
@@ -264,6 +275,13 @@ func touchCompanionRearm(dir companion.Dir, now time.Time) {
 		_ = companionWriteFile(p, nil, 0o644)
 	}
 	_ = os.Chtimes(p, now, now)
+}
+
+// clearCompanionRearm removes the RearmMarker (best-effort) so a FAILED wedge re-arm
+// (#106-b2) does not throttle retries for the whole window — the next eligible tick
+// re-attempts rather than leaving the rail dead on a re-arm that never succeeded.
+func clearCompanionRearm(dir companion.Dir) {
+	_ = os.Remove(dir.RearmMarker())
 }
 
 // fileContentDiffers reports whether the file at path is ABSENT or its bytes

--- a/daemon/internal/osadapter/companion_darwin.go
+++ b/daemon/internal/osadapter/companion_darwin.go
@@ -165,12 +165,13 @@ func (c companionReloaderCtl) bootout(label string) error { return c.r.bootout(l
 // ALIVE after its blocking watchdog handoff. Its launchd job then reads loaded=true,
 // so launchd never fires a fresh instance and the RanMarker freezes — the rail is
 // dead while the daemon is healthy. The existing !loaded re-arm never triggers. So
-// EVEN WHEN loaded==true, if the RanMarker is stale beyond companionRanRecentlyWindow
-// (the companion fired then froze), the DAEMON replaces the wedged instance:
+// EVEN WHEN loaded==true, if the RanMarker is stale beyond companionWedgeWindow (the
+// companion fired then froze), the DAEMON replaces the wedged instance:
 // bootout+bootstrap via robustReload. The actor is the DAEMON and the target is the
 // COMPANION (different processes), so the #102-a self-SIGTERM hazard does NOT apply.
-// A RearmMarker mtime throttles this to once per window so it can't churn a
-// legitimately in-progress (slow) rebuild.
+// companionWedgeWindow is deliberately > the companion's own watchdog timeout (b3), so
+// a legitimately-in-progress rebuild is never mistaken for wedged; a RearmMarker mtime
+// throttles this to once per window on top of that.
 func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionReloader, intervalSec int, now time.Time) error {
 	binChanged := false
 	if fileContentDiffers(dir.Binary(), embed) {
@@ -212,31 +213,46 @@ func ensureCompanionBinaryLoaded(dir companion.Dir, embed []byte, r companionRel
 	return r.bootstrap(pp) // reuses the enable-trick + bootstrap
 }
 
+// companionWedgeWindow is how long the companion RanMarker may stay frozen before
+// the daemon treats the companion as WEDGED and replaces it (#106-b2). It is
+// DELIBERATELY LONGER than the companion's own watchdog handoff timeout (cmd/companion
+// watchdogExecTimeout, ~3min) PLUS one StartInterval (~30s): b1 stamps the marker only
+// at pass START, so during a legitimately long (but healthy) rebuild the marker freezes
+// for up to that timeout. Keying the wedge decision off the shorter status window (90s)
+// would make the daemon bootout a still-progressing rebuild at 90s → kill → relaunch →
+// kill (a livelock). Above this window, b3's own timeout has ALREADY bounded any
+// genuine handoff hang and the companion has had a fresh pass to touch the marker — so
+// a marker still frozen past it is a truly wedged instance (loaded but not firing) the
+// daemon must replace. This is a SEPARATE concern from companionRanRecentlyWindow (the
+// status-display flap window), so it is its own constant even where the numbers differ.
+const companionWedgeWindow = 5 * time.Minute
+
 // companionRanStale reports whether the companion RanMarker EXISTS but is older than
-// companionRanRecentlyWindow as of now — the wedged-alive signal (#106-b2): b1 stamps
-// the marker at pass START, so a companion that fired and then FROZE in a blocking
-// handoff leaves an existing, frozen marker. A MISSING marker is deliberately NOT
-// stale here: it means the companion has not completed its first pass yet (a fresh
-// bootstrap) or crash-loops before b1's touch — neither is the wedged-alive case the
-// re-arm targets, and re-bootstrapping would not help.
+// companionWedgeWindow as of now — the wedged-alive signal (#106-b2): b1 stamps the
+// marker at pass START, so a companion that fired and then FROZE (loaded but not firing)
+// leaves an existing, long-frozen marker. A MISSING marker is deliberately NOT stale
+// here: it means the companion has not completed its first pass yet (a fresh bootstrap)
+// or crash-loops before b1's touch — neither is the wedged-alive case the re-arm targets,
+// and re-bootstrapping would not help.
 func companionRanStale(dir companion.Dir, now time.Time) bool {
 	fi, err := os.Stat(dir.RanMarker())
 	if err != nil {
 		return false // missing → not the wedged-alive case
 	}
-	return now.Sub(fi.ModTime()) >= companionRanRecentlyWindow
+	return now.Sub(fi.ModTime()) >= companionWedgeWindow
 }
 
 // companionRearmedRecently reports whether the daemon re-armed the companion (#106-b2)
-// within the last companionRanRecentlyWindow — the throttle so a wedge re-bootstrap
-// runs at most once per window (not every ~2s tick). A missing marker means never
-// re-armed → not throttled.
+// within the last companionWedgeWindow — the throttle so a wedge re-bootstrap runs at
+// most once per window (not every ~2s tick), giving the freshly-bootstrapped companion
+// a full window to complete a pass (and touch the marker) before another re-arm. A
+// missing marker means never re-armed → not throttled.
 func companionRearmedRecently(dir companion.Dir, now time.Time) bool {
 	fi, err := os.Stat(dir.RearmMarker())
 	if err != nil {
 		return false
 	}
-	return now.Sub(fi.ModTime()) < companionRanRecentlyWindow
+	return now.Sub(fi.ModTime()) < companionWedgeWindow
 }
 
 // touchCompanionRearm stamps the RearmMarker's mtime to now (best-effort) so the

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -383,7 +383,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Fresh install (binary absent) + job not loaded → write embed, bootstrap, and
 	// NO bootout (nothing was loaded to tear down).
 	var c1 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c1), 30); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c1), 30, time.Now()); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (fresh): %v", err)
 	}
 	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV1) {
@@ -402,7 +402,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Second pass, identical embed, job now loaded → PURE no-op (no write, no
 	// bootout, no bootstrap, no plist rewrite).
 	var c2 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c2), 30); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c2), 30, time.Now()); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (identical): %v", err)
 	}
 	if (c2 != reloadCalls{}) {
@@ -415,7 +415,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Embed CHANGED (upgrade) while the job is loaded → refresh the on-disk binary
 	// AND force an immediate reload (bootout then bootstrap + plist rewrite).
 	var c3 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV2, newTestReloader(launchDir, &loaded, &c3), 30); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV2, newTestReloader(launchDir, &loaded, &c3), 30, time.Now()); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (changed): %v", err)
 	}
 	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV2) {
@@ -429,6 +429,103 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	}
 	if !loaded {
 		t.Fatalf("job must be loaded again after the forced reload")
+	}
+}
+
+// TestEnsureCompanionBinaryLoadedRearmsWedged (#106-b2): a companion one-shot stuck
+// ALIVE after a blocking watchdog handoff keeps its launchd job loaded, so launchd
+// never fires a fresh pass and the RanMarker freezes. When the marker is loaded==true
+// but STALE beyond the window, the daemon replaces the wedged instance
+// (bootout+bootstrap via robustReload). A loaded job with a FRESH marker is a pure
+// no-op, and the re-arm is THROTTLED to once per window so it can't churn a
+// legitimately in-progress rebuild.
+func TestEnsureCompanionBinaryLoadedRearmsWedged(t *testing.T) {
+	home := t.TempDir()
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launchDir := t.TempDir()
+	embed := bytes.Repeat([]byte("C"), 2048)
+	now := time.Now()
+
+	// Materialize the binary on disk (byte-exact to the embed) so later ticks see
+	// binChanged=false and the ONLY driver is the RanMarker staleness.
+	if err := companionWriteFile(dir.Binary(), embed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	loaded := true // the job is loaded (a wedged one-shot stays loaded)
+
+	// Case 1: loaded + FRESH RanMarker → pure no-op (the companion is firing).
+	if err := os.WriteFile(dir.RanMarker(), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dir.RanMarker(), now, now); err != nil {
+		t.Fatal(err)
+	}
+	var cFresh reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cFresh), 30, now); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (fresh marker): %v", err)
+	}
+	if (cFresh != reloadCalls{}) {
+		t.Fatalf("loaded + fresh RanMarker must be a pure no-op, got %+v", cFresh)
+	}
+
+	// Case 2: loaded + STALE RanMarker → replace the wedged instance (bootout +
+	// bootstrap + plist rewrite) via robustReload.
+	stale := now.Add(-companionRanRecentlyWindow - time.Minute)
+	if err := os.Chtimes(dir.RanMarker(), stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	var cStale reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cStale), 30, now); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (stale marker): %v", err)
+	}
+	if cStale.bootout != 1 || cStale.bootstrap != 1 || cStale.plistWrite != 1 {
+		t.Fatalf("stale RanMarker must re-arm the wedged companion (bootout+bootstrap+plist), got %+v", cStale)
+	}
+	if !loaded {
+		t.Fatalf("companion must be loaded again after the re-arm")
+	}
+	// The re-arm stamped the throttle marker.
+	if _, err := os.Stat(dir.RearmMarker()); err != nil {
+		t.Fatalf("re-arm must stamp the RearmMarker throttle: %v", err)
+	}
+
+	// Case 3: THROTTLE — the marker is STILL stale, but we just re-armed, so a second
+	// pass within the window must NOT churn (no further bootout/bootstrap).
+	var cThrottled reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cThrottled), 30, now); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (throttled): %v", err)
+	}
+	if (cThrottled != reloadCalls{}) {
+		t.Fatalf("re-arm must be throttled to once per window, got %+v", cThrottled)
+	}
+}
+
+// TestEnsureCompanionBinaryLoadedMissingMarkerNoRearm (#106-b2 guard): a MISSING
+// RanMarker (fresh bootstrap not yet fired, or a crash-loop before b1's start-touch)
+// must NOT trigger the wedge re-arm — that case is not "wedged alive" and
+// re-bootstrapping would not help. A loaded job with no marker stays a pure no-op.
+func TestEnsureCompanionBinaryLoadedMissingMarkerNoRearm(t *testing.T) {
+	home := t.TempDir()
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launchDir := t.TempDir()
+	embed := bytes.Repeat([]byte("D"), 2048)
+	if err := companionWriteFile(dir.Binary(), embed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	loaded := true // loaded, but NO RanMarker on disk
+
+	var c reloadCalls
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &c), 30, time.Now()); err != nil {
+		t.Fatalf("ensureCompanionBinaryLoaded (missing marker): %v", err)
+	}
+	if (c != reloadCalls{}) {
+		t.Fatalf("a missing RanMarker must NOT trigger the wedge re-arm, got %+v", c)
 	}
 }
 

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -471,9 +471,10 @@ func TestEnsureCompanionBinaryLoadedRearmsWedged(t *testing.T) {
 		t.Fatalf("loaded + fresh RanMarker must be a pure no-op, got %+v", cFresh)
 	}
 
-	// Case 2: loaded + STALE RanMarker → replace the wedged instance (bootout +
-	// bootstrap + plist rewrite) via robustReload.
-	stale := now.Add(-companionRanRecentlyWindow - time.Minute)
+	// Case 2: loaded + STALE RanMarker (older than the wedge window, which exceeds
+	// the companion's own watchdog timeout so a healthy long rebuild is never killed)
+	// → replace the wedged instance (bootout + bootstrap + plist rewrite) via robustReload.
+	stale := now.Add(-companionWedgeWindow - time.Minute)
 	if err := os.Chtimes(dir.RanMarker(), stale, stale); err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/internal/osadapter/companion_test.go
+++ b/daemon/internal/osadapter/companion_test.go
@@ -383,7 +383,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Fresh install (binary absent) + job not loaded → write embed, bootstrap, and
 	// NO bootout (nothing was loaded to tear down).
 	var c1 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c1), 30, time.Now()); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c1), 30, time.Now(), noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (fresh): %v", err)
 	}
 	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV1) {
@@ -402,7 +402,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Second pass, identical embed, job now loaded → PURE no-op (no write, no
 	// bootout, no bootstrap, no plist rewrite).
 	var c2 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c2), 30, time.Now()); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV1, newTestReloader(launchDir, &loaded, &c2), 30, time.Now(), noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (identical): %v", err)
 	}
 	if (c2 != reloadCalls{}) {
@@ -415,7 +415,7 @@ func TestEnsureCompanionBinaryLoadedRefreshAndReload(t *testing.T) {
 	// Embed CHANGED (upgrade) while the job is loaded → refresh the on-disk binary
 	// AND force an immediate reload (bootout then bootstrap + plist rewrite).
 	var c3 reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embedV2, newTestReloader(launchDir, &loaded, &c3), 30, time.Now()); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embedV2, newTestReloader(launchDir, &loaded, &c3), 30, time.Now(), noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (changed): %v", err)
 	}
 	if got, _ := os.ReadFile(dir.Binary()); !bytes.Equal(got, embedV2) {
@@ -464,7 +464,7 @@ func TestEnsureCompanionBinaryLoadedRearmsWedged(t *testing.T) {
 		t.Fatal(err)
 	}
 	var cFresh reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cFresh), 30, now); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cFresh), 30, now, noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (fresh marker): %v", err)
 	}
 	if (cFresh != reloadCalls{}) {
@@ -479,7 +479,7 @@ func TestEnsureCompanionBinaryLoadedRearmsWedged(t *testing.T) {
 		t.Fatal(err)
 	}
 	var cStale reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cStale), 30, now); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cStale), 30, now, noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (stale marker): %v", err)
 	}
 	if cStale.bootout != 1 || cStale.bootstrap != 1 || cStale.plistWrite != 1 {
@@ -496,7 +496,7 @@ func TestEnsureCompanionBinaryLoadedRearmsWedged(t *testing.T) {
 	// Case 3: THROTTLE — the marker is STILL stale, but we just re-armed, so a second
 	// pass within the window must NOT churn (no further bootout/bootstrap).
 	var cThrottled reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cThrottled), 30, now); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &cThrottled), 30, now, noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (throttled): %v", err)
 	}
 	if (cThrottled != reloadCalls{}) {
@@ -522,11 +522,56 @@ func TestEnsureCompanionBinaryLoadedMissingMarkerNoRearm(t *testing.T) {
 	loaded := true // loaded, but NO RanMarker on disk
 
 	var c reloadCalls
-	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &c), 30, time.Now()); err != nil {
+	if err := ensureCompanionBinaryLoaded(dir, embed, newTestReloader(launchDir, &loaded, &c), 30, time.Now(), noSleep); err != nil {
 		t.Fatalf("ensureCompanionBinaryLoaded (missing marker): %v", err)
 	}
 	if (c != reloadCalls{}) {
 		t.Fatalf("a missing RanMarker must NOT trigger the wedge re-arm, got %+v", c)
+	}
+}
+
+// TestEnsureCompanionBinaryLoadedRearmClearsThrottleOnFailure (#106-b2, Copilot review):
+// if the wedge re-arm's robustReload ultimately FAILS, the RearmMarker throttle must be
+// CLEARED so the next eligible tick retries — otherwise a failed re-arm would leave the
+// rail dead for the whole window. A SUCCESSFUL re-arm keeps the marker (throttled).
+func TestEnsureCompanionBinaryLoadedRearmClearsThrottleOnFailure(t *testing.T) {
+	home := t.TempDir()
+	dir := companion.For(mode.User, home)
+	if err := os.MkdirAll(dir.Root(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launchDir := t.TempDir()
+	embed := bytes.Repeat([]byte("E"), 2048)
+	now := time.Now()
+	if err := companionWriteFile(dir.Binary(), embed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Wedged: loaded + a STALE RanMarker.
+	if err := os.WriteFile(dir.RanMarker(), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := now.Add(-companionWedgeWindow - time.Minute)
+	if err := os.Chtimes(dir.RanMarker(), stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	loaded := true
+
+	// A reloader whose bootstrap ALWAYS fails → robustReload exhausts its attempts and
+	// returns an error. noSleep keeps the retry loop instant.
+	failing := companionReloader{
+		loaded:     func(string) bool { return loaded },
+		bootout:    func(string) error { loaded = false; return nil },
+		bootstrap:  func(string) error { return errSentinel("synthetic bootstrap failure") },
+		plistPath:  func(label string) string { return filepath.Join(launchDir, label+".plist") },
+		writePlist: func(path, content string) error { return os.WriteFile(path, []byte(content), 0o644) },
+	}
+	err := ensureCompanionBinaryLoaded(dir, embed, failing, 30, now, noSleep)
+	if err == nil {
+		t.Fatalf("a failed wedge re-arm must surface the error")
+	}
+	// The throttle marker must be CLEARED so the next tick can retry.
+	if _, statErr := os.Stat(dir.RearmMarker()); !os.IsNotExist(statErr) {
+		t.Fatalf("a FAILED re-arm must clear the throttle marker (stat err = %v)", statErr)
 	}
 }
 

--- a/daemon/internal/osadapter/ctl_darwin.go
+++ b/daemon/internal/osadapter/ctl_darwin.go
@@ -523,6 +523,42 @@ func RetireOtherGenerations(m mode.Mode, keepBinaryPath, supportRoot string) (in
 		c.bootout, os.Remove, pkillBinary, killGenerationPlatform(supportRoot), os.RemoveAll), nil
 }
 
+// RetireDeadGenerations is the STEADY-STATE, DEAD-ONLY counterpart of
+// RetireOtherGenerations (#106-a). RetireOtherGenerations is contractually a
+// one-shot at install/rebuild: it ALSO retires LIVE "other" generations, and a
+// self-update's in-place path rotation transiently looks like two LIVE generations,
+// so running it continuously would fight an in-flight self-update. RetireDeadGenerations
+// closes the steady-state gap without reopening that hazard by retiring ONLY DEAD
+// generations — the deleted-binary zombies a workdir-delete/recovery cycle leaves
+// launchd-active (permanent other_generations=1 → DEGRADED once the one-shot install/
+// rebuild retire misses them). A dead generation's binary is PROVABLY GONE
+// (fs.ErrNotExist), so it can NEVER be a peer of a self-update, whose two transient
+// generations BOTH have PRESENT binaries — a dead-only reaper is therefore safe to
+// call on every reconcile tick.
+//
+// It discovers every generation, DISCARDS the live slice (passes nil live into the
+// shared retireGenerations core), and retires only the dead slice — reusing the
+// IDENTICAL safeToRemoveWorkdir belt, minBinPathLen/pkill guard, and platform-kill
+// seam. keepBinaryPath is the running daemon's OWN (always-present) binary, so the
+// empty-keep guard can never wipe everything, and a dead binary can never equal it.
+// Count-only return (never the disguised labels/paths); a discovery failure is
+// surfaced as err so the caller can log-and-continue (best-effort).
+func RetireDeadGenerations(m mode.Mode, keepBinaryPath, supportRoot string) (int, error) {
+	if keepBinaryPath == "" {
+		return 0, fmt.Errorf("retire dead: keepBinaryPath must not be empty")
+	}
+	_, dead, err := DiscoverAllGenerations(m, sig.VerifyFile)
+	if err != nil {
+		return 0, err
+	}
+	c := launchctlCtl{m: m}
+	// DEAD-ONLY: an empty (nil) live slice is the safety crux — no live generation
+	// is ever retired, so this can never fight a self-update's transient two-live
+	// generations. Only the dead (deleted-binary) zombies are torn down.
+	return retireGenerations(nil, dead, keepBinaryPath, supportRoot,
+		c.bootout, os.Remove, pkillBinary, killGenerationPlatform(supportRoot), os.RemoveAll), nil
+}
+
 // CountOtherGenerations is the READ-ONLY counterpart of RetireOtherGenerations
 // (FEATURE 17 generation cleanliness / `daemon status`): it reuses the SAME
 // DiscoverAllGenerations scan but retires NOTHING, returning only how many

--- a/daemon/internal/osadapter/ctl_other.go
+++ b/daemon/internal/osadapter/ctl_other.go
@@ -60,6 +60,12 @@ func DiscoverAllGenerations(mode.Mode, Verifier) ([]Generation, []DeadGeneration
 // to do" rather than surfacing ErrUnsupported on every install.
 func RetireOtherGenerations(mode.Mode, string, string) (int, error) { return 0, nil }
 
+// RetireDeadGenerations is a no-op on non-darwin (no launchd mesh / dead
+// generations to retire). Returns (0, nil) so the reconcile loop's steady-state
+// dead-generation retirement (#106-a) wires uniformly without surfacing
+// ErrUnsupported every tick.
+func RetireDeadGenerations(mode.Mode, string, string) (int, error) { return 0, nil }
+
 // CountOtherGenerations is unsupported on non-darwin (no launchd mesh to scan).
 // It returns ErrUnsupported so `daemon status` buckets generation cleanliness to
 // "unknown" (never a fabricated "clean" 0) off-platform.

--- a/daemon/internal/osadapter/generations_test.go
+++ b/daemon/internal/osadapter/generations_test.go
@@ -506,6 +506,91 @@ func TestRetireGenerationsSkipsPkillOnShortPath(t *testing.T) {
 	}
 }
 
+// TestRetireDeadGenerationsCoreDeadOnly (#106-a) pins the exact call
+// RetireDeadGenerations makes into the shared core: an EMPTY live slice + a dead
+// slice → ONLY the dead generations are retired (a live generation, had one been
+// passed, could never be touched because the live slice is nil). This is the
+// safety crux that makes continuous use safe against a self-update.
+func TestRetireDeadGenerationsCoreDeadOnly(t *testing.T) {
+	mkdir := func(p string) string {
+		t.Helper()
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	root := t.TempDir()
+	keepBin := filepath.Join(mkdir(filepath.Join(root, ".keep")), "keep.bin")
+	deadWd1 := mkdir(filepath.Join(root, ".dead1"))
+	deadWd2 := mkdir(filepath.Join(root, ".dead2"))
+	dead := []DeadGeneration{
+		{BinaryPath: filepath.Join(deadWd1, "d1.bin"), Workdir: deadWd1,
+			Labels: []string{"d1a", "d1b", "d1c"}, PlistPaths: []string{"/p/d1a", "/p/d1b", "/p/d1c"}},
+		{BinaryPath: filepath.Join(deadWd2, "d2.bin"), Workdir: deadWd2,
+			Labels: []string{"d2a"}, PlistPaths: []string{"/p/d2a"}},
+	}
+	f := &fakeRetire{}
+	// nil live slice — exactly what RetireDeadGenerations passes.
+	n := retireGenerations(nil, dead, keepBin, root,
+		func(l string) error { f.bootedOut = append(f.bootedOut, l); return nil },
+		func(p string) error { f.removedPlist = append(f.removedPlist, p); return nil },
+		func(b string) { f.killed = append(f.killed, b) },
+		func(string) {},
+		func(d string) error { f.removedAll = append(f.removedAll, d); return nil },
+	)
+	if n != 2 {
+		t.Fatalf("dead-only retire count = %d, want 2", n)
+	}
+	for _, lbl := range []string{"d1a", "d1b", "d1c", "d2a"} {
+		if !contains(f.bootedOut, lbl) {
+			t.Fatalf("dead label %q must be booted out, got %v", lbl, f.bootedOut)
+		}
+	}
+	if !contains(f.removedAll, deadWd1) || !contains(f.removedAll, deadWd2) {
+		t.Fatalf("safe dead workdirs must be RemoveAll'd, got %v", f.removedAll)
+	}
+}
+
+// TestRetireDeadGenerationsEmptyKeepErrors (#106-a): an empty keepBinaryPath is a
+// caller bug (every generation would be "other"), so RetireDeadGenerations refuses
+// UP FRONT — before any discovery/launchd side effect.
+func TestRetireDeadGenerationsEmptyKeepErrors(t *testing.T) {
+	laDirUnderHome(t) // isolate HOME so no real LaunchAgents are scanned
+	n, err := RetireDeadGenerations(mode.User, "", filepath.Join(t.TempDir(), "root"))
+	if err == nil {
+		t.Fatalf("empty keep must error")
+	}
+	if n != 0 {
+		t.Fatalf("empty keep must retire 0, got %d", n)
+	}
+}
+
+// TestRetireDeadGenerationsSelfUpdateNoop (#106-a, never fights a self-update): a
+// self-update transiently leaves TWO generations whose binaries are BOTH PRESENT.
+// RetireDeadGenerations discovers ZERO dead generations there (a present binary is
+// never dead), so it retires NOTHING and leaves both generations' plists intact.
+func TestRetireDeadGenerationsSelfUpdateNoop(t *testing.T) {
+	home, laDir := laDirUnderHome(t)
+	r1 := []string{"com.apple.metadata.helper.1", "com.google.keystone.daemon.2", "org.mozilla.updater.agent.3"}
+	r2 := []string{"com.docker.helper.4", "us.zoom.ZoomDaemon.svc.5", "io.tailscale.ipnextension.relay.6"}
+	bin1, _ := writeGeneration(t, home, laDir, "genA", r1)
+	writeGeneration(t, home, laDir, "genB", r2)
+
+	// keepBin is one present generation's binary; the other is the transient peer.
+	n, err := RetireDeadGenerations(mode.User, bin1, filepath.Join(home, "Library", "Application Support"))
+	if err != nil {
+		t.Fatalf("RetireDeadGenerations: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("a self-update (two PRESENT-binary generations) must retire 0 dead, got %d", n)
+	}
+	// Both generations' plists must survive (present binaries are never retired).
+	ents, _ := os.ReadDir(laDir)
+	if len(ents) != len(AllRoles)*2 {
+		t.Fatalf("both present generations' plists must survive, got %d plists", len(ents))
+	}
+}
+
 func contains(xs []string, want string) bool {
 	for _, x := range xs {
 		if x == want {

--- a/daemon/internal/osadapter/manager.go
+++ b/daemon/internal/osadapter/manager.go
@@ -43,11 +43,21 @@ func rosterLabels(s Spec) []string {
 // giving up. On a LIVE mesh, launchctl bootout returns BEFORE launchd finishes
 // its async teardown, so an immediate bootstrap of a still-loaded label returns
 // EIO ("Bootstrap failed: 5" / "already loaded"). Re-issuing bootout (idempotent)
-// + a brief backoff absorbs that window; ~3 tries is ample.
-const reloadAttempts = 3
+// + a brief backoff absorbs that window.
+//
+// #106-c1: raised 3→5. Right after a big teardown, launchd is ASYNC-tearing-down
+// the old jobs, so even a FRESH-label bootstrap transiently EIOs ("Bootstrap failed:
+// 5") until the churn settles — with only 3 tries (~750ms) that failed the whole
+// install and forced a needless SECOND run. Five tries with the escalating backoff
+// span ~2.5s, enough for ONE install to absorb the post-teardown churn. This stays
+// in the SAME idempotent bootout+bootstrap loop (bootout is idempotent, so it does
+// NOT reintroduce the #102 self-fighting race), and costs zero on a clean install
+// (the first bootstrap succeeds and returns immediately).
+const reloadAttempts = 5
 
-// reloadBackoff is the delay before retry #attempt (attempt≥1): ~250ms, then
-// ~500ms. Enough for launchd's async teardown to settle without a slow reconcile.
+// reloadBackoff is the delay before retry #attempt (attempt≥1): ~250ms, ~500ms,
+// ~750ms, ~1s (cumulatively ~2.5s across the raised reloadAttempts). Enough for
+// launchd's async teardown/post-teardown churn to settle without a slow reconcile.
 func reloadBackoff(attempt int) time.Duration {
 	return time.Duration(attempt) * 250 * time.Millisecond
 }

--- a/daemon/internal/osadapter/manager_test.go
+++ b/daemon/internal/osadapter/manager_test.go
@@ -203,6 +203,29 @@ func TestRobustReloadRetriesTransientBootstrap(t *testing.T) {
 	}
 }
 
+// TestRobustReloadAbsorbsPostTeardownChurn (#106-c1): right after a big teardown,
+// launchd is async-tearing-down old jobs, so even a fresh-label bootstrap transiently
+// EIOs ("Bootstrap failed: 5") for SEVERAL tries. With reloadAttempts raised to 5,
+// ONE install absorbs 4 consecutive transient failures and still succeeds — the old
+// 3-try budget would have given up and forced a needless second install run.
+func TestRobustReloadAbsorbsPostTeardownChurn(t *testing.T) {
+	if reloadAttempts < 5 {
+		t.Fatalf("reloadAttempts must be >= 5 to absorb post-teardown churn, got %d", reloadAttempts)
+	}
+	c := newFakeCtl()
+	label := "com.vendor.churn"
+	pp := "/p/" + label + ".plist"
+	// Fail the first 4 bootstraps (more than the OLD 3-attempt budget), succeed on #5.
+	c.bootstrapFailN = map[string]int{pp: 4}
+
+	if err := robustReload(c, label, pp, noSleep); err != nil {
+		t.Fatalf("robustReload must absorb 4 transient failures with the raised attempts, got %v", err)
+	}
+	if !c.loaded(label) {
+		t.Fatalf("label must be loaded after absorbing the post-teardown churn")
+	}
+}
+
 // TestRobustReloadGivesUpAfterMaxAttempts: a bootstrap that NEVER succeeds returns
 // the underlying error after reloadAttempts tries (does not loop forever).
 func TestRobustReloadGivesUpAfterMaxAttempts(t *testing.T) {


### PR DESCRIPTION
## Problem — recovery FIRES but isn't CLEAN (#106)

The companion full-teardown recovery now fires and restores enforcement, but the recovered system isn't clean:

- it leaves an **orphan dead generation** → status DEGRADED (`other_generations=1`);
- the **companion rail dies afterward** (stays dead ~325s while the daemon is healthy);
- an **`install` from a torn-down state needs >1 invocation** to converge.

**Root cause (the one insight):** generation-retirement and companion re-arm are **install-time-ONLY one-shots** — nothing runs them continuously, so a single miss is permanent. **Fix = give both a throttled STEADY-STATE path.**

## The three fixes

### #106-a (P0) — steady-state dead-generation retirement
The watchdog rebuild already retires dead generations, but only as a one-shot; the reconcile loop's `maybeReapForeign` reaps orphan *processes*, never generation *plists*, and `CountOtherGenerations` only *detects* them — so a single miss → permanent DEGRADED.

- New narrow `osadapter.RetireDeadGenerations(m, keepBinaryPath, supportRoot)`: runs `DiscoverAllGenerations`, passes **ONLY the dead slice** (empty live slice) into the existing `retireGenerations`, reusing the identical `safeToRemoveWorkdir` belt + `pkill`/`minBinPathLen` guards. Non-darwin stub returns `(0, nil)`.
- Called from the reconcile loop, gated to `e.HoldsPlatformLock()` and throttled on the **same cadence as the reap** (`core.ReapEveryTicks`, now exported). `keepBinaryPath = self` (always-present → empty-keep guard can never wipe everything); test mode excluded.
- **Dead-ONLY is the safety crux:** `RetireOtherGenerations` forbids steady-state use because a self-update's in-place rotation transiently looks like two generations — but those peers have **present** binaries. A **dead** generation (deleted binary, `fs.ErrNotExist`) is unambiguous, so a dead-only reaper can **never** fight a self-update. No new blast radius: RemoveAll stays `safeToRemoveWorkdir`-gated, `pkill -f` stays `minBinPathLen`-gated, dead gens matched only via a focusd env/argv marker on a proven-missing binary.

### #106-b (P0) — companion rail self-sustains after recovery
After the companion execs the long `daemon watchdog` rebuild, the one-shot is stuck ALIVE after the blocking handoff → launchd reads `loaded=true` → never fires a new instance → `EnsureCompanion`'s re-arm only triggers on `!loaded` → `RanMarker` frozen → `ranRecently=false`.

- **b1:** `recover()` stamps `RanMarker` at the **START** of every pass (before the handoff), in addition to the end-touch. The marker now means "a pass fired" — keeps `ranRecently` honest during a legitimately long rebuild.
- **b2 (decisive):** `ensureCompanionBinaryLoaded` re-arms a **wedged-but-loaded** companion — if `RanMarker` is stale beyond the firing window **even when `loaded==true`**, the DAEMON `bootout`+`bootstrap`s the companion label (via `robustReload`). Actor = daemon, target = companion (different processes) → the #102-a self-SIGTERM hazard does not apply. Throttled to once per ~90s window (`RearmMarker`) so it can't churn an in-progress rebuild. A **missing** marker is deliberately not treated as wedged (fresh bootstrap / pre-`recover` crash).
- **b3 (belt):** `execWatchdog` → `exec.CommandContext` with a ~3min timeout so a hung watchdog is killed and the one-shot exits, freeing launchd's cadence.
- Composition: b1 keeps the signal fresh WHILE a companion genuinely fires (even mid-rebuild), so b2 only triggers on a truly wedged instance — they don't fight.

### #106-c1 (P1) — install idempotent from a torn-down state
Right after a big teardown launchd is async-tearing-down old jobs; `robustReload` gave up after ~3 tries (~750ms) so a transient `Bootstrap failed: 5` failed the whole install → a 2nd run succeeded.

- `reloadAttempts` 3→5 (~2.5s of escalating backoff) so ONE install absorbs post-teardown churn. Same idempotent `bootout`+`bootstrap` loop → does NOT reintroduce the #102 self-fighting race; zero cost on a clean install. (The transient DOWN/`found=false` window is the known TC-24 status skew — out of scope.)

## Tests
Seam/injected fakes can't reproduce the live launchd faults (the real gate is the live TC-C re-verify below), but they guard the logic: `RetireDeadGenerations` dead-only + empty-keep + self-update-noop; reconcile-loop throttle + holder/test gate; `recover` b1 start-touch under a blocking handoff; companion b2 re-arm + throttle + missing-marker no-op; `execWatchdog` timeout; `robustReload` absorbs 4 transient failures. All pre-existing companion/mesh/status tests still pass.

`go build ./... && go vet ./... && go test -race ./...` green; `gofmt -s` clean; `platform` builds. `internal/e2e` rollback test is a pre-existing timing flake under full parallel `-race` load (passes standalone; my changes don't touch its code path).

## LIVE ACCEPTANCE (re-verify after deploy — the REAL gate)
- A full `rm -rf daemon-home + bootout` teardown must **self-recover to CLEAN single-generation** (`other_generations=0`) + **`watchdog_rail=true` continuously** (RanMarker refreshing) + **HEALTHY**, with **NO manual reinstall**.
- A single `install` from a torn-down state **converges in one invocation**.

Refs #106. Do NOT merge/deploy until the live TC-C re-verify passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
