### PR TITLE
fix(daemon): companion cross-compiles for windows/amd64 (#108)

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -93,3 +93,21 @@ jobs:
             CGO_ENABLED=0 GOOS=darwin GOARCH=$a go build -o /tmp/sign-darwin-$a ./cmd/focusd-sign
           done
           ls -l /tmp/daemon-darwin-* /tmp/sign-darwin-*
+      - name: Cross-build companion + daemon (release matrix, build-only)
+        # #108: the release matrix (daemon-release.yml) builds cmd/companion for
+        # ALL FIVE targets below, but this job previously only built cmd/daemon
+        # for darwin — so a unix-only syscall with no build tag in cmd/companion
+        # broke windows/amd64 unnoticed until release. Mirror the release matrix
+        # here (build-only, no run, no signing) so this class of break fails on
+        # PRs instead.
+        working-directory: daemon
+        run: |
+          set -euo pipefail
+          targets="darwin/arm64 darwin/amd64 linux/amd64 linux/arm64 windows/amd64"
+          for t in $targets; do
+            os=${t%/*}; arch=${t#*/}; ext=""
+            [ "$os" = windows ] && ext=".exe"
+            CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -o /tmp/matrix-companion-$os-$arch$ext ./cmd/companion
+            CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -o /tmp/matrix-daemon-$os-$arch$ext ./cmd/daemon
+          done
+          ls -l /tmp/matrix-companion-* /tmp/matrix-daemon-*

--- a/daemon/cmd/companion/main.go
+++ b/daemon/cmd/companion/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"syscall"
 	"time"
 
 	"github.com/eliteGoblin/focusd/daemon/internal/companion"
@@ -82,22 +81,19 @@ func execWatchdog(bin, desired string) error {
 // The watchdog rebuild itself shells out to launchctl (robustReload) — if the hang is
 // IN one of those grandchildren (a stuck/unresponsive launchd is exactly the scenario
 // this timeout guards), killing only the direct child would orphan the grandchild. So
-// the child is put in its OWN process group (Setpgid) and Cancel SIGKILLs the WHOLE
-// group, reaping the subtree. WaitDelay bounds Run() so a grandchild inheriting the
+// configureProcessGroup puts the child in its OWN process group and Cancel calls
+// killProcessGroup to SIGKILL the WHOLE group, reaping the subtree. Both are build-tagged
+// (procgroup_unix.go / procgroup_windows.go, #108) since Setpgid/syscall.Kill are
+// unix-only; the windows companion is future-ready and falls back to a best-effort
+// single-process kill. WaitDelay bounds Run() so a grandchild inheriting the
 // (nil ⇒ /dev/null) std handles can never make the wait hang after the kill.
 func execWatchdogCtx(ctx context.Context, bin, desired string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, "watchdog", "-v", desired)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureProcessGroup(cmd)
 	cmd.Cancel = func() error {
-		// Negative PID → signal the whole process group (the child + its launchctl
-		// grandchildren). Best-effort: fall back to the single child if the group
-		// signal fails (e.g. the child already exited).
-		if perr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); perr != nil {
-			return cmd.Process.Kill()
-		}
-		return nil
+		return killProcessGroup(cmd)
 	}
 	cmd.WaitDelay = 5 * time.Second
 	return cmd.Run()

--- a/daemon/cmd/companion/procgroup_unix.go
+++ b/daemon/cmd/companion/procgroup_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup puts cmd in its OWN process group (Setpgid) so
+// killProcessGroup can reap the whole subtree — including launchctl
+// grandchildren — on timeout. See execWatchdogCtx (#106-b3): the watchdog
+// rebuild shells out to launchctl, and a hang there would otherwise orphan
+// the grandchild if only the direct child were killed.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup SIGKILLs the whole process group (the child + its
+// launchctl grandchildren). Falls back to killing just the direct child if
+// the group signal fails (e.g. the child already exited).
+func killProcessGroup(cmd *exec.Cmd) error {
+	if perr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); perr != nil {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/daemon/cmd/companion/procgroup_windows.go
+++ b/daemon/cmd/companion/procgroup_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+// configureProcessGroup is a no-op on windows (#108). Process-group Setpgid
+// semantics are unix-only, and the grandchild-reaping they guard against
+// (a stuck launchctl) doesn't apply here — launchd/launchctl are darwin-only.
+// The windows companion is future-ready, not functionally deployed yet, so it
+// only needs to compile and provide a best-effort single-process kill.
+func configureProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup kills just the direct child process (best-effort; there
+// is no process-group handle to reap on windows).
+func killProcessGroup(cmd *exec.Cmd) error {
+	return cmd.Process.Kill()
+}


### PR DESCRIPTION
## Root cause

The #106-b3 fix in `daemon/cmd/companion/main.go` added process-group-kill-on-timeout logic for the watchdog handoff, using unix-only syscalls with **no build tag**:

```go
cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}     // no Setpgid field on windows
syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)            // syscall.Kill undefined on windows
```

This compiles fine on darwin/linux but breaks `windows/amd64`. The `Daemon Release` workflow builds the companion for all 5 targets (`darwin/{arm64,amd64} linux/{amd64,arm64} windows/amd64`) via `scripts/build-companion.sh`, so it went RED at Build+sign:

```
cmd/companion/main.go:92:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr
cmd/companion/main.go:97:22: undefined: syscall.Kill
```

The regular `Daemon CI` workflow (`.github/workflows/daemon.yml`) never caught this — its cross-build job only builds `cmd/daemon` for darwin, and never touches `cmd/companion` at all — so the break was invisible until release time.

## Fix

Extracted the process-group kill logic behind a small seam, split into build-tagged files so darwin behavior is preserved exactly and windows gets a compiling fallback:

- `daemon/cmd/companion/procgroup_unix.go` (`//go:build !windows`) — the **exact** prior behavior: `Setpgid: true` + `syscall.Kill(-pid, SIGKILL)` to reap the whole process group (the watchdog rebuild shells out to `launchctl`; killing only the direct child would orphan a stuck grandchild).
- `daemon/cmd/companion/procgroup_windows.go` (`//go:build windows`) — a compiling stub: no `Setpgid`, best-effort `cmd.Process.Kill()`. The windows companion is "future-ready" (launchd is darwin-only, so it isn't functionally deployed on windows) — it only needs to compile.
- `execWatchdogCtx` in `main.go` now calls `configureProcessGroup(cmd)` / `killProcessGroup(cmd)` instead of the raw unix syscalls; the context-timeout logic itself (`exec.CommandContext`, `WaitDelay`) stays portable and untouched.

## Verification

All 5 release targets build clean:

```
$ cd daemon && for t in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64 windows/amd64; do
    os=${t%/*}; arch=${t#*/}
    GOOS=$os GOARCH=$arch go build ./cmd/companion ./cmd/daemon || echo "FAIL $t"
  done
# (no FAIL lines — all 5 succeed)
```

Also on host (darwin/arm64):
- `go build ./...` clean
- `go vet ./...` clean
- `gofmt -s -l cmd/companion` clean
- `go test ./cmd/companion/... -race` green, including `TestExecWatchdogCtxTimesOut` / `TestExecWatchdogCtxSucceedsWithinTimeout` (the #106-b3 timeout tests, unchanged and still passing on darwin)
- `go test ./...` (full daemon module) green

## CI coverage gap closed

Added a "Cross-build companion + daemon (release matrix, build-only)" step to the `Daemon CI` → `build` job (`.github/workflows/daemon.yml`) that mirrors the release matrix (5 targets, build-only, no run, no signing). This makes this exact class of break fail on PRs going forward instead of only surfacing at release time.

## Scope

Minimal, build-tag-only split — no behavior change on darwin/linux (still uses `Setpgid` + process-group `SIGKILL`), no daemon/platform-facing API change. Companion functional behavior on windows is unchanged (it wasn't functionally used there before either — launchd/launchctl are darwin-only).

Closes #108.

## Test plan

- [x] `go build` for all 5 release targets (`cmd/companion` + `cmd/daemon`)
- [x] `go build ./... && go vet ./...` on host
- [x] `gofmt -s -l` clean on touched files
- [x] `go test ./cmd/companion/... -race` — b3 timeout tests still pass
- [x] `go test ./...` (full daemon module) green
- [ ] CI green on this PR (Daemon CI + new cross-build step)