### PR TITLE
fix(kill-steam): match Steam by executable path + honest post-kill verdict (green-over-dead-protection)

### DIFF
--- a/plugins/kill-steam/cmd/main.go
+++ b/plugins/kill-steam/cmd/main.go
@@ -94,20 +94,34 @@ func run(args []string) int {
 			"uninstall_reason":   un.Reason,
 		},
 	}
+
+	// Any of these is a controlled failure — the verdict must NOT read as a
+	// clean "ok" while Steam survives (green-over-dead-protection).
+	failed := false
 	if len(out.Failed) > 0 {
 		res.Status = "failed"
 		res.Message = fmt.Sprintf("killed %d, %d failed; %s",
 			out.KilledCount(), len(out.Failed), res.Message)
 		res.Details["failed"] = out.Failed
-		emit(res)
-		return 1 // controlled failure
+		failed = true
+	}
+	if len(out.Survivors) > 0 {
+		// Steam bundle processes still present after the kill pass — the
+		// kill didn't take or Steam relaunched. Report it honestly.
+		res.Status = "failed"
+		res.Message = fmt.Sprintf("Steam still present after kill (survivors=%d); %s",
+			len(out.Survivors), res.Message)
+		res.Details["survivors"] = out.Survivors
+		failed = true
 	}
 	if len(un.Errors) > 0 {
 		res.Status = "failed"
-		emit(res)
-		return 1
+		failed = true
 	}
 	emit(res)
+	if failed {
+		return 1 // controlled failure
+	}
 	return 0
 }
 

--- a/plugins/kill-steam/cmd/main.go
+++ b/plugins/kill-steam/cmd/main.go
@@ -116,7 +116,7 @@ func buildVerdict(out killer.Outcome, un uninstaller.Outcome) (result, int) {
 		res.Details["failed"] = out.Failed
 	}
 	if len(out.Survivors) > 0 {
-		reasons = append(reasons, fmt.Sprintf("Steam still present after kill (survivors=%d)", len(out.Survivors)))
+		reasons = append(reasons, fmt.Sprintf("Steam/Dota target still present after kill (survivors=%d)", len(out.Survivors)))
 		res.Details["survivors"] = out.Survivors
 	}
 	if out.RescanError != "" {

--- a/plugins/kill-steam/cmd/main.go
+++ b/plugins/kill-steam/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/killer"
 	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/uninstaller"
@@ -80,10 +81,24 @@ func run(args []string) int {
 	// helper. Cheap when Steam is absent (one os.Stat → return).
 	un := (&uninstaller.Reconciler{}).Reconcile()
 
+	res, code := buildVerdict(out, un)
+	emit(res)
+	return code
+}
+
+// buildVerdict maps a kill + uninstall outcome to the plugin result and exit
+// code. It is a pure function (no I/O) so the exit-code/status wiring — the
+// externally observed contract — is unit-tested directly. Any of: failed
+// kills, surviving Steam processes, an unrunnable post-kill re-scan, or
+// uninstall errors is a controlled failure (status=failed, exit 1). The
+// verdict must NEVER read as a clean "ok" while Steam survives OR while its
+// removal could not be verified (green-over-dead-protection).
+func buildVerdict(out killer.Outcome, un uninstaller.Outcome) (result, int) {
+	base := fmt.Sprintf("scanned=%d killed=%d uninstall_detected=%v removed=%d",
+		out.Scanned, out.KilledCount(), un.Detected, len(un.Removed))
 	res := result{
-		Status: "ok",
-		Message: fmt.Sprintf("scanned=%d killed=%d uninstall_detected=%v removed=%d",
-			out.Scanned, out.KilledCount(), un.Detected, len(un.Removed)),
+		Status:  "ok",
+		Message: base,
 		Details: map[string]any{
 			"scanned":            out.Scanned,
 			"killed_count":       out.KilledCount(),
@@ -95,34 +110,31 @@ func run(args []string) int {
 		},
 	}
 
-	// Any of these is a controlled failure — the verdict must NOT read as a
-	// clean "ok" while Steam survives (green-over-dead-protection).
-	failed := false
+	var reasons []string
 	if len(out.Failed) > 0 {
-		res.Status = "failed"
-		res.Message = fmt.Sprintf("killed %d, %d failed; %s",
-			out.KilledCount(), len(out.Failed), res.Message)
+		reasons = append(reasons, fmt.Sprintf("%d kill(s) failed", len(out.Failed)))
 		res.Details["failed"] = out.Failed
-		failed = true
 	}
 	if len(out.Survivors) > 0 {
-		// Steam bundle processes still present after the kill pass — the
-		// kill didn't take or Steam relaunched. Report it honestly.
-		res.Status = "failed"
-		res.Message = fmt.Sprintf("Steam still present after kill (survivors=%d); %s",
-			len(out.Survivors), res.Message)
+		reasons = append(reasons, fmt.Sprintf("Steam still present after kill (survivors=%d)", len(out.Survivors)))
 		res.Details["survivors"] = out.Survivors
-		failed = true
+	}
+	if out.RescanError != "" {
+		// Verification could not run → we cannot confirm Steam is gone. Refuse
+		// to report green over an unverified pass.
+		reasons = append(reasons, "post-kill verification failed: "+out.RescanError)
+		res.Details["rescan_error"] = out.RescanError
 	}
 	if len(un.Errors) > 0 {
-		res.Status = "failed"
-		failed = true
+		reasons = append(reasons, fmt.Sprintf("%d uninstall error(s)", len(un.Errors)))
 	}
-	emit(res)
-	if failed {
-		return 1 // controlled failure
+
+	if len(reasons) == 0 {
+		return res, 0
 	}
-	return 0
+	res.Status = "failed"
+	res.Message = strings.Join(reasons, "; ") + "; " + base
+	return res, 1 // controlled failure
 }
 
 // readJobConfig returns the job-config JSON bytes: from --config <path>

--- a/plugins/kill-steam/cmd/main_test.go
+++ b/plugins/kill-steam/cmd/main_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/killer"
+	"github.com/eliteGoblin/focusd/plugins/kill-steam/internal/uninstaller"
 )
 
 // writeF writes a test fixture file, failing fast on I/O error so a
@@ -154,5 +157,53 @@ func TestRunErrorOnBadStdinConfig(t *testing.T) {
 	withStdin(t, `{nope`, func() { code = run([]string{"run"}) })
 	if code != 2 {
 		t.Errorf("bad stdin config exit = %d, want 2", code)
+	}
+}
+
+// --- buildVerdict: the externally observed status/exit-code contract ---
+
+func TestBuildVerdictCleanIsOk(t *testing.T) {
+	res, code := buildVerdict(killer.Outcome{Scanned: 42}, uninstaller.Outcome{Reason: "clean"})
+	if res.Status != "ok" || code != 0 {
+		t.Fatalf("clean pass => ok/0, got %q/%d", res.Status, code)
+	}
+}
+
+// TestBuildVerdictSurvivorsFailAndExit1 locks the core fix: a surviving Steam
+// process must flip the reported status to failed and exit 1 — never a clean
+// green over a live Steam.
+func TestBuildVerdictSurvivorsFailAndExit1(t *testing.T) {
+	res, code := buildVerdict(killer.Outcome{Survivors: []int{123}}, uninstaller.Outcome{})
+	if res.Status != "failed" || code != 1 {
+		t.Fatalf("survivors => failed/1, got %q/%d", res.Status, code)
+	}
+	if res.Details["survivors"] == nil {
+		t.Error("survivors must be surfaced in details")
+	}
+}
+
+// TestBuildVerdictRescanErrorIsNotClean is the CRITICAL guard at the verdict
+// layer: an unverifiable post-kill re-scan must NOT read as clean ok.
+func TestBuildVerdictRescanErrorIsNotClean(t *testing.T) {
+	res, code := buildVerdict(killer.Outcome{RescanError: "post-kill re-scan failed: boom"}, uninstaller.Outcome{})
+	if res.Status != "failed" || code != 1 {
+		t.Fatalf("rescan error => failed/1 (never green over unverified protection), got %q/%d", res.Status, code)
+	}
+	if res.Details["rescan_error"] == nil {
+		t.Error("rescan_error must be surfaced in details")
+	}
+}
+
+func TestBuildVerdictFailedKillsExit1(t *testing.T) {
+	res, code := buildVerdict(killer.Outcome{Failed: []string{"10: EPERM"}}, uninstaller.Outcome{})
+	if res.Status != "failed" || code != 1 {
+		t.Fatalf("failed kills => failed/1, got %q/%d", res.Status, code)
+	}
+}
+
+func TestBuildVerdictUninstallErrorsExit1(t *testing.T) {
+	res, code := buildVerdict(killer.Outcome{}, uninstaller.Outcome{Errors: []string{"perm denied"}})
+	if res.Status != "failed" || code != 1 {
+		t.Fatalf("uninstall errors => failed/1, got %q/%d", res.Status, code)
 	}
 }

--- a/plugins/kill-steam/internal/killer/killer.go
+++ b/plugins/kill-steam/internal/killer/killer.go
@@ -65,9 +65,10 @@ type Outcome struct {
 	Scanned    int      `json:"scanned"`
 	KilledPIDs []int    `json:"killed_pids"`
 	Failed     []string `json:"failed,omitempty"` // "pid: reason"
-	// Survivors are Steam procs still present after the kill+settle window
-	// (kill didn't take / relaunch). Excludes PIDs already in Failed, so the
-	// two lists are disjoint.
+	// Survivors are target (Steam/Dota) procs still present after the
+	// kill+settle window (kill didn't take / relaunch). A survivor can be a
+	// name-matched Dota process, not only a Steam-bundle path. Excludes PIDs
+	// already in Failed, so the two lists are disjoint.
 	Survivors []int `json:"survivors,omitempty"`
 	// RescanError is set when the post-kill re-scan itself could not run.
 	// Verification could not confirm Steam is gone, so the caller MUST NOT
@@ -215,11 +216,16 @@ func listProcesses() ([]procView, error) {
 	}
 	out := make([]procView, 0, len(ps))
 	for _, p := range ps {
-		name, err := p.Name()
-		if err != nil {
-			continue // process vanished or unreadable; skip
+		// Read BOTH fields best-effort. Name() alone is not enough: Steam's
+		// helpers run under generic comm names and are caught by executable
+		// path, so a PID whose Name() is unreadable but whose Exe() resolves
+		// must still be enumerated — otherwise a path-only match never sees
+		// it. Skip only when NEITHER field is readable (nothing to match on).
+		name, nameErr := p.Name()
+		path, exeErr := p.Exe()
+		if nameErr != nil && exeErr != nil {
+			continue // process vanished or fully opaque; nothing to match
 		}
-		path, _ := p.Exe() // best-effort; empty on EPERM/vanished — name-match still works
 		out = append(out, procView{PID: int(p.Pid), Name: name, Path: path})
 	}
 	return out, nil

--- a/plugins/kill-steam/internal/killer/killer.go
+++ b/plugins/kill-steam/internal/killer/killer.go
@@ -49,17 +49,30 @@ var DefaultSteamPathMarkers = []string{
 	"/library/application support/steam/",
 }
 
-// settleDelay is how long we wait after killing before re-scanning, so a
-// SIGKILLed process has a moment to be reaped before we count it as a
-// survivor (avoids a false "still alive" on a kill that actually took).
-const settleDelay = 500 * time.Millisecond
+// settleInterval is how long we wait between post-kill re-scans, and
+// settleAttempts is how many times we re-check. Polling (rather than one
+// fixed sleep) gives a SIGKILLed process time to be reaped before we count
+// it as a survivor, while short-circuiting the moment it is confirmed gone
+// — so a successful kill is never miscounted as "still alive". Max wait
+// when a real survivor persists: settleInterval * settleAttempts (~1.5s).
+const (
+	settleInterval = 300 * time.Millisecond
+	settleAttempts = 5
+)
 
 // Outcome summarises a kill pass.
 type Outcome struct {
 	Scanned    int      `json:"scanned"`
 	KilledPIDs []int    `json:"killed_pids"`
-	Failed     []string `json:"failed,omitempty"`    // "pid: reason"
-	Survivors  []int    `json:"survivors,omitempty"` // Steam procs still present after the kill
+	Failed     []string `json:"failed,omitempty"` // "pid: reason"
+	// Survivors are Steam procs still present after the kill+settle window
+	// (kill didn't take / relaunch). Excludes PIDs already in Failed, so the
+	// two lists are disjoint.
+	Survivors []int `json:"survivors,omitempty"`
+	// RescanError is set when the post-kill re-scan itself could not run.
+	// Verification could not confirm Steam is gone, so the caller MUST NOT
+	// treat the pass as clean — an unverifiable pass is never green.
+	RescanError string `json:"rescan_error,omitempty"`
 }
 
 // KilledCount is the number of processes successfully terminated.
@@ -73,12 +86,13 @@ type procView struct {
 }
 
 type Killer struct {
-	names   []string
-	markers []string
-	list    func() ([]procView, error)
-	killPID func(pid int) error
-	sleep   func(time.Duration)
-	settle  time.Duration
+	names    []string
+	markers  []string
+	list     func() ([]procView, error)
+	killPID  func(pid int) error
+	sleep    func(time.Duration)
+	settle   time.Duration
+	attempts int
 }
 
 // New builds a Killer. Empty names => DefaultProcessNames.
@@ -87,12 +101,13 @@ func New(names []string) *Killer {
 		names = DefaultProcessNames
 	}
 	return &Killer{
-		names:   names,
-		markers: DefaultSteamPathMarkers,
-		list:    listProcesses,
-		killPID: killProcess,
-		sleep:   time.Sleep,
-		settle:  settleDelay,
+		names:    names,
+		markers:  DefaultSteamPathMarkers,
+		list:     listProcesses,
+		killPID:  killProcess,
+		sleep:    time.Sleep,
+		settle:   settleInterval,
+		attempts: settleAttempts,
 	}
 }
 
@@ -108,6 +123,7 @@ func (k *Killer) Run() (Outcome, error) {
 
 	var out Outcome
 	out.Scanned = len(procs)
+	failedPIDs := make(map[int]bool)
 	matchedAny := false
 	for _, p := range procs {
 		if !k.matches(p, want) {
@@ -116,28 +132,54 @@ func (k *Killer) Run() (Outcome, error) {
 		matchedAny = true
 		if err := k.killPID(p.PID); err != nil {
 			out.Failed = append(out.Failed, fmt.Sprintf("%d: %v", p.PID, err))
+			failedPIDs[p.PID] = true
 			continue
 		}
 		out.KilledPIDs = append(out.KilledPIDs, p.PID)
 	}
 	sort.Ints(out.KilledPIDs)
 
-	// Honest-verdict re-scan: if anything matched, let the kills settle and
-	// re-enumerate. A process STILL matching is a survivor — the kill did
-	// not take, or Steam relaunched. Surfacing survivors stops a clean "ok"
-	// from masking a live Steam (the green-over-dead-protection class).
+	// Honest-verdict re-scan: if anything matched, confirm it is actually
+	// gone. Survivors (or an unrunnable re-scan) stop a clean "ok" from
+	// masking a live Steam — the green-over-dead-protection class.
 	if matchedAny {
-		k.sleep(k.settle)
-		if after, err := k.list(); err == nil {
-			for _, p := range after {
-				if k.matches(p, want) {
-					out.Survivors = append(out.Survivors, p.PID)
-				}
-			}
-			sort.Ints(out.Survivors)
-		}
+		out.Survivors, out.RescanError = k.confirmGone(want, failedPIDs)
 	}
 	return out, nil
+}
+
+// confirmGone polls (bounded) after the kill pass until no Steam match
+// remains, giving SIGKILLed processes a moment to be reaped so a successful
+// kill is not miscounted as a survivor. A match that persists through the
+// whole window is a real survivor — the kill did not take or Steam
+// relaunched. PIDs already recorded as Failed are excluded (surfaced there),
+// so survivors and failures stay disjoint. If the re-scan ITSELF cannot run,
+// it returns a non-empty error string: verification could not confirm the
+// system is clean, and the caller must treat that as NOT ok — never a silent
+// green over an unverified pass.
+func (k *Killer) confirmGone(want map[string]struct{}, failed map[int]bool) ([]int, string) {
+	var survivors []int
+	for attempt := 0; attempt < k.attempts; attempt++ {
+		k.sleep(k.settle)
+		after, err := k.list()
+		if err != nil {
+			return nil, fmt.Sprintf("post-kill re-scan failed: %v", err)
+		}
+		survivors = nil
+		for _, p := range after {
+			if failed[p.PID] {
+				continue
+			}
+			if k.matches(p, want) {
+				survivors = append(survivors, p.PID)
+			}
+		}
+		if len(survivors) == 0 {
+			return nil, "" // confirmed gone
+		}
+	}
+	sort.Ints(survivors)
+	return survivors, ""
 }
 
 // matches reports whether p is a target: an exact (case-insensitive) comm

--- a/plugins/kill-steam/internal/killer/killer.go
+++ b/plugins/kill-steam/internal/killer/killer.go
@@ -3,12 +3,24 @@
 // process names are matched EXACTLY (case-insensitive), never as a
 // substring — substring matching killed Microsoft Teams via the "steam"
 // inside "msteams".
+//
+// Name-only matching under-killed, though: Steam's helpers run under
+// generic comm names (ipcserver, gameoverlayui, …) that no name list can
+// enumerate, so they survived while the plugin still reported success —
+// green over dead protection. This layer therefore ALSO matches by
+// executable path: any process running from under the Steam bundle is a
+// Steam process regardless of its comm name. An unrelated binary that
+// merely shares a generic name (e.g. /usr/local/bin/ipcserver) is not
+// under a Steam path and is left alone. After killing, the killer
+// re-scans; any Steam process still present is reported as a survivor so
+// a clean "ok" can never mask a live Steam.
 package killer
 
 import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/shirou/gopsutil/v3/process"
 )
@@ -24,11 +36,30 @@ var DefaultProcessNames = []string{
 	"dota2", "dota_osx64", "Dota 2", "dota2_launcher",
 }
 
+// DefaultSteamPathMarkers are executable-path substrings (matched
+// case-insensitively) that identify a process as part of the Steam
+// install regardless of its comm name. This is what catches the
+// generically-named helpers (ipcserver, steamwebhelper, gameoverlayui,
+// …) that a name-only match misses. A different app that happens to have
+// a generic process name will not sit under one of these paths, so it is
+// not false-matched.
+var DefaultSteamPathMarkers = []string{
+	"/steam.appbundle/",
+	"/steam.app/contents/",
+	"/library/application support/steam/",
+}
+
+// settleDelay is how long we wait after killing before re-scanning, so a
+// SIGKILLed process has a moment to be reaped before we count it as a
+// survivor (avoids a false "still alive" on a kill that actually took).
+const settleDelay = 500 * time.Millisecond
+
 // Outcome summarises a kill pass.
 type Outcome struct {
 	Scanned    int      `json:"scanned"`
 	KilledPIDs []int    `json:"killed_pids"`
-	Failed     []string `json:"failed,omitempty"` // "pid: reason"
+	Failed     []string `json:"failed,omitempty"`    // "pid: reason"
+	Survivors  []int    `json:"survivors,omitempty"` // Steam procs still present after the kill
 }
 
 // KilledCount is the number of processes successfully terminated.
@@ -38,12 +69,16 @@ func (o Outcome) KilledCount() int { return len(o.KilledPIDs) }
 type procView struct {
 	PID  int
 	Name string
+	Path string // executable path (best-effort; empty when unreadable)
 }
 
 type Killer struct {
 	names   []string
+	markers []string
 	list    func() ([]procView, error)
 	killPID func(pid int) error
+	sleep   func(time.Duration)
+	settle  time.Duration
 }
 
 // New builds a Killer. Empty names => DefaultProcessNames.
@@ -51,27 +86,34 @@ func New(names []string) *Killer {
 	if len(names) == 0 {
 		names = DefaultProcessNames
 	}
-	return &Killer{names: names, list: listProcesses, killPID: killProcess}
+	return &Killer{
+		names:   names,
+		markers: DefaultSteamPathMarkers,
+		list:    listProcesses,
+		killPID: killProcess,
+		sleep:   time.Sleep,
+		settle:  settleDelay,
+	}
 }
 
-// Run scans running processes and kills every one whose basename exactly
-// (case-insensitively) matches a configured name.
+// Run scans running processes and kills every one that matches either a
+// configured name (exact, case-insensitive) or a Steam bundle path. It
+// then re-scans; any match still present is recorded as a survivor.
 func (k *Killer) Run() (Outcome, error) {
 	procs, err := k.list()
 	if err != nil {
 		return Outcome{}, fmt.Errorf("enumerate processes: %w", err)
 	}
-	want := make(map[string]struct{}, len(k.names))
-	for _, n := range k.names {
-		want[strings.ToLower(n)] = struct{}{}
-	}
+	want := lowerSet(k.names)
 
 	var out Outcome
 	out.Scanned = len(procs)
+	matchedAny := false
 	for _, p := range procs {
-		if _, hit := want[strings.ToLower(p.Name)]; !hit {
+		if !k.matches(p, want) {
 			continue
 		}
+		matchedAny = true
 		if err := k.killPID(p.PID); err != nil {
 			out.Failed = append(out.Failed, fmt.Sprintf("%d: %v", p.PID, err))
 			continue
@@ -79,7 +121,49 @@ func (k *Killer) Run() (Outcome, error) {
 		out.KilledPIDs = append(out.KilledPIDs, p.PID)
 	}
 	sort.Ints(out.KilledPIDs)
+
+	// Honest-verdict re-scan: if anything matched, let the kills settle and
+	// re-enumerate. A process STILL matching is a survivor — the kill did
+	// not take, or Steam relaunched. Surfacing survivors stops a clean "ok"
+	// from masking a live Steam (the green-over-dead-protection class).
+	if matchedAny {
+		k.sleep(k.settle)
+		if after, err := k.list(); err == nil {
+			for _, p := range after {
+				if k.matches(p, want) {
+					out.Survivors = append(out.Survivors, p.PID)
+				}
+			}
+			sort.Ints(out.Survivors)
+		}
+	}
 	return out, nil
+}
+
+// matches reports whether p is a target: an exact (case-insensitive) comm
+// name match, or an executable running from under the Steam bundle.
+func (k *Killer) matches(p procView, want map[string]struct{}) bool {
+	if _, hit := want[strings.ToLower(p.Name)]; hit {
+		return true
+	}
+	if p.Path == "" {
+		return false
+	}
+	lp := strings.ToLower(p.Path)
+	for _, m := range k.markers {
+		if strings.Contains(lp, m) {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerSet(names []string) map[string]struct{} {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[strings.ToLower(n)] = struct{}{}
+	}
+	return want
 }
 
 func listProcesses() ([]procView, error) {
@@ -93,7 +177,8 @@ func listProcesses() ([]procView, error) {
 		if err != nil {
 			continue // process vanished or unreadable; skip
 		}
-		out = append(out, procView{PID: int(p.Pid), Name: name})
+		path, _ := p.Exe() // best-effort; empty on EPERM/vanished — name-match still works
+		out = append(out, procView{PID: int(p.Pid), Name: name, Path: path})
 	}
 	return out, nil
 }

--- a/plugins/kill-steam/internal/killer/killer_test.go
+++ b/plugins/kill-steam/internal/killer/killer_test.go
@@ -179,7 +179,7 @@ func TestDefaultsCoverSteamAndDota(t *testing.T) {
 // under a Steam path) MUST be left alone. This is the live-observed
 // survivor: /…/Library/Application Support/Steam/Steam.AppBundle/…/ipcserver.
 func TestMatchesByPathUnderSteamBundle(t *testing.T) {
-	const appSupport = "/Users/frank.sun/Library/Application Support/Steam"
+	const appSupport = "/Users/testuser/Library/Application Support/Steam"
 	procs := []procView{
 		// generic comm name, but under the Steam bundle → MUST be killed
 		{PID: 20, Name: "ipcserver", Path: appSupport + "/Steam.AppBundle/Steam/Contents/MacOS/ipcserver"},
@@ -227,7 +227,7 @@ func TestSurvivorAfterKillIsNotClean(t *testing.T) {
 	steam := procView{
 		PID:  30,
 		Name: "ipcserver",
-		Path: "/Users/frank.sun/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/ipcserver",
+		Path: "/Users/testuser/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/ipcserver",
 	}
 	k := New(nil)
 	k.settle = 0
@@ -345,6 +345,19 @@ func TestPathMatchIsCaseInsensitive(t *testing.T) {
 	upper := procView{PID: 9, Name: "x", Path: "/USERS/X/LIBRARY/APPLICATION SUPPORT/STEAM/STEAM.APPBUNDLE/X"}
 	if !k.matches(upper, want) {
 		t.Error("Steam bundle path match must be case-insensitive")
+	}
+}
+
+// TestMatchesEmptyNamePathOnly documents the enumeration fix: a helper whose
+// comm name is unreadable (empty) but which resolves to a Steam bundle path
+// MUST still match by path. This is why listProcesses keeps a PID when Name()
+// errors as long as Exe() is readable — a path-only survivor is not lost.
+func TestMatchesEmptyNamePathOnly(t *testing.T) {
+	k := New(nil)
+	want := lowerSet(k.names)
+	p := procView{PID: 7, Name: "", Path: "/Users/testuser/Library/Application Support/Steam/Steam.AppBundle/x"}
+	if !k.matches(p, want) {
+		t.Error("empty-name process under a Steam path must match by path")
 	}
 }
 

--- a/plugins/kill-steam/internal/killer/killer_test.go
+++ b/plugins/kill-steam/internal/killer/killer_test.go
@@ -3,12 +3,34 @@ package killer
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
+// newFake wires a stateful, instant Killer: a successful kill removes the
+// PID from the process list (so the post-kill re-scan reflects reality),
+// and the settle delay is zeroed so tests never sleep.
 func newFake(procs []procView, killErr map[int]error) *Killer {
 	k := New(nil)
-	k.list = func() ([]procView, error) { return procs, nil }
-	k.killPID = func(pid int) error { return killErr[pid] }
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	killed := map[int]bool{}
+	k.list = func() ([]procView, error) {
+		live := make([]procView, 0, len(procs))
+		for _, p := range procs {
+			if killed[p.PID] {
+				continue
+			}
+			live = append(live, p)
+		}
+		return live, nil
+	}
+	k.killPID = func(pid int) error {
+		if err := killErr[pid]; err != nil {
+			return err
+		}
+		killed[pid] = true
+		return nil
+	}
 	return k
 }
 
@@ -65,10 +87,20 @@ func TestKillFailureRecordedNotFatal(t *testing.T) {
 
 func TestCustomNamesOverrideDefaults(t *testing.T) {
 	k := New([]string{"OnlyThis"})
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	killed := map[int]bool{}
+	all := []procView{{PID: 1, Name: "Steam"}, {PID: 2, Name: "OnlyThis"}}
 	k.list = func() ([]procView, error) {
-		return []procView{{PID: 1, Name: "Steam"}, {PID: 2, Name: "OnlyThis"}}, nil
+		var live []procView
+		for _, p := range all {
+			if !killed[p.PID] {
+				live = append(live, p)
+			}
+		}
+		return live, nil
 	}
-	k.killPID = func(int) error { return nil }
+	k.killPID = func(pid int) error { killed[pid] = true; return nil }
 	out, _ := k.Run()
 	if out.KilledCount() != 1 || out.KilledPIDs[0] != 2 {
 		t.Errorf("custom names not honored: %+v", out)
@@ -136,6 +168,118 @@ func TestDefaultsCoverSteamAndDota(t *testing.T) {
 	for _, must := range []string{"Steam", "steamwebhelper", "dota2", "Dota 2"} {
 		if !got[must] {
 			t.Errorf("default process names missing %q", must)
+		}
+	}
+}
+
+// TestMatchesByPathUnderSteamBundle is the core false-green regression:
+// a generically-named helper (ipcserver) that a name-only match misses,
+// but which executes from under the Steam bundle, MUST be killed — while
+// an unrelated binary that merely shares that generic name (and is NOT
+// under a Steam path) MUST be left alone. This is the live-observed
+// survivor: /…/Library/Application Support/Steam/Steam.AppBundle/…/ipcserver.
+func TestMatchesByPathUnderSteamBundle(t *testing.T) {
+	const appSupport = "/Users/frank.sun/Library/Application Support/Steam"
+	procs := []procView{
+		// generic comm name, but under the Steam bundle → MUST be killed
+		{PID: 20, Name: "ipcserver", Path: appSupport + "/Steam.AppBundle/Steam/Contents/MacOS/ipcserver"},
+		// another generic helper under Application Support/Steam → killed
+		{PID: 21, Name: "gameoverlayui", Path: appSupport + "/gameoverlayui"},
+		// Steam.app bundle path (case varies) → killed by path
+		{PID: 22, Name: "someHelper", Path: "/Applications/Steam.app/Contents/MacOS/steam_osx"},
+		// SAME generic name but NOT under any Steam path → MUST survive
+		{PID: 23, Name: "ipcserver", Path: "/usr/local/bin/ipcserver"},
+		// unrelated app → survives
+		{PID: 24, Name: "Finder", Path: "/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder"},
+		// classic name matches still work (name-only, empty path)
+		{PID: 25, Name: "Steam", Path: ""},
+		{PID: 26, Name: "dota2", Path: ""},
+	}
+	out, err := newFake(procs, nil).Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := map[int]bool{20: true, 21: true, 22: true, 25: true, 26: true}
+	if out.KilledCount() != len(want) {
+		t.Fatalf("killed %v, want %v", out.KilledPIDs, want)
+	}
+	for _, pid := range out.KilledPIDs {
+		if !want[pid] {
+			t.Errorf("killed unexpected pid %d (path/name over-match)", pid)
+		}
+	}
+	// The unrelated /usr/local/bin/ipcserver must never be touched.
+	for _, pid := range out.KilledPIDs {
+		if pid == 23 {
+			t.Fatal("false-matched unrelated /usr/local/bin/ipcserver by generic name")
+		}
+	}
+	if len(out.Survivors) != 0 {
+		t.Errorf("expected no survivors after successful kills, got %v", out.Survivors)
+	}
+}
+
+// TestSurvivorAfterKillIsNotClean locks the honest-verdict re-scan: when a
+// Steam-bundle process is STILL present after the kill (kill didn't take /
+// relaunched), it must be reported as a survivor so the verdict cannot read
+// as clean "ok" over a live Steam.
+func TestSurvivorAfterKillIsNotClean(t *testing.T) {
+	steam := procView{
+		PID:  30,
+		Name: "ipcserver",
+		Path: "/Users/frank.sun/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/ipcserver",
+	}
+	k := New(nil)
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	// The process persists across both scans (relaunch / kill ineffective).
+	k.list = func() ([]procView, error) { return []procView{steam}, nil }
+	k.killPID = func(int) error { return nil } // "succeeds" but proc survives
+	out, err := k.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.KilledCount() != 1 {
+		t.Fatalf("expected the matched pid to be killed once, got %v", out.KilledPIDs)
+	}
+	if len(out.Survivors) != 1 || out.Survivors[0] != 30 {
+		t.Fatalf("expected survivor pid 30, got %v", out.Survivors)
+	}
+}
+
+// TestNoSurvivorRescanWhenNothingMatched: the settle+re-scan only runs when
+// something matched, so a steady-state (no Steam) pass stays cheap and never
+// sleeps. The sleep seam panics to prove it is not called.
+func TestNoSurvivorRescanWhenNothingMatched(t *testing.T) {
+	k := New(nil)
+	k.sleep = func(time.Duration) { t.Fatal("must not sleep/re-scan when nothing matched") }
+	k.list = func() ([]procView, error) {
+		return []procView{{PID: 1, Name: "Finder", Path: "/System/.../Finder"}}, nil
+	}
+	k.killPID = func(int) error { return nil }
+	out, err := k.Run()
+	if err != nil || out.KilledCount() != 0 || len(out.Survivors) != 0 {
+		t.Fatalf("expected clean no-match outcome, got %+v err=%v", out, err)
+	}
+}
+
+func TestPathMatchIsCaseInsensitive(t *testing.T) {
+	k := New(nil)
+	want := lowerSet(k.names)
+	upper := procView{PID: 9, Name: "x", Path: "/USERS/X/LIBRARY/APPLICATION SUPPORT/STEAM/STEAM.APPBUNDLE/X"}
+	if !k.matches(upper, want) {
+		t.Error("Steam bundle path match must be case-insensitive")
+	}
+}
+
+func TestDefaultSteamPathMarkersPresent(t *testing.T) {
+	got := map[string]bool{}
+	for _, m := range DefaultSteamPathMarkers {
+		got[m] = true
+	}
+	for _, must := range []string{"/steam.appbundle/", "/library/application support/steam/"} {
+		if !got[must] {
+			t.Errorf("default steam path markers missing %q", must)
 		}
 	}
 }

--- a/plugins/kill-steam/internal/killer/killer_test.go
+++ b/plugins/kill-steam/internal/killer/killer_test.go
@@ -247,6 +247,82 @@ func TestSurvivorAfterKillIsNotClean(t *testing.T) {
 	}
 }
 
+// TestRescanErrorIsSurfacedNotSwallowed is the CRITICAL guard: if the
+// post-kill re-scan itself fails, that failure MUST be surfaced (so the
+// caller cannot report a clean "ok" over an unverified pass). The original
+// design silently discarded the rescan error — reintroducing the exact
+// false-green class this fix closes.
+func TestRescanErrorIsSurfacedNotSwallowed(t *testing.T) {
+	k := New(nil)
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	calls := 0
+	k.list = func() ([]procView, error) {
+		calls++
+		if calls == 1 {
+			return []procView{{PID: 40, Name: "Steam"}}, nil // initial scan matches
+		}
+		return nil, errors.New("proc enum boom") // re-scan cannot run
+	}
+	k.killPID = func(int) error { return nil }
+	out, err := k.Run()
+	if err != nil {
+		t.Fatalf("Run must not hard-error on rescan failure: %v", err)
+	}
+	if out.RescanError == "" {
+		t.Fatal("rescan failure must be surfaced (RescanError), not swallowed into a clean ok")
+	}
+}
+
+// TestSurvivorClearsWithinPollWindow: a process still present on the first
+// re-scan but gone on a later poll is NOT a survivor (the kill took, it just
+// hadn't been reaped yet) — guards against a spurious status=failed.
+func TestSurvivorClearsWithinPollWindow(t *testing.T) {
+	k := New(nil)
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	scan := 0
+	k.list = func() ([]procView, error) {
+		scan++
+		if scan <= 2 { // initial scan + first re-scan still show Steam
+			return []procView{{PID: 50, Name: "Steam"}}, nil
+		}
+		return nil, nil // reaped by the second re-scan
+	}
+	k.killPID = func(int) error { return nil }
+	out, err := k.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out.Survivors) != 0 {
+		t.Fatalf("process reaped within the poll window must not be a survivor, got %v", out.Survivors)
+	}
+	if out.RescanError != "" {
+		t.Fatalf("unexpected rescan error: %s", out.RescanError)
+	}
+}
+
+// TestFailedKillNotDoubleCountedAsSurvivor: a PID whose kill errored is
+// recorded in Failed and MUST NOT also appear in Survivors (disjoint lists).
+func TestFailedKillNotDoubleCountedAsSurvivor(t *testing.T) {
+	// Static list: the failed-kill Steam persists across re-scans.
+	k := New(nil)
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	k.list = func() ([]procView, error) { return []procView{{PID: 60, Name: "Steam"}}, nil }
+	k.killPID = func(int) error { return errors.New("EPERM") }
+	out, err := k.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out.Failed) != 1 {
+		t.Fatalf("expected pid 60 in Failed, got %v", out.Failed)
+	}
+	if len(out.Survivors) != 0 {
+		t.Fatalf("failed-kill PID must not double-count as a survivor, got %v", out.Survivors)
+	}
+}
+
 // TestNoSurvivorRescanWhenNothingMatched: the settle+re-scan only runs when
 // something matched, so a steady-state (no Steam) pass stays cheap and never
 // sleeps. The sleep seam panics to prove it is not called.


### PR DESCRIPTION
## The bug — false green over dead protection

`kill-steam-reconcile` reported `status=ok / HEALTHY` while a Steam process was **still running**:

```
/Users/<user>/Library/Application Support/Steam/Steam.AppBundle/Steam/Contents/MacOS/ipcserver  (ppid 1)
```

### Root cause
The killer matched processes by **comm name only** (`DefaultProcessNames` = "Steam", "steam_osx", "dota2", …). It killed the main Steam + Dota2, but Steam's helpers run under **generic comm names** (`ipcserver`, `gameoverlayui`, `steamwebhelper` variants) that no name list can enumerate. Those survived — yet the plugin still exited 0 / `ok`. Under-kill masked by a false green: exactly the "green over dead protection" class.

## The fix (KISS, keeps existing behavior)

1. **Match Steam by executable PATH, not just comm name.** Any process whose executable path is under the Steam bundle is killed regardless of its comm name — markers: `/Steam.AppBundle/`, `/Steam.app/Contents/`, `~/Library/Application Support/Steam/` (matched case-insensitively). This catches `ipcserver` and every generically-named helper. An unrelated binary that merely shares a generic name (e.g. `/usr/local/bin/ipcserver`) is **not** under a Steam path, so it is **not** false-matched. Name matching is kept for Dota2 and name-only cases. Enumeration now also reads each PID's executable path (`gopsutil` `Exe()`, best-effort; empty path falls back to name matching).

2. **Honest verdict — post-kill re-scan.** After killing, settle briefly and re-scan. Any Steam match still present is recorded as a **survivor** (kill didn't take / Steam relaunched). Survivors set `status=failed` / exit 1, so a clean `ok` can never mask a live Steam. The re-scan only runs when something matched, so a steady-state (no Steam) pass stays cheap and never sleeps.

3. **Phase-2 uninstall location.** Confirmed already covered: `Reconcile()` sweeps `~/Library/Application Support/Steam` for **every** user on **every** pass (not just `/Applications/Steam.app`), so the live Application-Support install is removed. No change needed there.

## Tests (TDD — permanent regression cases)

- `TestMatchesByPathUnderSteamBundle` — generic-named `ipcserver` **under** the Steam bundle → **killed**; an unrelated `/usr/local/bin/ipcserver` → **not** matched; classic `Steam`/`dota2` name matches still work.
- `TestSurvivorAfterKillIsNotClean` — a Steam-bundle process still present after the kill → recorded as a survivor (verdict is failure, not clean `ok`).
- `TestNoSurvivorRescanWhenNothingMatched` — no match → no settle/re-scan (steady-state stays cheap).
- `TestPathMatchIsCaseInsensitive`, `TestDefaultSteamPathMarkersPresent`.

The `msteams`-survives exact-name guard and all prior tests still pass.

## Verification

- `cd plugins/kill-steam && go build ./... && go vet ./... && go test -race ./...` — green
- `gofmt -s -l .` — clean
- `platform` module compiles; `kill-steam` cross-compiles for `darwin/arm64` (release bundle target). Embedded plugin binaries are gitignored build artifacts rebundled from source by release CI, so none are committed here.

**Do not merge/deploy yet** — to be batched into the next release. This is a latent false-green worth keeping as a permanent test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)