### PR TITLE
fix(kill-steam): O(1)-spawn process enumeration (fixes #111 timeout regression from #110)

### DIFF
--- a/plugins/kill-steam/internal/killer/killer.go
+++ b/plugins/kill-steam/internal/killer/killer.go
@@ -17,6 +17,7 @@
 package killer
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -212,14 +213,24 @@ func lowerSet(names []string) map[string]struct{} {
 	return want
 }
 
+// psTimeout bounds the single ps spawn. #111 is a timeout-class bug (the
+// enumeration blew the per-job budget); a bounded inner deadline makes sure a
+// pathologically hung /bin/ps can never recreate that symptom — it fails fast
+// and honestly (enumerate error → not a silent green) instead of blocking
+// until the platform's outer job-kill fires.
+const psTimeout = 3 * time.Second
+
 // psCommand is the single-spawn process listing (the seam that makes
-// enumeration O(1) exec calls, not O(N) syscalls). macOS `comm` is the FULL
-// path of the executable — not the truncated accounting name, and not the
-// argument vector — so one `ps` exec yields every process's pid + full exe
-// path at once. Matching Steam markers against the exe path (never the args)
-// keeps a process that merely MENTIONS a Steam path in its arguments from
-// being false-matched. Overridable in tests so parsing is exercised without
-// spawning ps and a test can assert the enumeration spawns exactly once.
+// enumeration O(1) exec calls, not O(N) syscalls). On macOS `comm` is
+// typically the FULL path of the executable — not the truncated accounting
+// name, and not the argument vector — so one `ps` exec yields every process's
+// pid + exe path at once. Matching Steam markers against the exe path (never
+// the args) keeps a process that merely MENTIONS a Steam path in its arguments
+// from being false-matched. (A few system processes report a short display
+// name rather than a path; parsePS degrades gracefully — such a process simply
+// can't path-match, exactly as the old gopsutil Exe()-failure case behaved.)
+// Overridable in tests so parsing is exercised without spawning ps and a test
+// can assert the enumeration spawns exactly once.
 //
 // This replaces the per-PID gopsutil Exe() enumeration from #110: that read
 // each process's path with its own proc_pidpath syscall, and under the
@@ -227,7 +238,9 @@ func lowerSet(names []string) map[string]struct{} {
 // (kill-steam-reconcile flipped DEGRADED, #111). The path-match itself — the
 // #110 fix that catches generically-named Steam helpers — is unchanged.
 var psCommand = func() ([]byte, error) {
-	return exec.Command("/bin/ps", "-Ao", "pid=,comm=").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "/bin/ps", "-Ao", "pid=,comm=").Output()
 }
 
 func listProcesses() ([]procView, error) {

--- a/plugins/kill-steam/internal/killer/killer.go
+++ b/plugins/kill-steam/internal/killer/killer.go
@@ -18,7 +18,10 @@ package killer
 
 import (
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -209,26 +212,62 @@ func lowerSet(names []string) map[string]struct{} {
 	return want
 }
 
+// psCommand is the single-spawn process listing (the seam that makes
+// enumeration O(1) exec calls, not O(N) syscalls). macOS `comm` is the FULL
+// path of the executable — not the truncated accounting name, and not the
+// argument vector — so one `ps` exec yields every process's pid + full exe
+// path at once. Matching Steam markers against the exe path (never the args)
+// keeps a process that merely MENTIONS a Steam path in its arguments from
+// being false-matched. Overridable in tests so parsing is exercised without
+// spawning ps and a test can assert the enumeration spawns exactly once.
+//
+// This replaces the per-PID gopsutil Exe() enumeration from #110: that read
+// each process's path with its own proc_pidpath syscall, and under the
+// platform's per-job timeout + machine load the O(N) syscalls blew the budget
+// (kill-steam-reconcile flipped DEGRADED, #111). The path-match itself — the
+// #110 fix that catches generically-named Steam helpers — is unchanged.
+var psCommand = func() ([]byte, error) {
+	return exec.Command("/bin/ps", "-Ao", "pid=,comm=").Output()
+}
+
 func listProcesses() ([]procView, error) {
-	ps, err := process.Processes()
+	raw, err := psCommand()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ps enumerate: %w", err)
 	}
-	out := make([]procView, 0, len(ps))
-	for _, p := range ps {
-		// Read BOTH fields best-effort. Name() alone is not enough: Steam's
-		// helpers run under generic comm names and are caught by executable
-		// path, so a PID whose Name() is unreadable but whose Exe() resolves
-		// must still be enumerated — otherwise a path-only match never sees
-		// it. Skip only when NEITHER field is readable (nothing to match on).
-		name, nameErr := p.Name()
-		path, exeErr := p.Exe()
-		if nameErr != nil && exeErr != nil {
-			continue // process vanished or fully opaque; nothing to match
+	return parsePS(raw), nil
+}
+
+// parsePS turns `ps -Ao pid=,comm=` output into procViews. Each line is
+// "<pid> <full-exe-path>"; the exe path may contain spaces, so we split on the
+// FIRST space only (never strings.Fields, which would shatter a spaced path).
+// Name is the path basename — for the exact, case-insensitive name-set match
+// (Steam/Dota by comm). Path is the full exe path — for the Steam bundle
+// marker match. Pure (no I/O), so it is unit-tested on fixed fake output.
+func parsePS(raw []byte) []procView {
+	lines := strings.Split(string(raw), "\n")
+	out := make([]procView, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
 		}
-		out = append(out, procView{PID: int(p.Pid), Name: name, Path: path})
+		sp := strings.IndexByte(line, ' ')
+		if sp < 0 {
+			continue // no comm column; nothing to match on
+		}
+		pid, err := strconv.Atoi(line[:sp])
+		if err != nil {
+			continue // non-numeric first column → not a process row
+		}
+		exe := strings.TrimLeft(line[sp+1:], " ")
+		name := ""
+		if exe != "" {
+			name = filepath.Base(exe)
+		}
+		out = append(out, procView{PID: pid, Name: name, Path: exe})
 	}
-	return out, nil
+	return out
 }
 
 func killProcess(pid int) error {

--- a/plugins/kill-steam/internal/killer/killer_test.go
+++ b/plugins/kill-steam/internal/killer/killer_test.go
@@ -407,6 +407,28 @@ func TestParsePSExtractsPidNameAndFullPath(t *testing.T) {
 	}
 }
 
+// TestParsePSSkipsMalformedLines locks the two documented defensive skips:
+// a line with no comm column (no space) and a line whose first column is not
+// numeric (a stray header/garbage row) are dropped, never mis-parsed into a
+// bogus procView. Only the one well-formed row survives.
+func TestParsePSSkipsMalformedLines(t *testing.T) {
+	raw := []byte(strings.Join([]string{
+		"  PID COMM",     // header-like: non-numeric first column → skipped
+		"total 0",        // garbage: non-numeric first column → skipped
+		"123",            // pid only, no comm column (no space) → skipped
+		"   ",            // whitespace-only → skipped
+		"78x9 /bad/pid",  // non-numeric pid token → skipped
+		"  456 /bin/zsh", // the only valid row
+	}, "\n"))
+	got := parsePS(raw)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 valid row, got %d: %+v", len(got), got)
+	}
+	if got[0].PID != 456 || got[0].Name != "zsh" || got[0].Path != "/bin/zsh" {
+		t.Fatalf("malformed-line filtering wrong, got %+v", got[0])
+	}
+}
+
 // TestParsedListDrivesKillMatch runs the full ps→parse→match pipeline through
 // an injected list and asserts #110 behavior is preserved end-to-end: an
 // ipcserver under the Steam bundle IS killed, an unrelated same-named

--- a/plugins/kill-steam/internal/killer/killer_test.go
+++ b/plugins/kill-steam/internal/killer/killer_test.go
@@ -2,6 +2,8 @@ package killer
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -358,6 +360,140 @@ func TestMatchesEmptyNamePathOnly(t *testing.T) {
 	p := procView{PID: 7, Name: "", Path: "/Users/testuser/Library/Application Support/Steam/Steam.AppBundle/x"}
 	if !k.matches(p, want) {
 		t.Error("empty-name process under a Steam path must match by path")
+	}
+}
+
+// --- #111: single-spawn enumeration (perf regression guards) ---
+//
+// #110 matched Steam helpers by executable path but read that path with a
+// per-PID gopsutil Exe() call (one proc_pidpath syscall per process). Under
+// the platform's per-job timeout + machine load the O(N) syscalls blew the
+// budget → kill-steam-reconcile flipped DEGRADED. The fix reads every
+// process's pid + full exe path from a SINGLE `ps` spawn and parses it. These
+// tests lock the fast path and its preserved match behavior, and would fail
+// if per-PID enumeration were reintroduced.
+
+// TestParsePSExtractsPidNameAndFullPath verifies the pure parser: each line is
+// "<pid> <full-exe-path>", the exe path may contain spaces (split on the FIRST
+// space only), Name is the path basename, Path is the full exe path.
+func TestParsePSExtractsPidNameAndFullPath(t *testing.T) {
+	const appSupport = "/Users/testuser/Library/Application Support/Steam"
+	raw := []byte(strings.Join([]string{
+		"    1 /sbin/launchd",
+		// space-containing path: basename must stay intact, path preserved whole
+		"  796 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
+		"  900 " + appSupport + "/Steam.AppBundle/Steam/Contents/MacOS/ipcserver",
+		"  901 /usr/local/bin/ipcserver",
+		"  902 /Applications/Steam.app/Contents/MacOS/steam_osx",
+		"  903 /Applications/Dota 2 beta/game/dota.app/Contents/MacOS/dota2",
+		"", // trailing blank line tolerated
+	}, "\n"))
+
+	byPID := map[int]procView{}
+	for _, p := range parsePS(raw) {
+		byPID[p.PID] = p
+	}
+	if len(byPID) != 6 {
+		t.Fatalf("parsed %d procs, want 6: %+v", len(byPID), byPID)
+	}
+	if p := byPID[900]; p.Name != "ipcserver" || !strings.HasSuffix(p.Path, "/Contents/MacOS/ipcserver") || !strings.Contains(p.Path, "/Steam.AppBundle/") {
+		t.Errorf("pid 900 (bundle ipcserver) parsed wrong: %+v", p)
+	}
+	if p := byPID[903]; p.Name != "dota2" || !strings.Contains(p.Path, "/Dota 2 beta/") {
+		t.Errorf("space-containing exe path not preserved for pid 903: %+v", p)
+	}
+	if p := byPID[796]; p.Name != "Finder" {
+		t.Errorf("basename of pid 796 = %q, want Finder", p.Name)
+	}
+}
+
+// TestParsedListDrivesKillMatch runs the full ps→parse→match pipeline through
+// an injected list and asserts #110 behavior is preserved end-to-end: an
+// ipcserver under the Steam bundle IS killed, an unrelated same-named
+// /usr/local/bin/ipcserver is NOT, and main Steam/Dota2 are killed by name.
+func TestParsedListDrivesKillMatch(t *testing.T) {
+	const appSupport = "/Users/testuser/Library/Application Support/Steam"
+	raw := []byte(strings.Join([]string{
+		"    1 /sbin/launchd",
+		"  796 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
+		"  900 " + appSupport + "/Steam.AppBundle/Steam/Contents/MacOS/ipcserver",
+		"  901 /usr/local/bin/ipcserver",
+		"  902 /Applications/Steam.app/Contents/MacOS/steam_osx",
+		"  903 /Applications/Dota 2 beta/game/dota.app/Contents/MacOS/dota2",
+	}, "\n"))
+
+	k := New(nil)
+	k.settle = 0
+	k.sleep = func(time.Duration) {}
+	killed := map[int]bool{}
+	k.list = func() ([]procView, error) {
+		live := make([]procView, 0)
+		for _, p := range parsePS(raw) {
+			if !killed[p.PID] {
+				live = append(live, p)
+			}
+		}
+		return live, nil
+	}
+	k.killPID = func(pid int) error { killed[pid] = true; return nil }
+
+	out, err := k.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := map[int]bool{900: true, 902: true, 903: true} // bundle ipcserver + steam_osx + dota2
+	if out.KilledCount() != len(want) {
+		t.Fatalf("killed %v, want pids %v", out.KilledPIDs, want)
+	}
+	for _, pid := range out.KilledPIDs {
+		if !want[pid] {
+			t.Errorf("killed unexpected pid %d (over-match)", pid)
+		}
+		if pid == 901 {
+			t.Fatal("false-matched unrelated /usr/local/bin/ipcserver")
+		}
+	}
+	if len(out.Survivors) != 0 {
+		t.Errorf("expected no survivors, got %v", out.Survivors)
+	}
+}
+
+// TestEnumerationIsSingleSpawnNotPerPID is the core perf-regression guard: the
+// enumeration must issue exactly ONE process listing regardless of process
+// count. A reintroduction of per-PID enumeration (one proc_pidpath syscall per
+// process — the #110→#111 regression) would scale spawns with N; this locks it
+// to O(1).
+func TestEnumerationIsSingleSpawnNotPerPID(t *testing.T) {
+	var b strings.Builder
+	const n = 500
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, "%d /usr/bin/proc%d\n", i, i)
+	}
+	orig := psCommand
+	t.Cleanup(func() { psCommand = orig })
+	calls := 0
+	psCommand = func() ([]byte, error) { calls++; return []byte(b.String()), nil }
+
+	procs, err := listProcesses()
+	if err != nil {
+		t.Fatalf("listProcesses: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("enumeration spawned %d times for %d processes; must be exactly 1 (O(1) spawns)", calls, n)
+	}
+	if len(procs) != n {
+		t.Fatalf("parsed %d processes, want %d", len(procs), n)
+	}
+}
+
+// TestListProcessesSurfacesPSError: a failing ps spawn must propagate, not be
+// swallowed into a silent empty (and thus falsely-clean) process list.
+func TestListProcessesSurfacesPSError(t *testing.T) {
+	orig := psCommand
+	t.Cleanup(func() { psCommand = orig })
+	psCommand = func() ([]byte, error) { return nil, errors.New("ps boom") }
+	if _, err := listProcesses(); err == nil {
+		t.Fatal("expected ps spawn error to surface")
 	}
 }
 


### PR DESCRIPTION
## Problem — #111: `kill-steam-reconcile` intermittently `timedout` → DEGRADED

The #110 fix (match Steam helpers like `ipcserver` by executable path so
generically-named helpers can no longer masquerade as unrelated processes) read
each process's path with a **per-PID `gopsutil` `Exe()` call — one `proc_pidpath`
syscall per process**. Standalone that's 0.1–0.5s, but under the platform's
per-job timeout budget + machine load the **O(N) syscalls** blew the budget on
most reconcile ticks, flipping `kill-steam-reconcile` to `timedout` → **DEGRADED**.

## Root cause

Per-PID enumeration: `process.Processes()` then `p.Name()` + `p.Exe()` for
**every** process each tick (plus up to 5 settle re-scans when Steam is present).
The cost scales with total process count and contends under load.

## Fix — make enumeration O(1) process-spawns, not O(N) syscalls

Replace the per-PID loop with a **single** `/bin/ps -Ao pid=,comm=` spawn,
parsed once. On macOS `comm` is the **full executable path** (not the truncated
accounting name, not the argv), so one exec yields `pid` + full exe path for
every process at once.

- **Path-match preserved:** the Steam bundle markers (`/steam.appbundle/`,
  `/steam.app/contents/`, `/library/application support/steam/`; trailing-slash,
  case-insensitive) are matched against the **exe path** — matched against `comm`,
  never the argument vector, so a process that merely *mentions* a Steam path in
  its args is **not** false-matched.
- **Behavior identical to #110:**
  - `ipcserver` under the Steam bundle → still killed
  - unrelated `/usr/local/bin/ipcserver` (and `SteamVR`) → still survive
  - main Steam / Dota2 by name (exact, case-insensitive) → still killed
  - **honest survivor re-scan verdict unchanged** — a survivor after kill →
    `failed`/exit 1, and the surfaced rescan-error logic from #110 is untouched
    (no green over dead protection).
- **Enumeration kept behind the existing `list` seam**; added a pure `parsePS()`
  and a `psCommand` seam so parsing is unit-tested without spawning `ps`.
- **Timeout budget:** left at 20s. The single-spawn enumeration (~tens of ms +
  up to ~1.5s of settle re-scans only when Steam is present) has ample headroom,
  so no bump was needed (preferred the fast-enumeration fix per the issue).

## Tests (TDD)

New tests in `internal/killer/killer_test.go`:
- `TestParsePSExtractsPidNameAndFullPath` — pure parser: pid + full exe path,
  space-containing paths split on the first space only (basename intact).
- `TestParsedListDrivesKillMatch` — full ps→parse→match pipeline: bundle
  `ipcserver` + `steam_osx` + `dota2` killed; `/usr/local/bin/ipcserver` and
  `Finder`/`launchd` survive; no survivors.
- `TestEnumerationIsSingleSpawnNotPerPID` — **perf-regression guard**: the
  enumeration spawns **exactly once** for 500 processes. Fails if per-PID
  enumeration is reintroduced.
- `TestListProcessesSurfacesPSError` — a failing `ps` spawn propagates (never a
  silently-empty, falsely-clean process list).

All existing behavior tests (exact-match `msteams` guard, path-under-bundle,
survivor→failed, rescan-error-surfaced, poll-window) continue to pass.

```
gofmt -s -l .        # clean
go build ./...       # OK
go vet ./...         # OK
go test -race ./...  # ok (killer, cmd, uninstaller)
```
Plugin cross-builds for the bundle target (`CGO_ENABLED=0 GOOS=darwin GOARCH=arm64`)
and `platform go build ./...` is green.

Closes #111.